### PR TITLE
Use two options to control SPIR-V build and test and update generator number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,16 @@ option(HLSL_ENABLE_FIXED_VER "Sets up fixed version information." OFF) # HLSL Ch
 option(HLSL_ENABLE_ANALYZE "Enables compiler analysis during compilation." OFF) # HLSL Change
 option(HLSL_OPTIONAL_PROJS_IN_DEFAULT "Include optional projects in default build target." OFF) # HLSL Change
 
-option(ENABLE_SPIRV_CODEGEN "Enables the HLSL to SPIR-V conversion flow." OFF) # SPIRV Change
+# SPIRV change starts
+option(ENABLE_SPIRV_CODEGEN "Enables SPIR-V code generation." OFF)
+option(SPIRV_BUILD_TESTS "Build targets for the SPIR-V unit tests." OFF)
+if (${SPIRV_BUILD_TESTS})
+  set(ENABLE_SPIRV_CODEGEN ON)
+endif()
+if (${ENABLE_SPIRV_CODEGEN})
+  add_definitions(-DENABLE_SPIRV_CODEGEN)
+endif()
+# SPIRV change ends
 
 include(VersionFromVCS)
 
@@ -613,7 +622,7 @@ else()
   endif()
 endif()
 
-if(LLVM_INCLUDE_TESTS OR ENABLE_SPIRV_CODEGEN)
+if(LLVM_INCLUDE_TESTS OR SPIRV_BUILD_TESTS)
   add_subdirectory(utils/unittest)
 endif()
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ build_script:
 
     call utils\hct\hctstart %HLSL_SRC_DIR% %HLSL_BLD_DIR%
 
-    call utils\hct\hctbuild -%PLATFORM% -%CONFIGURATION% -vs2017
+    call utils\hct\hctbuild -%PLATFORM% -%CONFIGURATION% -vs2017 -spirvtest
 test_script:
 - cmd: >-
     cd %HLSL_SRC_DIR%
@@ -22,6 +22,9 @@ test_script:
     call utils\hct\hctstart %HLSL_SRC_DIR% %HLSL_BLD_DIR%
 
     powershell utils\appveyor\appveyor_test.ps1
+# Running SPIR-V tests
+- cmd: >-
+    %HLSL_BLD_DIR%\tools\clang\unittests\SPIRV\%CONFIGURATION%\clang-spirv-tests.exe
 
 notifications:
 - provider: GitHubPullRequest

--- a/cmake/modules/AddLLVM.cmake
+++ b/cmake/modules/AddLLVM.cmake
@@ -749,7 +749,7 @@ endfunction(add_llvm_implicit_external_projects)
 
 # Generic support for adding a unittest.
 function(add_unittest test_suite test_name)
-  if( NOT LLVM_BUILD_TESTS )
+  if( NOT LLVM_BUILD_TESTS AND NOT SPIRV_BUILD_TESTS ) # SPIRV change
     set(EXCLUDE_FROM_ALL ON)
   endif()
 

--- a/tools/clang/lib/CMakeLists.txt
+++ b/tools/clang/lib/CMakeLists.txt
@@ -22,4 +22,8 @@ if(CLANG_ENABLE_STATIC_ANALYZER)
   add_subdirectory(StaticAnalyzer)
 endif()
 add_subdirectory(Format)
-add_subdirectory(SPIRV) # SPIRV change
+# SPIRV change starts
+if (ENABLE_SPIRV_CODEGEN)
+  add_subdirectory(SPIRV)
+endif (ENABLE_SPIRV_CODEGEN)
+# SPIRV change ends

--- a/tools/clang/lib/SPIRV/ModuleBuilder.cpp
+++ b/tools/clang/lib/SPIRV/ModuleBuilder.cpp
@@ -18,6 +18,9 @@ namespace spirv {
 namespace {
 constexpr size_t kHeaderSize = 5;
 constexpr size_t kBoundIndex = 3;
+
+constexpr uint32_t kGeneratorNumber = 14;
+constexpr uint32_t kToolVersion = 0;
 }
 
 ModuleBuilder::ModuleBuilder(SPIRVContext *C) : TheContext(*C) {}
@@ -37,7 +40,7 @@ void ModuleBuilder::GenHeader() {
   TheModule.reserve(kHeaderSize);
   TheModule.emplace_back(spv::MagicNumber);
   TheModule.emplace_back(spv::Version);
-  TheModule.emplace_back(~0u); // TODO: register a generator number
+  TheModule.emplace_back((kGeneratorNumber << 16) | kToolVersion);
   TheModule.emplace_back(0u);  // Bound
   TheModule.emplace_back(0u);  // Schema
 }

--- a/tools/clang/tools/dxc/dxc.cpp
+++ b/tools/clang/tools/dxc/dxc.cpp
@@ -839,12 +839,19 @@ int __cdecl wmain(int argc, const wchar_t **argv_) {
       }
 
       // SPIRV change starts
+#ifdef ENABLE_SPIRV_CODEGEN
       // This ideally should be put in ReadDxcOpts(), but ReadDxcOpts() are called
       // again in DxcCompilerCompile() with -Fo stripped.
       if (dxcOpts.GenSPIRV && dxcOpts.OutputObject.empty()) {
         fprintf(stderr, "-spirv requires -Fo for output object file name.");
         return 1;
       }
+#else
+      if (dxcOpts.GenSPIRV) {
+        fprintf(stderr, "SPIR-V codegen not configured via ENABLE_SPIRV_CODEGEN");
+        return 1;
+      }
+#endif
       // SPIRV change ends
     }
 

--- a/tools/clang/tools/dxcompiler/CMakeLists.txt
+++ b/tools/clang/tools/dxcompiler/CMakeLists.txt
@@ -67,7 +67,6 @@ set(LIBRARIES
   clangLex
   clangTooling
   clangBasic
-  clangSPIRV # SPIRV change
   libclang
   )
 
@@ -84,6 +83,11 @@ set(GENERATED_HEADERS
 
 add_clang_library(dxcompiler SHARED ${SOURCES})
 target_link_libraries(dxcompiler PRIVATE ${LIBRARIES} ${DIASDK_LIBRARIES})
+# SPIRV change starts
+if (ENABLE_SPIRV_CODEGEN)
+  target_link_libraries(dxcompiler PRIVATE clangSPIRV)
+endif (ENABLE_SPIRV_CODEGEN)
+# SPIRV change ends
 add_dependencies(dxcompiler ${GENERATED_HEADERS} clang-headers)
 add_dependencies(dxcompiler DxcEtw)
 include_directories(AFTER ${LLVM_INCLUDE_DIR}/dxc/Tracing ${DIASDK_INCLUDE_DIRS})

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -30,7 +30,6 @@
 #include "llvm/Bitcode/ReaderWriter.h"
 #include "clang/Frontend/FrontendActions.h"
 #include "clang/CodeGen/CodeGenAction.h"
-#include "clang/SPIRV/EmitSPIRVAction.h" // SPIRV change
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/DiagnosticPrinter.h"
 #include "llvm/Support/Format.h"
@@ -41,6 +40,11 @@
 #include "dxc/HLSL/DxilPipelineStateValidation.h"
 #include "dxc/HLSL/HLSLExtensionsCodegenHelper.h"
 #include "dxc/HLSL/DxilRootSignature.h"
+// SPIRV change starts
+#ifdef ENABLE_SPIRV_CODEGEN
+#include "clang/SPIRV/EmitSPIRVAction.h"
+#endif
+// SPIRV change ends
 
 #ifdef _DEBUG
 #if defined(_MSC_VER)
@@ -2138,6 +2142,7 @@ public:
         }
       }
       // SPIRV change starts
+#ifdef ENABLE_SPIRV_CODEGEN
       else if (opts.GenSPIRV) {
           clang::EmitSPIRVAction action;
           FrontendInputFile file(utf8SourceName.m_psz, IK_HLSL);
@@ -2146,6 +2151,7 @@ public:
           action.EndSourceFile();
           outStream.flush();
       }
+#endif
       // SPIRV change ends
       else {
         llvm::LLVMContext llvmContext;

--- a/tools/clang/unittests/CMakeLists.txt
+++ b/tools/clang/unittests/CMakeLists.txt
@@ -45,8 +45,8 @@ endif (HLSL_INCLUDE_TESTS)
 
 # SPIRV Change Starts
 
-if (ENABLE_SPIRV_CODEGEN)
+if (SPIRV_BUILD_TESTS)
   add_subdirectory(SPIRV)
-endif (ENABLE_SPIRV_CODEGEN)
+endif (SPIRV_BUILD_TESTS)
 
 # SPIRV Change Ends

--- a/tools/clang/unittests/SPIRV/ModuleBuilderTest.cpp
+++ b/tools/clang/unittests/SPIRV/ModuleBuilderTest.cpp
@@ -25,7 +25,7 @@ TEST(ValidateModuleBuilder, ValidateModuleWithHeaderOnly) {
   // At the very least, running BeginModule() and EndModule() should
   // create the SPIR-V Header. The header is exactly 5 words long.
   EXPECT_EQ(spvModule.size(), 5u);
-  EXPECT_THAT(spvModule, ElementsAre(spv::MagicNumber, spv::Version, ~0u, 1u, 0u));
+  EXPECT_THAT(spvModule, ElementsAre(spv::MagicNumber, spv::Version, 14u << 16, 1u, 0u));
 }
 
 // TODO: Add more ModuleBuilder tests

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -103,8 +103,13 @@ if "%1"=="-vs2017" (
 
 rem Begin SPIRV change
 if "%1"=="-spirv" (
-  echo SPIRV generation is enabled.
+  echo SPIR-V codegen is enabled.
   set CMAKE_OPTS=%CMAKE_OPTS% -DENABLE_SPIRV_CODEGEN:BOOL=ON
+  shift /1
+)
+if "%1"=="-spirvtest" (
+  echo Building SPIR-V tests is enabled.
+  set CMAKE_OPTS=%CMAKE_OPTS% -DSPIRV_BUILD_TESTS:BOOL=ON
   shift /1
 )
 rem End SPIRV change


### PR DESCRIPTION
* Add a new SPIRV_BUILD_TESTS option to control building of
  SPIR-V tests. The original ENABLE_SPIRV_CODEGEN is only used
  for turning on SPIR-V codegen in the library right now.
* SPIRV_BUILD_TESTS turns on ENABLE_SPIRV_CODEGEN implicitly.
* Add a new -spirvtest option to hctbuild to build SPIR-V tests.