### PR TITLE
Added Decoration, Type, and utils.

### DIFF
--- a/tools/clang/include/clang/SPIRV/Decoration.h
+++ b/tools/clang/include/clang/SPIRV/Decoration.h
@@ -1,0 +1,156 @@
+//===-- Decoration.h - SPIR-V Decoration --*- C++-*------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_CLANG_SPIRV_DECORATION_H
+#define LLVM_CLANG_SPIRV_DECORATION_H
+
+#include <unordered_set>
+#include <vector>
+
+#include "clang/SPIRV/Option.h"
+#include "clang/SPIRV/spirv.hpp"
+
+namespace clang {
+namespace spirv {
+
+class SPIRVContext;
+class Decoration {
+  enum { kInvalidMember = -1 };
+
+public:
+  spv::Decoration getDecorationType() const { return id; }
+  const std::vector<uint32_t> &getArgs() const { return args; }
+  const uint32_t getMemberIndex() const { return memberIndex; }
+
+  static const Decoration *getDecorationRelaxedPrecision(SPIRVContext &ctx);
+  static const Decoration *getDecorationSpecId(SPIRVContext &ctx, uint32_t id);
+  static const Decoration *getDecorationBlock(SPIRVContext &ctx);
+  static const Decoration *getDecorationBufferBlock(SPIRVContext &ctx);
+  static const Decoration *getDecorationRowMajor(SPIRVContext &ctx,
+                                                 int32_t member_idx);
+  static const Decoration *getDecorationColMajor(SPIRVContext &ctx,
+                                                 int32_t member_idx);
+  static const Decoration *getDecorationArrayStride(SPIRVContext &ctx,
+                                                    uint32_t stride);
+  static const Decoration *getDecorationMatrixStride(SPIRVContext &ctx,
+                                                     uint32_t stride,
+                                                     int32_t member_idx);
+  static const Decoration *getDecorationGLSLShared(SPIRVContext &ctx);
+  static const Decoration *getDecorationGLSLPacked(SPIRVContext &ctx);
+  static const Decoration *getDecorationCPacked(SPIRVContext &ctx);
+  static const Decoration *
+  getDecorationBuiltIn(SPIRVContext &ctx, spv::BuiltIn builtin,
+                       int32_t member_idx = kInvalidMember);
+  static const Decoration *
+  getDecorationNoPerspective(SPIRVContext &ctx,
+                             int32_t member_idx = kInvalidMember);
+  static const Decoration *
+  getDecorationFlat(SPIRVContext &ctx, int32_t member_idx = kInvalidMember);
+  static const Decoration *
+  getDecorationPatch(SPIRVContext &ctx, int32_t member_idx = kInvalidMember);
+  static const Decoration *
+  getDecorationCentroid(SPIRVContext &ctx, int32_t member_idx = kInvalidMember);
+  static const Decoration *
+  getDecorationSample(SPIRVContext &ctx, int32_t member_idx = kInvalidMember);
+  static const Decoration *getDecorationInvariant(SPIRVContext &ctx);
+  static const Decoration *getDecorationRestrict(SPIRVContext &ctx);
+  static const Decoration *getDecorationAliased(SPIRVContext &ctx);
+  static const Decoration *
+  getDecorationVolatile(SPIRVContext &ctx, int32_t member_idx = kInvalidMember);
+  static const Decoration *getDecorationConstant(SPIRVContext &ctx);
+  static const Decoration *
+  getDecorationCoherent(SPIRVContext &ctx, int32_t member_idx = kInvalidMember);
+  static const Decoration *
+  getDecorationNonWritable(SPIRVContext &ctx,
+                           int32_t member_idx = kInvalidMember);
+  static const Decoration *
+  getDecorationNonReadable(SPIRVContext &ctx,
+                           int32_t member_idx = kInvalidMember);
+  static const Decoration *
+  getDecorationUniform(SPIRVContext &ctx, int32_t member_idx = kInvalidMember);
+  static const Decoration *getDecorationSaturatedConversion(SPIRVContext &ctx);
+  static const Decoration *
+  getDecorationStream(SPIRVContext &ctx, uint32_t stream_number,
+                      int32_t member_idx = kInvalidMember);
+  static const Decoration *
+  getDecorationLocation(SPIRVContext &ctx, uint32_t location,
+                        int32_t member_idx = kInvalidMember);
+  static const Decoration *
+  getDecorationComponent(SPIRVContext &ctx, uint32_t component,
+                         int32_t member_idx = kInvalidMember);
+  static const Decoration *getDecorationIndex(SPIRVContext &ctx,
+                                              uint32_t index);
+  static const Decoration *getDecorationBinding(SPIRVContext &ctx,
+                                                uint32_t binding_point);
+  static const Decoration *getDecorationDescriptorSet(SPIRVContext &ctx,
+                                                      uint32_t set);
+  static const Decoration *
+  getDecorationOffset(SPIRVContext &ctx, uint32_t byte_offset,
+                      int32_t member_idx = kInvalidMember);
+  static const Decoration *
+  getDecorationXfbBuffer(SPIRVContext &ctx, uint32_t xfb_buf,
+                         int32_t member_idx = kInvalidMember);
+  static const Decoration *getDecorationXfbStride(SPIRVContext &ctx,
+                                                  uint32_t xfb_stride);
+  static const Decoration *
+  getDecorationFuncParamAttr(SPIRVContext &ctx,
+                             spv::FunctionParameterAttribute attr);
+  static const Decoration *
+  getDecorationFPRoundingMode(SPIRVContext &ctx, spv::FPRoundingMode mode);
+  static const Decoration *
+  getDecorationFPFastMathMode(SPIRVContext &ctx, spv::FPFastMathModeShift mode);
+  static const Decoration *
+  getDecorationLinkageAttributes(SPIRVContext &ctx, std::string name,
+                                 spv::LinkageType linkage_type);
+  static const Decoration *getDecorationNoContraction(SPIRVContext &ctx);
+  static const Decoration *getDecorationInputAttachmentIndex(SPIRVContext &ctx,
+                                                             uint32_t index);
+  static const Decoration *getDecorationAlignment(SPIRVContext &ctx,
+                                                  uint32_t alignment);
+  static const Decoration *getDecorationMaxByteOffset(SPIRVContext &ctx,
+                                                      uint32_t max_byte_offset);
+  static const Decoration *getDecorationOverrideCoverageNV(SPIRVContext &ctx);
+  static const Decoration *getDecorationPassthroughNV(SPIRVContext &ctx);
+  static const Decoration *getDecorationViewportRelativeNV(SPIRVContext &ctx);
+  static const Decoration *
+  getDecorationSecondaryViewportRelativeNV(SPIRVContext &ctx, uint32_t offset);
+
+  bool operator==(const Decoration &other) const {
+    return id == other.id && args == other.args &&
+           memberIndex == other.memberIndex;
+  }
+
+private:
+  /// \brief prevent public APIs from creating Decoration objects.
+  Decoration(spv::Decoration dec_id, std::vector<uint32_t> arg = {},
+             int32_t idx = kInvalidMember)
+      : id(dec_id), args(arg), memberIndex(idx) {}
+
+  /// \brief Sets the index of the structure member to which the decoration
+  /// applies.
+  void setMemberIndex(int32_t idx) { memberIndex = idx; }
+
+  /// \brief Uses ExistingDecorations to return a unique Decoration.
+  static const Decoration *getUniqueDecoration(SPIRVContext &ctx,
+                                               Decoration &d);
+
+private:
+  // Private members that define a unique SPIR-V Decoration.
+  spv::Decoration id;
+  std::vector<uint32_t> args;
+  // If this is a decoration that applies to a structure member, the index
+  // of the member is stored here. It will be kInvalidMember in all other
+  // cases. A 32-bit integer is certainly enough to store the member index
+  // (see Universal Limits in SPIRV Spec.)
+  int32_t memberIndex;
+};
+
+} // end namespace spirv
+} // end namespace clang
+
+#endif

--- a/tools/clang/include/clang/SPIRV/Decoration.h
+++ b/tools/clang/include/clang/SPIRV/Decoration.h
@@ -1,4 +1,4 @@
-//===-- Decoration.h - SPIR-V Decoration --*- C++-*------------------------===//
+//===-- Decoration.h - SPIR-V Decoration ------------------------*- C++ -*-===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -9,145 +9,152 @@
 #ifndef LLVM_CLANG_SPIRV_DECORATION_H
 #define LLVM_CLANG_SPIRV_DECORATION_H
 
-#include <unordered_set>
 #include <vector>
 
-#include "clang/SPIRV/Option.h"
 #include "clang/SPIRV/spirv.hpp"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace clang {
 namespace spirv {
 
+/// \brief SPIR-V Decoration.
+///
+/// This class defines a unique SPIR-V Decoration.
+/// A SPIR-V Decoration includes an identifier defined by the SPIR-V Spec.
+/// It also incldues any arguments (32-bit words) needed to define the
+/// decoration. If the decoration applies to a structure member, it also
+/// includes the index of the member to which the decoration applies.
+///
+/// The class includes static getXXX(...) functions for getting pointers of any
+/// needed decoration. A unique Decoration has a unique pointer (e.g. calling
+/// 'getRelaxedPrecision' function will always return the same pointer for the
+/// given context)
 class SPIRVContext;
 class Decoration {
-  enum { kInvalidMember = -1 };
 
 public:
-  spv::Decoration getDecorationType() const { return id; }
-  const std::vector<uint32_t> &getArgs() const { return args; }
-  const uint32_t getMemberIndex() const { return memberIndex; }
+  spv::Decoration getValue() const { return id; }
+  const llvm::SmallVectorImpl<uint32_t> &getArgs() const { return args; }
+  const llvm::Optional<uint32_t> getMemberIndex() const { return memberIndex; }
 
-  static const Decoration *getDecorationRelaxedPrecision(SPIRVContext &ctx);
-  static const Decoration *getDecorationSpecId(SPIRVContext &ctx, uint32_t id);
-  static const Decoration *getDecorationBlock(SPIRVContext &ctx);
-  static const Decoration *getDecorationBufferBlock(SPIRVContext &ctx);
-  static const Decoration *getDecorationRowMajor(SPIRVContext &ctx,
-                                                 int32_t member_idx);
-  static const Decoration *getDecorationColMajor(SPIRVContext &ctx,
-                                                 int32_t member_idx);
-  static const Decoration *getDecorationArrayStride(SPIRVContext &ctx,
-                                                    uint32_t stride);
-  static const Decoration *getDecorationMatrixStride(SPIRVContext &ctx,
-                                                     uint32_t stride,
-                                                     int32_t member_idx);
-  static const Decoration *getDecorationGLSLShared(SPIRVContext &ctx);
-  static const Decoration *getDecorationGLSLPacked(SPIRVContext &ctx);
-  static const Decoration *getDecorationCPacked(SPIRVContext &ctx);
+  static const Decoration *getRelaxedPrecision(SPIRVContext &ctx);
+  static const Decoration *getSpecId(SPIRVContext &ctx, uint32_t id);
+  static const Decoration *getBlock(SPIRVContext &ctx);
+  static const Decoration *getBufferBlock(SPIRVContext &ctx);
+  static const Decoration *getRowMajor(SPIRVContext &ctx, uint32_t member_idx);
+  static const Decoration *getColMajor(SPIRVContext &ctx, uint32_t member_idx);
+  static const Decoration *getArrayStride(SPIRVContext &ctx, uint32_t stride);
+  static const Decoration *getMatrixStride(SPIRVContext &ctx, uint32_t stride,
+                                           uint32_t member_idx);
+  static const Decoration *getGLSLShared(SPIRVContext &ctx);
+  static const Decoration *getGLSLPacked(SPIRVContext &ctx);
+  static const Decoration *getCPacked(SPIRVContext &ctx);
   static const Decoration *
-  getDecorationBuiltIn(SPIRVContext &ctx, spv::BuiltIn builtin,
-                       int32_t member_idx = kInvalidMember);
+  getBuiltIn(SPIRVContext &ctx, spv::BuiltIn builtin,
+             llvm::Optional<uint32_t> member_idx = llvm::None);
   static const Decoration *
-  getDecorationNoPerspective(SPIRVContext &ctx,
-                             int32_t member_idx = kInvalidMember);
+  getNoPerspective(SPIRVContext &ctx,
+                   llvm::Optional<uint32_t> member_idx = llvm::None);
   static const Decoration *
-  getDecorationFlat(SPIRVContext &ctx, int32_t member_idx = kInvalidMember);
+  getFlat(SPIRVContext &ctx, llvm::Optional<uint32_t> member_idx = llvm::None);
   static const Decoration *
-  getDecorationPatch(SPIRVContext &ctx, int32_t member_idx = kInvalidMember);
+  getPatch(SPIRVContext &ctx, llvm::Optional<uint32_t> member_idx = llvm::None);
   static const Decoration *
-  getDecorationCentroid(SPIRVContext &ctx, int32_t member_idx = kInvalidMember);
+  getCentroid(SPIRVContext &ctx,
+              llvm::Optional<uint32_t> member_idx = llvm::None);
+
   static const Decoration *
-  getDecorationSample(SPIRVContext &ctx, int32_t member_idx = kInvalidMember);
-  static const Decoration *getDecorationInvariant(SPIRVContext &ctx);
-  static const Decoration *getDecorationRestrict(SPIRVContext &ctx);
-  static const Decoration *getDecorationAliased(SPIRVContext &ctx);
+  getSample(SPIRVContext &ctx,
+            llvm::Optional<uint32_t> member_idx = llvm::None);
+  static const Decoration *getInvariant(SPIRVContext &ctx);
+  static const Decoration *getRestrict(SPIRVContext &ctx);
+  static const Decoration *getAliased(SPIRVContext &ctx);
   static const Decoration *
-  getDecorationVolatile(SPIRVContext &ctx, int32_t member_idx = kInvalidMember);
-  static const Decoration *getDecorationConstant(SPIRVContext &ctx);
+  getVolatile(SPIRVContext &ctx,
+              llvm::Optional<uint32_t> member_idx = llvm::None);
+
+  static const Decoration *getConstant(SPIRVContext &ctx);
   static const Decoration *
-  getDecorationCoherent(SPIRVContext &ctx, int32_t member_idx = kInvalidMember);
+  getCoherent(SPIRVContext &ctx,
+              llvm::Optional<uint32_t> member_idx = llvm::None);
+
   static const Decoration *
-  getDecorationNonWritable(SPIRVContext &ctx,
-                           int32_t member_idx = kInvalidMember);
+  getNonWritable(SPIRVContext &ctx,
+                 llvm::Optional<uint32_t> member_idx = llvm::None);
   static const Decoration *
-  getDecorationNonReadable(SPIRVContext &ctx,
-                           int32_t member_idx = kInvalidMember);
+  getNonReadable(SPIRVContext &ctx,
+                 llvm::Optional<uint32_t> member_idx = llvm::None);
   static const Decoration *
-  getDecorationUniform(SPIRVContext &ctx, int32_t member_idx = kInvalidMember);
-  static const Decoration *getDecorationSaturatedConversion(SPIRVContext &ctx);
+  getUniform(SPIRVContext &ctx,
+             llvm::Optional<uint32_t> member_idx = llvm::None);
+  static const Decoration *getSaturatedConversion(SPIRVContext &ctx);
   static const Decoration *
-  getDecorationStream(SPIRVContext &ctx, uint32_t stream_number,
-                      int32_t member_idx = kInvalidMember);
+  getStream(SPIRVContext &ctx, uint32_t stream_number,
+            llvm::Optional<uint32_t> member_idx = llvm::None);
   static const Decoration *
-  getDecorationLocation(SPIRVContext &ctx, uint32_t location,
-                        int32_t member_idx = kInvalidMember);
+  getLocation(SPIRVContext &ctx, uint32_t location,
+              llvm::Optional<uint32_t> member_idx = llvm::None);
   static const Decoration *
-  getDecorationComponent(SPIRVContext &ctx, uint32_t component,
-                         int32_t member_idx = kInvalidMember);
-  static const Decoration *getDecorationIndex(SPIRVContext &ctx,
-                                              uint32_t index);
-  static const Decoration *getDecorationBinding(SPIRVContext &ctx,
-                                                uint32_t binding_point);
-  static const Decoration *getDecorationDescriptorSet(SPIRVContext &ctx,
-                                                      uint32_t set);
+  getComponent(SPIRVContext &ctx, uint32_t component,
+               llvm::Optional<uint32_t> member_idx = llvm::None);
+  static const Decoration *getIndex(SPIRVContext &ctx, uint32_t index);
+  static const Decoration *getBinding(SPIRVContext &ctx,
+                                      uint32_t binding_point);
+  static const Decoration *getDescriptorSet(SPIRVContext &ctx, uint32_t set);
   static const Decoration *
-  getDecorationOffset(SPIRVContext &ctx, uint32_t byte_offset,
-                      int32_t member_idx = kInvalidMember);
+  getOffset(SPIRVContext &ctx, uint32_t byte_offset,
+            llvm::Optional<uint32_t> member_idx = llvm::None);
   static const Decoration *
-  getDecorationXfbBuffer(SPIRVContext &ctx, uint32_t xfb_buf,
-                         int32_t member_idx = kInvalidMember);
-  static const Decoration *getDecorationXfbStride(SPIRVContext &ctx,
-                                                  uint32_t xfb_stride);
+  getXfbBuffer(SPIRVContext &ctx, uint32_t xfb_buf,
+               llvm::Optional<uint32_t> member_idx = llvm::None);
+  static const Decoration *getXfbStride(SPIRVContext &ctx, uint32_t xfb_stride);
   static const Decoration *
-  getDecorationFuncParamAttr(SPIRVContext &ctx,
-                             spv::FunctionParameterAttribute attr);
-  static const Decoration *
-  getDecorationFPRoundingMode(SPIRVContext &ctx, spv::FPRoundingMode mode);
-  static const Decoration *
-  getDecorationFPFastMathMode(SPIRVContext &ctx, spv::FPFastMathModeShift mode);
-  static const Decoration *
-  getDecorationLinkageAttributes(SPIRVContext &ctx, std::string name,
-                                 spv::LinkageType linkage_type);
-  static const Decoration *getDecorationNoContraction(SPIRVContext &ctx);
-  static const Decoration *getDecorationInputAttachmentIndex(SPIRVContext &ctx,
-                                                             uint32_t index);
-  static const Decoration *getDecorationAlignment(SPIRVContext &ctx,
-                                                  uint32_t alignment);
-  static const Decoration *getDecorationMaxByteOffset(SPIRVContext &ctx,
-                                                      uint32_t max_byte_offset);
-  static const Decoration *getDecorationOverrideCoverageNV(SPIRVContext &ctx);
-  static const Decoration *getDecorationPassthroughNV(SPIRVContext &ctx);
-  static const Decoration *getDecorationViewportRelativeNV(SPIRVContext &ctx);
-  static const Decoration *
-  getDecorationSecondaryViewportRelativeNV(SPIRVContext &ctx, uint32_t offset);
+  getFuncParamAttr(SPIRVContext &ctx, spv::FunctionParameterAttribute attr);
+  static const Decoration *getFPRoundingMode(SPIRVContext &ctx,
+                                             spv::FPRoundingMode mode);
+  static const Decoration *getFPFastMathMode(SPIRVContext &ctx,
+                                             spv::FPFastMathModeShift mode);
+  static const Decoration *getLinkageAttributes(SPIRVContext &ctx,
+                                                std::string name,
+                                                spv::LinkageType linkage_type);
+  static const Decoration *getNoContraction(SPIRVContext &ctx);
+  static const Decoration *getInputAttachmentIndex(SPIRVContext &ctx,
+                                                   uint32_t index);
+  static const Decoration *getAlignment(SPIRVContext &ctx, uint32_t alignment);
+  static const Decoration *getMaxByteOffset(SPIRVContext &ctx,
+                                            uint32_t max_byte_offset);
+  static const Decoration *getOverrideCoverageNV(SPIRVContext &ctx);
+  static const Decoration *getPassthroughNV(SPIRVContext &ctx);
+  static const Decoration *getViewportRelativeNV(SPIRVContext &ctx);
+  static const Decoration *getSecondaryViewportRelativeNV(SPIRVContext &ctx,
+                                                          uint32_t offset);
 
   bool operator==(const Decoration &other) const {
     return id == other.id && args == other.args &&
-           memberIndex == other.memberIndex;
+           memberIndex.hasValue() == other.memberIndex.hasValue() &&
+           (!memberIndex.hasValue() ||
+            memberIndex.getValue() == other.memberIndex.getValue());
   }
 
 private:
   /// \brief prevent public APIs from creating Decoration objects.
-  Decoration(spv::Decoration dec_id, std::vector<uint32_t> arg = {},
-             int32_t idx = kInvalidMember)
+  Decoration(spv::Decoration dec_id, llvm::SmallVector<uint32_t, 2> arg = {},
+    llvm::Optional<uint32_t> idx = llvm::None)
       : id(dec_id), args(arg), memberIndex(idx) {}
 
   /// \brief Sets the index of the structure member to which the decoration
   /// applies.
-  void setMemberIndex(int32_t idx) { memberIndex = idx; }
+  void setMemberIndex(llvm::Optional<uint32_t> idx) { memberIndex = idx; }
 
-  /// \brief Uses ExistingDecorations to return a unique Decoration.
+  /// \brief Returns the unique decoration pointer within the given context.
   static const Decoration *getUniqueDecoration(SPIRVContext &ctx,
                                                Decoration &d);
 
 private:
-  // Private members that define a unique SPIR-V Decoration.
-  spv::Decoration id;
-  std::vector<uint32_t> args;
-  // If this is a decoration that applies to a structure member, the index
-  // of the member is stored here. It will be kInvalidMember in all other
-  // cases. A 32-bit integer is certainly enough to store the member index
-  // (see Universal Limits in SPIRV Spec.)
-  int32_t memberIndex;
+  spv::Decoration id;                   ///< Defined by SPIR-V Spec
+  llvm::SmallVector<uint32_t, 2> args;  ///< Decoration parameters
+  llvm::Optional<uint32_t> memberIndex; ///< Struct member index (if applicable)
 };
 
 } // end namespace spirv

--- a/tools/clang/include/clang/SPIRV/Decoration.h
+++ b/tools/clang/include/clang/SPIRV/Decoration.h
@@ -18,6 +18,8 @@
 namespace clang {
 namespace spirv {
 
+class SPIRVContext;
+
 /// \brief SPIR-V Decoration.
 ///
 /// This class defines a unique SPIR-V Decoration.
@@ -29,14 +31,13 @@ namespace spirv {
 /// The class includes static getXXX(...) functions for getting pointers of any
 /// needed decoration. A unique Decoration has a unique pointer (e.g. calling
 /// 'getRelaxedPrecision' function will always return the same pointer for the
-/// given context)
-class SPIRVContext;
+/// given context).
 class Decoration {
 
 public:
   spv::Decoration getValue() const { return id; }
-  const llvm::SmallVectorImpl<uint32_t> &getArgs() const { return args; }
-  const llvm::Optional<uint32_t> getMemberIndex() const { return memberIndex; }
+  const llvm::SmallVector<uint32_t, 2> &getArgs() const { return args; }
+  llvm::Optional<uint32_t> getMemberIndex() const { return memberIndex; }
 
   static const Decoration *getRelaxedPrecision(SPIRVContext &ctx);
   static const Decoration *getSpecId(SPIRVContext &ctx, uint32_t id);
@@ -149,7 +150,7 @@ private:
 
   /// \brief Returns the unique decoration pointer within the given context.
   static const Decoration *getUniqueDecoration(SPIRVContext &ctx,
-                                               Decoration &d);
+                                               const Decoration &d);
 
 private:
   spv::Decoration id;                   ///< Defined by SPIR-V Spec

--- a/tools/clang/include/clang/SPIRV/SPIRVContext.h
+++ b/tools/clang/include/clang/SPIRV/SPIRVContext.h
@@ -51,30 +51,25 @@ public:
   /// has not been defined, it will define and store its instruction.
   uint32_t getResultIdForType(const Type *);
 
-  /// \brief Returns the instruction that defined the given Type.
-  /// If no <result-id> has been associated with this Type (not defined yet),
-  /// the instruction will be created, registered, and returned.
-  const std::vector<uint32_t> &getInstrForType(const Type *);
-
   /// \brief Registers the existence of the given type in the current context,
   /// and returns the unique Type pointer.
-  const Type *registerType(Type &);
+  const Type *registerType(const Type &);
 
   /// \brief Registers the existence of the given decoration in the current
   /// context, and returns the unique Decoration pointer.
-  const Decoration *registerDecoration(Decoration &);
+  const Decoration *registerDecoration(const Decoration &);
 
 private:
+  using TypeSet = std::unordered_set<Type, TypeHash>;
+  using DecorationSet = std::unordered_set<Decoration, DecorationHash>;
+
   uint32_t nextId;
 
   /// \brief All the unique Decorations defined in the current context.
-  std::unordered_set<Decoration, DecorationHash> existingDecorations;
+  DecorationSet existingDecorations;
 
   /// \brief All the unique types defined in the current context.
-  std::unordered_set<Type, TypeHash> existingTypes;
-
-  /// \brief Maps a <result-id> to its SPIR-V instruction.
-  std::unordered_map<uint32_t, std::vector<uint32_t>> idToInstructionMap;
+  TypeSet existingTypes;
 
   /// \brief Maps a given type to the <result-id> that is defined for
   /// that type. If a Type* does not exist in the map, the type

--- a/tools/clang/include/clang/SPIRV/SPIRVContext.h
+++ b/tools/clang/include/clang/SPIRV/SPIRVContext.h
@@ -9,10 +9,27 @@
 #ifndef LLVM_CLANG_SPIRV_SPIRVCONTEXT_H
 #define LLVM_CLANG_SPIRV_SPIRVCONTEXT_H
 
+#include <unordered_map>
+
 #include "clang/Frontend/FrontendAction.h"
+#include "clang/SPIRV/Decoration.h"
+#include "clang/SPIRV/Type.h"
 
 namespace clang {
 namespace spirv {
+
+struct TypeHash {
+  std::size_t operator()(const Type &t) const {
+    // TODO: We could improve this hash function if necessary.
+    return std::hash<uint32_t>{}(static_cast<uint32_t>(t.getOpcode()));
+  }
+};
+struct DecorationHash {
+  std::size_t operator()(const Decoration &d) const {
+    // TODO: We could probably improve this hash function if needed.
+    return std::hash<uint32_t>{}(static_cast<uint32_t>(d.getDecorationType()));
+  }
+};
 
 /// \brief A class for holding various data needed in SPIR-V codegen.
 /// It should outlive all SPIR-V codegen components that requires/allocates
@@ -30,8 +47,35 @@ public:
   inline uint32_t GetNextId() const;
   inline uint32_t TakeNextId();
 
+  /// \brief Returns the ResultID that defines the given Type. If the type
+  /// has not been defined, it will define and store its instruction.
+  /// The 'next_id_func' will be called to get the ResultID for the type.
+  uint32_t GetResultIdForType(const Type *t,
+                              std::function<uint32_t()> next_id_func);
+
+  /// \brief Returns the instruction that defined the given Type.
+  /// If no ResultID has been associated with this Type (not defined yet),
+  /// the instruction will be created, registered, and returned.
+  /// The 'next_id_func' will be called to get the result_id for the type.
+  const std::vector<uint32_t> &
+  GetInstrForType(const Type *t, std::function<uint32_t()> next_id_func);
+
+  // All the unique types defined in the current context.
+  std::unordered_set<Type, TypeHash> ExistingTypes;
+
+  // All the unique Decorations defined in the current context.
+  std::unordered_set<Decoration, DecorationHash> ExistingDecorations;
+
 private:
   uint32_t NextId;
+
+  // Maps a ResultID to its SPIR-V instruction.
+  std::unordered_map<uint32_t, std::vector<uint32_t>> IdToInstructionMap;
+
+  // Maps a given type to the ResultID that is defined for
+  // that type. If a Type* does not exist in the map, the type
+  // is not yet defined and is not associated with a ResultID.
+  std::unordered_map<const Type *, uint32_t> TypeResultIdMap;
 };
 
 SPIRVContext::SPIRVContext() : NextId(1) {}

--- a/tools/clang/include/clang/SPIRV/Type.h
+++ b/tools/clang/include/clang/SPIRV/Type.h
@@ -1,0 +1,118 @@
+//===-- Type.h - SPIR-V Type --*- C++-*------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_CLANG_SPIRV_TYPE_H
+#define LLVM_CLANG_SPIRV_TYPE_H
+
+#include <set>
+#include <unordered_set>
+#include <vector>
+
+#include "clang/SPIRV/Decoration.h"
+#include "clang/SPIRV/Option.h"
+#include "clang/SPIRV/spirv.hpp"
+
+namespace clang {
+namespace spirv {
+
+class SPIRVContext;
+
+class Type {
+public:
+  spv::Op getOpcode() const { return opcode; }
+  const std::vector<uint32_t> &getArgs() const { return args; }
+  bool isBooleanType(const Type *t);
+  bool isIntegerType(const Type *t);
+  bool isFloatType(const Type *t);
+  bool isNumericalType(const Type *t);
+  bool isScalarType(const Type *t);
+  bool isVectorType(const Type *t);
+  bool isMatrixType(const Type *t);
+  bool isArrayType(const Type *t);
+  bool isStructureType(const Type *t);
+  bool isAggregateType(const Type *t);
+  bool isCompositeType(const Type *t);
+  bool isImageType(const Type *t);
+
+  static const Type *getType(SPIRVContext &ctx, spv::Op op,
+                             std::vector<uint32_t> arg = {},
+                             std::set<const Decoration *> decs = {});
+
+  static const Type *getTypeVoid(SPIRVContext &ctx);
+  static const Type *getTypeBool(SPIRVContext &ctx);
+  static const Type *getTypeInt8(SPIRVContext &ctx);
+  static const Type *getTypeUnsignedInt8(SPIRVContext &ctx);
+  static const Type *getTypeInt16(SPIRVContext &ctx);
+  static const Type *getTypeUnsignedInt16(SPIRVContext &ctx);
+  static const Type *getTypeInt32(SPIRVContext &ctx);
+  static const Type *getTypeUnsignedInt32(SPIRVContext &ctx);
+  static const Type *getTypeInt64(SPIRVContext &ctx);
+  static const Type *getTypeUnsignedInt64(SPIRVContext &ctx);
+  static const Type *getTypeFloat16(SPIRVContext &ctx);
+  static const Type *getTypeFloat32(SPIRVContext &ctx);
+  static const Type *getTypeFloat64(SPIRVContext &ctx);
+  static const Type *getTypeVector(SPIRVContext &ctx, uint32_t component_type,
+                                   uint32_t vec_size);
+  static const Type *getTypeVec2(SPIRVContext &ctx, uint32_t component_type);
+  static const Type *getTypeVec3(SPIRVContext &ctx, uint32_t component_type);
+  static const Type *getTypeVec4(SPIRVContext &ctx, uint32_t component_type);
+  static const Type *getTypeMatrix(SPIRVContext &ctx, uint32_t column_type_id,
+                                   uint32_t column_count);
+  static const Type *
+  getTypeImage(SPIRVContext &ctx, uint32_t sampled_type, spv::Dim dim,
+               uint32_t depth, uint32_t arrayed, uint32_t ms, uint32_t sampled,
+               spv::ImageFormat image_format,
+               Option<spv::AccessQualifier> access_qualifier);
+  static const Type *getTypeSampler(SPIRVContext &ctx);
+  static const Type *getTypeSampledImage(SPIRVContext &ctx,
+                                         uint32_t imag_type_id);
+  static const Type *getTypeArray(SPIRVContext &ctx, uint32_t component_type_id,
+                                  uint32_t len_id);
+  static const Type *getTypeRuntimeArray(SPIRVContext &ctx,
+                                         uint32_t component_type_id);
+  static const Type *getTypeStruct(SPIRVContext &ctx,
+                                   std::initializer_list<uint32_t> members);
+  static const Type *getTypeOpaque(SPIRVContext &ctx, std::string name);
+  static const Type *getTyePointer(SPIRVContext &ctx,
+                                   spv::StorageClass storage_class,
+                                   uint32_t type);
+  static const Type *getTypeFunction(SPIRVContext &ctx, uint32_t return_type,
+                                     std::initializer_list<uint32_t> params);
+  static const Type *getTypeEvent(SPIRVContext &ctx);
+  static const Type *getTypeDeviceEvent(SPIRVContext &ctx);
+  static const Type *getTypeQueue(SPIRVContext &ctx);
+  static const Type *getTypePipe(SPIRVContext &ctx,
+                                 spv::AccessQualifier qualifier);
+  static const Type *getTypeForwardPointer(SPIRVContext &ctx,
+                                           uint32_t pointer_type,
+                                           spv::StorageClass storage_class);
+  static const Type *getTypePipeStorage(SPIRVContext &ctx);
+  static const Type *getTypeNamedBarrier(SPIRVContext &ctx);
+
+  bool operator==(const Type &other) const {
+    return opcode == other.opcode && args == other.args &&
+           decorations == other.decorations;
+  }
+
+private:
+  Type(spv::Op op, std::vector<uint32_t> arg = {},
+       std::set<const Decoration *> dec = {});
+
+  // Uses ExistingTypes to return an unique type.
+  static const Type *getUniqueType(SPIRVContext &context, Type &t);
+
+  // Private members that define a unique SPIR-V type.
+  spv::Op opcode;
+  std::vector<uint32_t> args;
+  std::set<const Decoration *> decorations;
+};
+
+} // end namespace spirv
+} // end namespace clang
+
+#endif

--- a/tools/clang/include/clang/SPIRV/Type.h
+++ b/tools/clang/include/clang/SPIRV/Type.h
@@ -1,4 +1,4 @@
-//===-- Type.h - SPIR-V Type --*- C++-*------------------------------------===//
+//===-- Type.h - SPIR-V Type ------------------------------------*- C++ -*-===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -14,85 +14,93 @@
 #include <vector>
 
 #include "clang/SPIRV/Decoration.h"
-#include "clang/SPIRV/Option.h"
 #include "clang/SPIRV/spirv.hpp"
+#include "llvm/ADT/Optional.h"
 
 namespace clang {
 namespace spirv {
 
 class SPIRVContext;
 
+/// \brief SPIR-V Type
+///
+/// This class defines a unique SPIR-V Type.
+/// A SPIR-V Type includes its <opcode> defined by the SPIR-V Spec.
+/// It also incldues any arguments (32-bit words) needed to define the
+/// type. It also includes a set of decorations that are applied to that type.
+///
+/// The class includes static getXXX(...) functions for getting pointers of any
+/// needed type. A unique type has a unique pointer (e.g. calling
+/// 'getBoolean' function will always return the same pointer for the given
+/// context)
 class Type {
 public:
   spv::Op getOpcode() const { return opcode; }
   const std::vector<uint32_t> &getArgs() const { return args; }
-  bool isBooleanType(const Type *t);
-  bool isIntegerType(const Type *t);
-  bool isFloatType(const Type *t);
-  bool isNumericalType(const Type *t);
-  bool isScalarType(const Type *t);
-  bool isVectorType(const Type *t);
-  bool isMatrixType(const Type *t);
-  bool isArrayType(const Type *t);
-  bool isStructureType(const Type *t);
-  bool isAggregateType(const Type *t);
-  bool isCompositeType(const Type *t);
-  bool isImageType(const Type *t);
+  bool isBooleanType() const;
+  bool isIntegerType() const;
+  bool isFloatType() const;
+  bool isNumericalType() const;
+  bool isScalarType() const;
+  bool isVectorType() const;
+  bool isMatrixType() const;
+  bool isArrayType() const;
+  bool isStructureType() const;
+  bool isAggregateType() const;
+  bool isCompositeType() const;
+  bool isImageType() const;
 
   static const Type *getType(SPIRVContext &ctx, spv::Op op,
                              std::vector<uint32_t> arg = {},
                              std::set<const Decoration *> decs = {});
 
-  static const Type *getTypeVoid(SPIRVContext &ctx);
-  static const Type *getTypeBool(SPIRVContext &ctx);
-  static const Type *getTypeInt8(SPIRVContext &ctx);
-  static const Type *getTypeUnsignedInt8(SPIRVContext &ctx);
-  static const Type *getTypeInt16(SPIRVContext &ctx);
-  static const Type *getTypeUnsignedInt16(SPIRVContext &ctx);
-  static const Type *getTypeInt32(SPIRVContext &ctx);
-  static const Type *getTypeUnsignedInt32(SPIRVContext &ctx);
-  static const Type *getTypeInt64(SPIRVContext &ctx);
-  static const Type *getTypeUnsignedInt64(SPIRVContext &ctx);
-  static const Type *getTypeFloat16(SPIRVContext &ctx);
-  static const Type *getTypeFloat32(SPIRVContext &ctx);
-  static const Type *getTypeFloat64(SPIRVContext &ctx);
-  static const Type *getTypeVector(SPIRVContext &ctx, uint32_t component_type,
-                                   uint32_t vec_size);
-  static const Type *getTypeVec2(SPIRVContext &ctx, uint32_t component_type);
-  static const Type *getTypeVec3(SPIRVContext &ctx, uint32_t component_type);
-  static const Type *getTypeVec4(SPIRVContext &ctx, uint32_t component_type);
-  static const Type *getTypeMatrix(SPIRVContext &ctx, uint32_t column_type_id,
-                                   uint32_t column_count);
+  static const Type *getVoid(SPIRVContext &ctx);
+  static const Type *getBool(SPIRVContext &ctx);
+  static const Type *getInt8(SPIRVContext &ctx);
+  static const Type *getUnsignedInt8(SPIRVContext &ctx);
+  static const Type *getInt16(SPIRVContext &ctx);
+  static const Type *getUnsignedInt16(SPIRVContext &ctx);
+  static const Type *getInt32(SPIRVContext &ctx);
+  static const Type *getUnsignedInt32(SPIRVContext &ctx);
+  static const Type *getInt64(SPIRVContext &ctx);
+  static const Type *getUnsignedInt64(SPIRVContext &ctx);
+  static const Type *getFloat16(SPIRVContext &ctx);
+  static const Type *getFloat32(SPIRVContext &ctx);
+  static const Type *getFloat64(SPIRVContext &ctx);
+  static const Type *getVector(SPIRVContext &ctx, uint32_t component_type,
+                               uint32_t vec_size);
+  static const Type *getVec2(SPIRVContext &ctx, uint32_t component_type);
+  static const Type *getVec3(SPIRVContext &ctx, uint32_t component_type);
+  static const Type *getVec4(SPIRVContext &ctx, uint32_t component_type);
+  static const Type *getMatrix(SPIRVContext &ctx, uint32_t column_type_id,
+                               uint32_t column_count);
   static const Type *
-  getTypeImage(SPIRVContext &ctx, uint32_t sampled_type, spv::Dim dim,
-               uint32_t depth, uint32_t arrayed, uint32_t ms, uint32_t sampled,
-               spv::ImageFormat image_format,
-               Option<spv::AccessQualifier> access_qualifier);
-  static const Type *getTypeSampler(SPIRVContext &ctx);
-  static const Type *getTypeSampledImage(SPIRVContext &ctx,
-                                         uint32_t imag_type_id);
-  static const Type *getTypeArray(SPIRVContext &ctx, uint32_t component_type_id,
-                                  uint32_t len_id);
-  static const Type *getTypeRuntimeArray(SPIRVContext &ctx,
-                                         uint32_t component_type_id);
-  static const Type *getTypeStruct(SPIRVContext &ctx,
-                                   std::initializer_list<uint32_t> members);
-  static const Type *getTypeOpaque(SPIRVContext &ctx, std::string name);
+  getImage(SPIRVContext &ctx, uint32_t sampled_type, spv::Dim dim,
+           uint32_t depth, uint32_t arrayed, uint32_t ms, uint32_t sampled,
+           spv::ImageFormat image_format,
+           llvm::Optional<spv::AccessQualifier> access_qualifier);
+  static const Type *getSampler(SPIRVContext &ctx);
+  static const Type *getSampledImage(SPIRVContext &ctx, uint32_t imag_type_id);
+  static const Type *getArray(SPIRVContext &ctx, uint32_t component_type_id,
+                              uint32_t len_id);
+  static const Type *getRuntimeArray(SPIRVContext &ctx,
+                                     uint32_t component_type_id);
+  static const Type *getStruct(SPIRVContext &ctx,
+                               std::initializer_list<uint32_t> members);
+  static const Type *getOpaque(SPIRVContext &ctx, std::string name);
   static const Type *getTyePointer(SPIRVContext &ctx,
                                    spv::StorageClass storage_class,
                                    uint32_t type);
-  static const Type *getTypeFunction(SPIRVContext &ctx, uint32_t return_type,
-                                     std::initializer_list<uint32_t> params);
-  static const Type *getTypeEvent(SPIRVContext &ctx);
-  static const Type *getTypeDeviceEvent(SPIRVContext &ctx);
-  static const Type *getTypeQueue(SPIRVContext &ctx);
-  static const Type *getTypePipe(SPIRVContext &ctx,
-                                 spv::AccessQualifier qualifier);
-  static const Type *getTypeForwardPointer(SPIRVContext &ctx,
-                                           uint32_t pointer_type,
-                                           spv::StorageClass storage_class);
-  static const Type *getTypePipeStorage(SPIRVContext &ctx);
-  static const Type *getTypeNamedBarrier(SPIRVContext &ctx);
+  static const Type *getFunction(SPIRVContext &ctx, uint32_t return_type,
+                                 std::initializer_list<uint32_t> params);
+  static const Type *getEvent(SPIRVContext &ctx);
+  static const Type *getDeviceEvent(SPIRVContext &ctx);
+  static const Type *getQueue(SPIRVContext &ctx);
+  static const Type *getPipe(SPIRVContext &ctx, spv::AccessQualifier qualifier);
+  static const Type *getForwardPointer(SPIRVContext &ctx, uint32_t pointer_type,
+                                       spv::StorageClass storage_class);
+  static const Type *getPipeStorage(SPIRVContext &ctx);
+  static const Type *getNamedBarrier(SPIRVContext &ctx);
 
   bool operator==(const Type &other) const {
     return opcode == other.opcode && args == other.args &&
@@ -100,16 +108,17 @@ public:
   }
 
 private:
+  /// \brief Private constructor.
   Type(spv::Op op, std::vector<uint32_t> arg = {},
        std::set<const Decoration *> dec = {});
 
-  // Uses ExistingTypes to return an unique type.
-  static const Type *getUniqueType(SPIRVContext &context, Type &t);
+  /// \brief Returns the unique Type pointer within the given context.
+  static const Type *getUniqueType(SPIRVContext &, Type &);
 
-  // Private members that define a unique SPIR-V type.
-  spv::Op opcode;
-  std::vector<uint32_t> args;
-  std::set<const Decoration *> decorations;
+private:
+  spv::Op opcode;             ///< OpCode of the Type defined in SPIR-V Spec
+  std::vector<uint32_t> args; ///< Arguments needed to define the type
+  std::set<const Decoration *> decorations; ///< decorations applied to the type
 };
 
 } // end namespace spirv

--- a/tools/clang/include/clang/SPIRV/Type.h
+++ b/tools/clang/include/clang/SPIRV/Type.h
@@ -32,11 +32,12 @@ class SPIRVContext;
 /// The class includes static getXXX(...) functions for getting pointers of any
 /// needed type. A unique type has a unique pointer (e.g. calling
 /// 'getBoolean' function will always return the same pointer for the given
-/// context)
+/// context).
 class Type {
 public:
   spv::Op getOpcode() const { return opcode; }
   const std::vector<uint32_t> &getArgs() const { return args; }
+
   bool isBooleanType() const;
   bool isIntegerType() const;
   bool isFloatType() const;
@@ -57,13 +58,13 @@ public:
   static const Type *getVoid(SPIRVContext &ctx);
   static const Type *getBool(SPIRVContext &ctx);
   static const Type *getInt8(SPIRVContext &ctx);
-  static const Type *getUnsignedInt8(SPIRVContext &ctx);
+  static const Type *getUint8(SPIRVContext &ctx);
   static const Type *getInt16(SPIRVContext &ctx);
-  static const Type *getUnsignedInt16(SPIRVContext &ctx);
+  static const Type *getUint16(SPIRVContext &ctx);
   static const Type *getInt32(SPIRVContext &ctx);
-  static const Type *getUnsignedInt32(SPIRVContext &ctx);
+  static const Type *getUint32(SPIRVContext &ctx);
   static const Type *getInt64(SPIRVContext &ctx);
-  static const Type *getUnsignedInt64(SPIRVContext &ctx);
+  static const Type *getUint64(SPIRVContext &ctx);
   static const Type *getFloat16(SPIRVContext &ctx);
   static const Type *getFloat32(SPIRVContext &ctx);
   static const Type *getFloat64(SPIRVContext &ctx);
@@ -113,7 +114,7 @@ private:
        std::set<const Decoration *> dec = {});
 
   /// \brief Returns the unique Type pointer within the given context.
-  static const Type *getUniqueType(SPIRVContext &, Type &);
+  static const Type *getUniqueType(SPIRVContext &, const Type &);
 
 private:
   spv::Op opcode;             ///< OpCode of the Type defined in SPIR-V Spec

--- a/tools/clang/include/clang/SPIRV/Utils.h
+++ b/tools/clang/include/clang/SPIRV/Utils.h
@@ -1,0 +1,32 @@
+//===-- Utils.h - SPIR-V Utils --------*- C++-*----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_CLANG_SPIRV_UTILS_H
+#define LLVM_CLANG_SPIRV_UTILS_H
+
+#include <string>
+#include <vector>
+
+namespace clang {
+namespace spirv {
+namespace utils {
+
+/// \brief Reinterprets a given string as sequence of words.
+/// Assumes Little Endian architecture.
+std::vector<uint32_t> reinterpretStringAsUintVec(std::string s);
+  
+/// \brief Reinterprets the given vector of 32-bit words as a string.
+/// Expectes that the words represent a NULL-terminated string.
+/// Assumes Little Endian architecture.
+std::string reinterpretUintVecAsString(std::vector<uint32_t>& vec);
+
+} // end namespace utils
+} // end namespace spirv
+} // end namespace clang
+
+#endif

--- a/tools/clang/include/clang/SPIRV/Utils.h
+++ b/tools/clang/include/clang/SPIRV/Utils.h
@@ -1,4 +1,4 @@
-//===-- Utils.h - SPIR-V Utils --------*- C++-*----------------------------===//
+//===-- Utils.h - SPIR-V Utils ----------------------------------*- C++ -*-===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -16,14 +16,14 @@ namespace clang {
 namespace spirv {
 namespace utils {
 
-/// \brief Reinterprets a given string as sequence of words.
-/// Assumes Little Endian architecture.
-std::vector<uint32_t> reinterpretStringAsUintVec(std::string s);
-  
+/// \brief Reinterprets a given string as sequence of words. It follows the
+/// SPIR-V string encoding requirements.
+std::vector<uint32_t> encodeSPIRVString(std::string s);
+
 /// \brief Reinterprets the given vector of 32-bit words as a string.
 /// Expectes that the words represent a NULL-terminated string.
-/// Assumes Little Endian architecture.
-std::string reinterpretUintVecAsString(std::vector<uint32_t>& vec);
+/// It follows the SPIR-V string encoding requirements.
+std::string decodeSPIRVString(std::vector<uint32_t> &vec);
 
 } // end namespace utils
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/CMakeLists.txt
+++ b/tools/clang/lib/SPIRV/CMakeLists.txt
@@ -3,10 +3,14 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_clang_library(clangSPIRV
+  Decoration.cpp
   EmitSPIRVAction.cpp
   InstBuilderAuto.cpp
   InstBuilderManual.cpp
   ModuleBuilder.cpp
+  SPIRVContext.cpp
+  Type.cpp
+  Utils.cpp
 
   LINK_LIBS
   clangAST

--- a/tools/clang/lib/SPIRV/Decoration.cpp
+++ b/tools/clang/lib/SPIRV/Decoration.cpp
@@ -1,0 +1,296 @@
+//===--- Decoration.cpp - SPIR-V Decoration implementation-----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/SPIRV/Decoration.h"
+#include "clang/SPIRV/SPIRVContext.h"
+#include "clang/SPIRV/Utils.h"
+#include "clang/SPIRV/spirv.hpp"
+#include "llvm/llvm_assert/assert.h"
+
+namespace clang {
+namespace spirv {
+
+const Decoration *Decoration::getUniqueDecoration(SPIRVContext &context,
+                                                  Decoration &d) {
+  // Insert function will only insert if it doesn't already exist in the set.
+  context.ExistingDecorations.insert(d);
+  return &(*context.ExistingDecorations.find(d));
+}
+const Decoration *
+Decoration::getDecorationRelaxedPrecision(SPIRVContext &context) {
+  Decoration d = Decoration(spv::Decoration::RelaxedPrecision);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationSpecId(SPIRVContext &context,
+                                                  uint32_t id) {
+  Decoration d = Decoration(spv::Decoration::SpecId, {id});
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationBlock(SPIRVContext &context) {
+  Decoration d = Decoration(spv::Decoration::Block);
+  return getUniqueDecoration(context, d);
+}
+
+const Decoration *Decoration::getDecorationBufferBlock(SPIRVContext &context) {
+  Decoration d = Decoration(spv::Decoration::BufferBlock);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationRowMajor(SPIRVContext &context,
+                                                    int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::RowMajor);
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationColMajor(SPIRVContext &context,
+                                                    int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::ColMajor);
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationArrayStride(SPIRVContext &context,
+                                                       uint32_t stride) {
+  Decoration d = Decoration(spv::Decoration::ArrayStride, {stride});
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationMatrixStride(SPIRVContext &context,
+                                                        uint32_t stride,
+                                                        int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::MatrixStride, {stride});
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationGLSLShared(SPIRVContext &context) {
+  Decoration d = Decoration(spv::Decoration::GLSLShared);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationGLSLPacked(SPIRVContext &context) {
+  Decoration d = Decoration(spv::Decoration::GLSLPacked);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationCPacked(SPIRVContext &context) {
+  Decoration d = Decoration(spv::Decoration::CPacked);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationBuiltIn(SPIRVContext &context,
+                                                   spv::BuiltIn builtin,
+                                                   int32_t member_idx) {
+  Decoration d =
+      Decoration(spv::Decoration::BuiltIn, {static_cast<uint32_t>(builtin)});
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationNoPerspective(SPIRVContext &context,
+                                                         int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::NoPerspective);
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationFlat(SPIRVContext &context,
+                                                int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::Flat);
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationPatch(SPIRVContext &context,
+                                                 int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::Patch);
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationCentroid(SPIRVContext &context,
+                                                    int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::Centroid);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationSample(SPIRVContext &context,
+                                                  int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::Sample);
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationInvariant(SPIRVContext &context) {
+  Decoration d = Decoration(spv::Decoration::Invariant);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationRestrict(SPIRVContext &context) {
+  Decoration d = Decoration(spv::Decoration::Restrict);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationAliased(SPIRVContext &context) {
+  Decoration d = Decoration(spv::Decoration::Aliased);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationVolatile(SPIRVContext &context,
+                                                    int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::Volatile);
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationConstant(SPIRVContext &context) {
+  Decoration d = Decoration(spv::Decoration::Constant);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationCoherent(SPIRVContext &context,
+                                                    int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::Coherent);
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationNonWritable(SPIRVContext &context,
+                                                       int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::NonWritable);
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationNonReadable(SPIRVContext &context,
+                                                       int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::NonReadable);
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationUniform(SPIRVContext &context,
+                                                   int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::Uniform);
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *
+Decoration::getDecorationSaturatedConversion(SPIRVContext &context) {
+  Decoration d = Decoration(spv::Decoration::SaturatedConversion);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationStream(SPIRVContext &context,
+                                                  uint32_t stream_number,
+                                                  int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::Stream, {stream_number});
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationLocation(SPIRVContext &context,
+                                                    uint32_t location,
+                                                    int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::Location, {location});
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationComponent(SPIRVContext &context,
+                                                     uint32_t component,
+                                                     int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::Component, {component});
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationIndex(SPIRVContext &context,
+                                                 uint32_t index) {
+  Decoration d = Decoration(spv::Decoration::Index, {index});
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationBinding(SPIRVContext &context,
+                                                   uint32_t binding_point) {
+  Decoration d = Decoration(spv::Decoration::Binding, {binding_point});
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationDescriptorSet(SPIRVContext &context,
+                                                         uint32_t set) {
+  Decoration d = Decoration(spv::Decoration::DescriptorSet, {set});
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationOffset(SPIRVContext &context,
+                                                  uint32_t byte_offset,
+                                                  int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::Offset, {byte_offset});
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationXfbBuffer(SPIRVContext &context,
+                                                     uint32_t xfb_buf,
+                                                     int32_t member_idx) {
+  Decoration d = Decoration(spv::Decoration::XfbBuffer, {xfb_buf});
+  d.setMemberIndex(member_idx);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationXfbStride(SPIRVContext &context,
+                                                     uint32_t xfb_stride) {
+  Decoration d = Decoration(spv::Decoration::XfbStride, {xfb_stride});
+  return getUniqueDecoration(context, d);
+}
+const Decoration *
+Decoration::getDecorationFuncParamAttr(SPIRVContext &context,
+                                       spv::FunctionParameterAttribute attr) {
+  Decoration d =
+      Decoration(spv::Decoration::FuncParamAttr, {static_cast<uint32_t>(attr)});
+  return getUniqueDecoration(context, d);
+}
+const Decoration *
+Decoration::getDecorationFPRoundingMode(SPIRVContext &context,
+                                        spv::FPRoundingMode mode) {
+  Decoration d = Decoration(spv::Decoration::FPRoundingMode,
+                            {static_cast<uint32_t>(mode)});
+  return getUniqueDecoration(context, d);
+}
+const Decoration *
+Decoration::getDecorationFPFastMathMode(SPIRVContext &context,
+                                        spv::FPFastMathModeShift mode) {
+  Decoration d = Decoration(spv::Decoration::FPFastMathMode,
+                            {static_cast<uint32_t>(mode)});
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationLinkageAttributes(
+    SPIRVContext &context, std::string name, spv::LinkageType linkage_type) {
+  std::vector<uint32_t> args = utils::reinterpretStringAsUintVec(name);
+  args.push_back(static_cast<uint32_t>(linkage_type));
+  Decoration d = Decoration(spv::Decoration::LinkageAttributes, args);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *
+Decoration::getDecorationNoContraction(SPIRVContext &context) {
+  Decoration d = Decoration(spv::Decoration::NoContraction);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *
+Decoration::getDecorationInputAttachmentIndex(SPIRVContext &context,
+                                              uint32_t index) {
+  Decoration d = Decoration(spv::Decoration::InputAttachmentIndex, {index});
+  return getUniqueDecoration(context, d);
+}
+const Decoration *Decoration::getDecorationAlignment(SPIRVContext &context,
+                                                     uint32_t alignment) {
+  Decoration d = Decoration(spv::Decoration::Alignment, {alignment});
+  return getUniqueDecoration(context, d);
+}
+const Decoration *
+Decoration::getDecorationMaxByteOffset(SPIRVContext &context,
+                                       uint32_t max_byte_offset) {
+  Decoration d = Decoration(spv::Decoration::MaxByteOffset, {max_byte_offset});
+  return getUniqueDecoration(context, d);
+}
+const Decoration *
+Decoration::getDecorationOverrideCoverageNV(SPIRVContext &context) {
+  Decoration d = Decoration(spv::Decoration::OverrideCoverageNV);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *
+Decoration::getDecorationPassthroughNV(SPIRVContext &context) {
+  Decoration d = Decoration(spv::Decoration::PassthroughNV);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *
+Decoration::getDecorationViewportRelativeNV(SPIRVContext &context) {
+  Decoration d = Decoration(spv::Decoration::ViewportRelativeNV);
+  return getUniqueDecoration(context, d);
+}
+const Decoration *
+Decoration::getDecorationSecondaryViewportRelativeNV(SPIRVContext &context,
+                                                     uint32_t offset) {
+  Decoration d = Decoration(spv::Decoration::SecondaryViewportRelativeNV);
+  return getUniqueDecoration(context, d);
+}
+
+} // end namespace spirv
+} // end namespace clang

--- a/tools/clang/lib/SPIRV/Decoration.cpp
+++ b/tools/clang/lib/SPIRV/Decoration.cpp
@@ -17,7 +17,7 @@ namespace clang {
 namespace spirv {
 
 const Decoration *Decoration::getUniqueDecoration(SPIRVContext &context,
-                                                  Decoration &d) {
+                                                  const Decoration &d) {
   return context.registerDecoration(d);
 }
 const Decoration *Decoration::getRelaxedPrecision(SPIRVContext &context) {

--- a/tools/clang/lib/SPIRV/Decoration.cpp
+++ b/tools/clang/lib/SPIRV/Decoration.cpp
@@ -18,276 +18,268 @@ namespace spirv {
 
 const Decoration *Decoration::getUniqueDecoration(SPIRVContext &context,
                                                   Decoration &d) {
-  // Insert function will only insert if it doesn't already exist in the set.
-  context.ExistingDecorations.insert(d);
-  return &(*context.ExistingDecorations.find(d));
+  return context.registerDecoration(d);
 }
-const Decoration *
-Decoration::getDecorationRelaxedPrecision(SPIRVContext &context) {
+const Decoration *Decoration::getRelaxedPrecision(SPIRVContext &context) {
   Decoration d = Decoration(spv::Decoration::RelaxedPrecision);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationSpecId(SPIRVContext &context,
-                                                  uint32_t id) {
+const Decoration *Decoration::getSpecId(SPIRVContext &context, uint32_t id) {
   Decoration d = Decoration(spv::Decoration::SpecId, {id});
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationBlock(SPIRVContext &context) {
+const Decoration *Decoration::getBlock(SPIRVContext &context) {
   Decoration d = Decoration(spv::Decoration::Block);
   return getUniqueDecoration(context, d);
 }
 
-const Decoration *Decoration::getDecorationBufferBlock(SPIRVContext &context) {
+const Decoration *Decoration::getBufferBlock(SPIRVContext &context) {
   Decoration d = Decoration(spv::Decoration::BufferBlock);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationRowMajor(SPIRVContext &context,
-                                                    int32_t member_idx) {
+const Decoration *Decoration::getRowMajor(SPIRVContext &context,
+                                          uint32_t member_idx) {
   Decoration d = Decoration(spv::Decoration::RowMajor);
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationColMajor(SPIRVContext &context,
-                                                    int32_t member_idx) {
+const Decoration *Decoration::getColMajor(SPIRVContext &context,
+                                          uint32_t member_idx) {
   Decoration d = Decoration(spv::Decoration::ColMajor);
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationArrayStride(SPIRVContext &context,
-                                                       uint32_t stride) {
+const Decoration *Decoration::getArrayStride(SPIRVContext &context,
+                                             uint32_t stride) {
   Decoration d = Decoration(spv::Decoration::ArrayStride, {stride});
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationMatrixStride(SPIRVContext &context,
-                                                        uint32_t stride,
-                                                        int32_t member_idx) {
+const Decoration *Decoration::getMatrixStride(SPIRVContext &context,
+                                              uint32_t stride,
+                                              uint32_t member_idx) {
   Decoration d = Decoration(spv::Decoration::MatrixStride, {stride});
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationGLSLShared(SPIRVContext &context) {
+const Decoration *Decoration::getGLSLShared(SPIRVContext &context) {
   Decoration d = Decoration(spv::Decoration::GLSLShared);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationGLSLPacked(SPIRVContext &context) {
+const Decoration *Decoration::getGLSLPacked(SPIRVContext &context) {
   Decoration d = Decoration(spv::Decoration::GLSLPacked);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationCPacked(SPIRVContext &context) {
+const Decoration *Decoration::getCPacked(SPIRVContext &context) {
   Decoration d = Decoration(spv::Decoration::CPacked);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationBuiltIn(SPIRVContext &context,
-                                                   spv::BuiltIn builtin,
-                                                   int32_t member_idx) {
+const Decoration *Decoration::getBuiltIn(SPIRVContext &context,
+                                         spv::BuiltIn builtin,
+                                         llvm::Optional<uint32_t> member_idx) {
   Decoration d =
       Decoration(spv::Decoration::BuiltIn, {static_cast<uint32_t>(builtin)});
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationNoPerspective(SPIRVContext &context,
-                                                         int32_t member_idx) {
+const Decoration *
+Decoration::getNoPerspective(SPIRVContext &context,
+                             llvm::Optional<uint32_t> member_idx) {
   Decoration d = Decoration(spv::Decoration::NoPerspective);
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationFlat(SPIRVContext &context,
-                                                int32_t member_idx) {
+const Decoration *Decoration::getFlat(SPIRVContext &context,
+                                      llvm::Optional<uint32_t> member_idx) {
   Decoration d = Decoration(spv::Decoration::Flat);
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationPatch(SPIRVContext &context,
-                                                 int32_t member_idx) {
+const Decoration *Decoration::getPatch(SPIRVContext &context,
+                                       llvm::Optional<uint32_t> member_idx) {
   Decoration d = Decoration(spv::Decoration::Patch);
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationCentroid(SPIRVContext &context,
-                                                    int32_t member_idx) {
+const Decoration *Decoration::getCentroid(SPIRVContext &context,
+                                          llvm::Optional<uint32_t> member_idx) {
   Decoration d = Decoration(spv::Decoration::Centroid);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationSample(SPIRVContext &context,
-                                                  int32_t member_idx) {
+const Decoration *Decoration::getSample(SPIRVContext &context,
+                                        llvm::Optional<uint32_t> member_idx) {
   Decoration d = Decoration(spv::Decoration::Sample);
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationInvariant(SPIRVContext &context) {
+const Decoration *Decoration::getInvariant(SPIRVContext &context) {
   Decoration d = Decoration(spv::Decoration::Invariant);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationRestrict(SPIRVContext &context) {
+const Decoration *Decoration::getRestrict(SPIRVContext &context) {
   Decoration d = Decoration(spv::Decoration::Restrict);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationAliased(SPIRVContext &context) {
+const Decoration *Decoration::getAliased(SPIRVContext &context) {
   Decoration d = Decoration(spv::Decoration::Aliased);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationVolatile(SPIRVContext &context,
-                                                    int32_t member_idx) {
+const Decoration *Decoration::getVolatile(SPIRVContext &context,
+                                          llvm::Optional<uint32_t> member_idx) {
   Decoration d = Decoration(spv::Decoration::Volatile);
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationConstant(SPIRVContext &context) {
+const Decoration *Decoration::getConstant(SPIRVContext &context) {
   Decoration d = Decoration(spv::Decoration::Constant);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationCoherent(SPIRVContext &context,
-                                                    int32_t member_idx) {
+const Decoration *Decoration::getCoherent(SPIRVContext &context,
+                                          llvm::Optional<uint32_t> member_idx) {
   Decoration d = Decoration(spv::Decoration::Coherent);
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationNonWritable(SPIRVContext &context,
-                                                       int32_t member_idx) {
+const Decoration *
+Decoration::getNonWritable(SPIRVContext &context,
+                           llvm::Optional<uint32_t> member_idx) {
   Decoration d = Decoration(spv::Decoration::NonWritable);
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationNonReadable(SPIRVContext &context,
-                                                       int32_t member_idx) {
+const Decoration *
+Decoration::getNonReadable(SPIRVContext &context,
+                           llvm::Optional<uint32_t> member_idx) {
   Decoration d = Decoration(spv::Decoration::NonReadable);
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationUniform(SPIRVContext &context,
-                                                   int32_t member_idx) {
+const Decoration *Decoration::getUniform(SPIRVContext &context,
+                                         llvm::Optional<uint32_t> member_idx) {
   Decoration d = Decoration(spv::Decoration::Uniform);
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *
-Decoration::getDecorationSaturatedConversion(SPIRVContext &context) {
+const Decoration *Decoration::getSaturatedConversion(SPIRVContext &context) {
   Decoration d = Decoration(spv::Decoration::SaturatedConversion);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationStream(SPIRVContext &context,
-                                                  uint32_t stream_number,
-                                                  int32_t member_idx) {
+const Decoration *Decoration::getStream(SPIRVContext &context,
+                                        uint32_t stream_number,
+                                        llvm::Optional<uint32_t> member_idx) {
   Decoration d = Decoration(spv::Decoration::Stream, {stream_number});
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationLocation(SPIRVContext &context,
-                                                    uint32_t location,
-                                                    int32_t member_idx) {
+const Decoration *Decoration::getLocation(SPIRVContext &context,
+                                          uint32_t location,
+                                          llvm::Optional<uint32_t> member_idx) {
   Decoration d = Decoration(spv::Decoration::Location, {location});
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationComponent(SPIRVContext &context,
-                                                     uint32_t component,
-                                                     int32_t member_idx) {
+const Decoration *
+Decoration::getComponent(SPIRVContext &context, uint32_t component,
+                         llvm::Optional<uint32_t> member_idx) {
   Decoration d = Decoration(spv::Decoration::Component, {component});
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationIndex(SPIRVContext &context,
-                                                 uint32_t index) {
+const Decoration *Decoration::getIndex(SPIRVContext &context, uint32_t index) {
   Decoration d = Decoration(spv::Decoration::Index, {index});
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationBinding(SPIRVContext &context,
-                                                   uint32_t binding_point) {
+const Decoration *Decoration::getBinding(SPIRVContext &context,
+                                         uint32_t binding_point) {
   Decoration d = Decoration(spv::Decoration::Binding, {binding_point});
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationDescriptorSet(SPIRVContext &context,
-                                                         uint32_t set) {
+const Decoration *Decoration::getDescriptorSet(SPIRVContext &context,
+                                               uint32_t set) {
   Decoration d = Decoration(spv::Decoration::DescriptorSet, {set});
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationOffset(SPIRVContext &context,
-                                                  uint32_t byte_offset,
-                                                  int32_t member_idx) {
+const Decoration *Decoration::getOffset(SPIRVContext &context,
+                                        uint32_t byte_offset,
+                                        llvm::Optional<uint32_t> member_idx) {
   Decoration d = Decoration(spv::Decoration::Offset, {byte_offset});
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationXfbBuffer(SPIRVContext &context,
-                                                     uint32_t xfb_buf,
-                                                     int32_t member_idx) {
+const Decoration *
+Decoration::getXfbBuffer(SPIRVContext &context, uint32_t xfb_buf,
+                         llvm::Optional<uint32_t> member_idx) {
   Decoration d = Decoration(spv::Decoration::XfbBuffer, {xfb_buf});
   d.setMemberIndex(member_idx);
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationXfbStride(SPIRVContext &context,
-                                                     uint32_t xfb_stride) {
+const Decoration *Decoration::getXfbStride(SPIRVContext &context,
+                                           uint32_t xfb_stride) {
   Decoration d = Decoration(spv::Decoration::XfbStride, {xfb_stride});
   return getUniqueDecoration(context, d);
 }
 const Decoration *
-Decoration::getDecorationFuncParamAttr(SPIRVContext &context,
-                                       spv::FunctionParameterAttribute attr) {
+Decoration::getFuncParamAttr(SPIRVContext &context,
+                             spv::FunctionParameterAttribute attr) {
   Decoration d =
       Decoration(spv::Decoration::FuncParamAttr, {static_cast<uint32_t>(attr)});
   return getUniqueDecoration(context, d);
 }
-const Decoration *
-Decoration::getDecorationFPRoundingMode(SPIRVContext &context,
-                                        spv::FPRoundingMode mode) {
+const Decoration *Decoration::getFPRoundingMode(SPIRVContext &context,
+                                                spv::FPRoundingMode mode) {
   Decoration d = Decoration(spv::Decoration::FPRoundingMode,
                             {static_cast<uint32_t>(mode)});
   return getUniqueDecoration(context, d);
 }
-const Decoration *
-Decoration::getDecorationFPFastMathMode(SPIRVContext &context,
-                                        spv::FPFastMathModeShift mode) {
+const Decoration *Decoration::getFPFastMathMode(SPIRVContext &context,
+                                                spv::FPFastMathModeShift mode) {
   Decoration d = Decoration(spv::Decoration::FPFastMathMode,
                             {static_cast<uint32_t>(mode)});
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationLinkageAttributes(
-    SPIRVContext &context, std::string name, spv::LinkageType linkage_type) {
-  std::vector<uint32_t> args = utils::reinterpretStringAsUintVec(name);
+const Decoration *
+Decoration::getLinkageAttributes(SPIRVContext &context, std::string name,
+                                 spv::LinkageType linkage_type) {
+  llvm::SmallVector<uint32_t, 2> args;
+  const auto &vec = utils::encodeSPIRVString(name);
+  args.insert(args.end(), vec.begin(), vec.end());
   args.push_back(static_cast<uint32_t>(linkage_type));
   Decoration d = Decoration(spv::Decoration::LinkageAttributes, args);
   return getUniqueDecoration(context, d);
 }
-const Decoration *
-Decoration::getDecorationNoContraction(SPIRVContext &context) {
+const Decoration *Decoration::getNoContraction(SPIRVContext &context) {
   Decoration d = Decoration(spv::Decoration::NoContraction);
   return getUniqueDecoration(context, d);
 }
-const Decoration *
-Decoration::getDecorationInputAttachmentIndex(SPIRVContext &context,
-                                              uint32_t index) {
+const Decoration *Decoration::getInputAttachmentIndex(SPIRVContext &context,
+                                                      uint32_t index) {
   Decoration d = Decoration(spv::Decoration::InputAttachmentIndex, {index});
   return getUniqueDecoration(context, d);
 }
-const Decoration *Decoration::getDecorationAlignment(SPIRVContext &context,
-                                                     uint32_t alignment) {
+const Decoration *Decoration::getAlignment(SPIRVContext &context,
+                                           uint32_t alignment) {
   Decoration d = Decoration(spv::Decoration::Alignment, {alignment});
   return getUniqueDecoration(context, d);
 }
-const Decoration *
-Decoration::getDecorationMaxByteOffset(SPIRVContext &context,
-                                       uint32_t max_byte_offset) {
+const Decoration *Decoration::getMaxByteOffset(SPIRVContext &context,
+                                               uint32_t max_byte_offset) {
   Decoration d = Decoration(spv::Decoration::MaxByteOffset, {max_byte_offset});
   return getUniqueDecoration(context, d);
 }
-const Decoration *
-Decoration::getDecorationOverrideCoverageNV(SPIRVContext &context) {
+const Decoration *Decoration::getOverrideCoverageNV(SPIRVContext &context) {
   Decoration d = Decoration(spv::Decoration::OverrideCoverageNV);
   return getUniqueDecoration(context, d);
 }
-const Decoration *
-Decoration::getDecorationPassthroughNV(SPIRVContext &context) {
+const Decoration *Decoration::getPassthroughNV(SPIRVContext &context) {
   Decoration d = Decoration(spv::Decoration::PassthroughNV);
   return getUniqueDecoration(context, d);
 }
-const Decoration *
-Decoration::getDecorationViewportRelativeNV(SPIRVContext &context) {
+const Decoration *Decoration::getViewportRelativeNV(SPIRVContext &context) {
   Decoration d = Decoration(spv::Decoration::ViewportRelativeNV);
   return getUniqueDecoration(context, d);
 }
 const Decoration *
-Decoration::getDecorationSecondaryViewportRelativeNV(SPIRVContext &context,
-                                                     uint32_t offset) {
+Decoration::getSecondaryViewportRelativeNV(SPIRVContext &context,
+                                           uint32_t offset) {
   Decoration d = Decoration(spv::Decoration::SecondaryViewportRelativeNV);
   return getUniqueDecoration(context, d);
 }

--- a/tools/clang/lib/SPIRV/InstBuilderManual.cpp
+++ b/tools/clang/lib/SPIRV/InstBuilderManual.cpp
@@ -16,7 +16,7 @@ namespace clang {
 namespace spirv {
 
 void InstBuilder::encodeString(std::string value) {
-  std::vector<uint32_t> words = utils::reinterpretStringAsUintVec(value);
+  const auto& words = utils::encodeSPIRVString(value);
   TheInst.insert(TheInst.end(), words.begin(), words.end());
 }
 

--- a/tools/clang/lib/SPIRV/InstBuilderManual.cpp
+++ b/tools/clang/lib/SPIRV/InstBuilderManual.cpp
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/SPIRV/InstBuilder.h"
+#include "clang/SPIRV/Utils.h"
 
 #include "llvm/llvm_assert/assert.h"
 
@@ -15,26 +16,9 @@ namespace clang {
 namespace spirv {
 
 void InstBuilder::encodeString(std::string value) {
-  const size_t numChars = value.size();
-  const size_t oldSize = TheInst.size();
-  TheInst.resize(oldSize + (numChars / 4 + 1));
-  // Make sure all the bytes in the last word are zeros, in case we only
-  // write a partial word at the end.
-  TheInst.back() = 0;
-  // From the SPIR-V spec, literal string is
-  //
-  // A nul-terminated stream of characters consuming an integral number of
-  // words. The character set is Unicode in the UTF-8 encoding scheme. The UTF-8
-  // octets (8-bit bytes) are packed four per word, following the little-endian
-  // convention (i.e., the first octet is in the lowest-order 8 bits of the
-  // word). The final word contains the string's nul-termination character (0),
-  // and all contents past the end of the string in the final word are padded
-  // with 0.
-  //
-  // So the following works on little endian machines.
-  char *strDest = reinterpret_cast<char *>(&TheInst[oldSize]);
-  strncpy(strDest, value.c_str(), numChars);
-};
+  std::vector<uint32_t> words = utils::reinterpretStringAsUintVec(value);
+  TheInst.insert(TheInst.end(), words.begin(), words.end());
+}
 
 } // end namespace spirv
 } // end namespace clang

--- a/tools/clang/lib/SPIRV/ModuleBuilder.cpp
+++ b/tools/clang/lib/SPIRV/ModuleBuilder.cpp
@@ -29,7 +29,7 @@ void ModuleBuilder::BeginModule() { GenHeader(); }
 
 void ModuleBuilder::EndModule() {
   assert(!TheModule.empty() && "BeginModule() not called before EndModule()");
-  TheModule[kBoundIndex] = TheContext.GetNextId();
+  TheModule[kBoundIndex] = TheContext.getNextId();
 }
 std::vector<uint32_t> ModuleBuilder::TakeModule() {
   return std::move(TheModule);

--- a/tools/clang/lib/SPIRV/SPIRVContext.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVContext.cpp
@@ -1,0 +1,59 @@
+//===--- SPIRVContext.cpp - SPIR-V SPIRVContext implementation-------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/SPIRV/SPIRVContext.h"
+#include "llvm/llvm_assert/assert.h"
+
+namespace clang {
+namespace spirv {
+
+uint32_t
+SPIRVContext::GetResultIdForType(const Type *t,
+                                 std::function<uint32_t()> get_id_func) {
+  assert(t != nullptr);
+  uint32_t result_id = 0;
+
+  auto iter = TypeResultIdMap.find(t);
+  if (iter == TypeResultIdMap.end()) {
+    // The Type has not been defined yet. Reserve an ID for it.
+    result_id = get_id_func();
+
+    // Make the instruction from the Type words
+    std::vector<uint32_t> instr;
+    instr.push_back(static_cast<uint32_t>(t->getOpcode()));
+    // OpTypeForwardPointer is the only OpTypeXXX that does not have a
+    // result_id.
+    if (t->getOpcode() != spv::Op::OpTypeForwardPointer) {
+      instr.push_back(result_id);
+    }
+    for (const auto &word : t->getArgs()) {
+      instr.push_back(word);
+    }
+    instr[0] |= static_cast<uint16_t>(t->getArgs().size()) << 16;
+
+    // Register it.
+    TypeResultIdMap[t] = result_id;
+    IdToInstructionMap[result_id] = instr;
+  } else {
+    result_id = iter->second;
+  }
+
+  assert(result_id != 0);
+  return result_id;
+}
+
+const std::vector<uint32_t> &
+SPIRVContext::GetInstrForType(const Type *t,
+                              std::function<uint32_t()> get_id_func) {
+  uint32_t result_id = GetResultIdForType(t, get_id_func);
+  return IdToInstructionMap[result_id];
+}
+
+} // end namespace spirv
+} // end namespace clang

--- a/tools/clang/lib/SPIRV/SPIRVContext.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVContext.cpp
@@ -22,23 +22,7 @@ SPIRVContext::getResultIdForType(const Type *t) {
   if (iter == typeResultIdMap.end()) {
     // The Type has not been defined yet. Reserve an ID for it.
     result_id = takeNextId();
-
-    // Make the instruction from the Type words
-    std::vector<uint32_t> instr;
-    instr.push_back(static_cast<uint32_t>(t->getOpcode()));
-    // OpTypeForwardPointer is the only OpTypeXXX that does not have a
-    // result_id.
-    if (t->getOpcode() != spv::Op::OpTypeForwardPointer) {
-      instr.push_back(result_id);
-    }
-    for (const auto &word : t->getArgs()) {
-      instr.push_back(word);
-    }
-    instr[0] |= static_cast<uint16_t>(t->getArgs().size()) << 16;
-
-    // Register it.
     typeResultIdMap[t] = result_id;
-    idToInstructionMap[result_id] = instr;
   } else {
     result_id = iter->second;
   }
@@ -47,22 +31,16 @@ SPIRVContext::getResultIdForType(const Type *t) {
   return result_id;
 }
 
-const std::vector<uint32_t> &
-SPIRVContext::getInstrForType(const Type *t) {
-  uint32_t result_id = getResultIdForType(t);
-  return idToInstructionMap[result_id];
-}
-
-const Type* SPIRVContext::registerType(Type& t) {
+const Type* SPIRVContext::registerType(const Type& t) {
   // Insert function will only insert if it doesn't already exist in the set.
-  std::unordered_set<Type, TypeHash>::iterator it;
+  TypeSet::iterator it;
   std::tie(it, std::ignore) = existingTypes.insert(t);
   return &*it;
 }
 
-const Decoration* SPIRVContext::registerDecoration(Decoration& d) {
+const Decoration* SPIRVContext::registerDecoration(const Decoration& d) {
   // Insert function will only insert if it doesn't already exist in the set.
-  std::unordered_set<Decoration, DecorationHash>::iterator it;
+  DecorationSet::iterator it;
   std::tie(it, std::ignore) = existingDecorations.insert(d);
   return &*it;
 }

--- a/tools/clang/lib/SPIRV/Type.cpp
+++ b/tools/clang/lib/SPIRV/Type.cpp
@@ -18,7 +18,7 @@ Type::Type(spv::Op op, std::vector<uint32_t> arg,
            std::set<const Decoration *> decs)
     : opcode(op), args(arg), decorations(decs) {}
 
-const Type *Type::getUniqueType(SPIRVContext &context, Type &t) {
+const Type *Type::getUniqueType(SPIRVContext &context, const Type &t) {
   return context.registerType(t);
 }
 const Type *Type::getVoid(SPIRVContext &context) {
@@ -33,7 +33,7 @@ const Type *Type::getInt8(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeInt, {8, 1});
   return getUniqueType(context, t);
 }
-const Type *Type::getUnsignedInt8(SPIRVContext &context) {
+const Type *Type::getUint8(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeInt, {8, 0});
   return getUniqueType(context, t);
 }
@@ -41,7 +41,7 @@ const Type *Type::getInt16(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeInt, {16, 1});
   return getUniqueType(context, t);
 }
-const Type *Type::getUnsignedInt16(SPIRVContext &context) {
+const Type *Type::getUint16(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeInt, {16, 0});
   return getUniqueType(context, t);
 }
@@ -49,7 +49,7 @@ const Type *Type::getInt32(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeInt, {32, 1});
   return getUniqueType(context, t);
 }
-const Type *Type::getUnsignedInt32(SPIRVContext &context) {
+const Type *Type::getUint32(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeInt, {32, 0});
   return getUniqueType(context, t);
 }
@@ -57,7 +57,7 @@ const Type *Type::getInt64(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeInt, {64, 1});
   return getUniqueType(context, t);
 }
-const Type *Type::getUnsignedInt64(SPIRVContext &context) {
+const Type *Type::getUint64(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeInt, {64, 0});
   return getUniqueType(context, t);
 }

--- a/tools/clang/lib/SPIRV/Type.cpp
+++ b/tools/clang/lib/SPIRV/Type.cpp
@@ -10,8 +10,6 @@
 #include "clang/SPIRV/Type.h"
 #include "clang/SPIRV/SPIRVContext.h"
 #include "clang/SPIRV/Utils.h"
-#include "clang/SPIRV/spirv.hpp"
-#include "llvm/llvm_assert/assert.h"
 
 namespace clang {
 namespace spirv {
@@ -21,121 +19,119 @@ Type::Type(spv::Op op, std::vector<uint32_t> arg,
     : opcode(op), args(arg), decorations(decs) {}
 
 const Type *Type::getUniqueType(SPIRVContext &context, Type &t) {
-  // Insert function will only insert if it doesn't already exist in the set.
-  context.ExistingTypes.insert(t);
-  return &(*context.ExistingTypes.find(t));
+  return context.registerType(t);
 }
-const Type *Type::getTypeVoid(SPIRVContext &context) {
+const Type *Type::getVoid(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeVoid);
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeBool(SPIRVContext &context) {
+const Type *Type::getBool(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeBool);
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeInt8(SPIRVContext &context) {
+const Type *Type::getInt8(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeInt, {8, 1});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeUnsignedInt8(SPIRVContext &context) {
+const Type *Type::getUnsignedInt8(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeInt, {8, 0});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeInt16(SPIRVContext &context) {
+const Type *Type::getInt16(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeInt, {16, 1});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeUnsignedInt16(SPIRVContext &context) {
+const Type *Type::getUnsignedInt16(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeInt, {16, 0});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeInt32(SPIRVContext &context) {
+const Type *Type::getInt32(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeInt, {32, 1});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeUnsignedInt32(SPIRVContext &context) {
+const Type *Type::getUnsignedInt32(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeInt, {32, 0});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeInt64(SPIRVContext &context) {
+const Type *Type::getInt64(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeInt, {64, 1});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeUnsignedInt64(SPIRVContext &context) {
+const Type *Type::getUnsignedInt64(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeInt, {64, 0});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeFloat16(SPIRVContext &context) {
+const Type *Type::getFloat16(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeFloat, {16});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeFloat32(SPIRVContext &context) {
+const Type *Type::getFloat32(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeFloat, {32});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeFloat64(SPIRVContext &context) {
+const Type *Type::getFloat64(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeFloat, {64});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeVector(SPIRVContext &context, uint32_t component_type,
-                                uint32_t vec_size) {
+const Type *Type::getVector(SPIRVContext &context, uint32_t component_type,
+                            uint32_t vec_size) {
   Type t = Type(spv::Op::OpTypeVector, {component_type, vec_size});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeVec2(SPIRVContext &context, uint32_t component_type) {
-  return getTypeVector(context, component_type, 2u);
+const Type *Type::getVec2(SPIRVContext &context, uint32_t component_type) {
+  return getVector(context, component_type, 2u);
 }
-const Type *Type::getTypeVec3(SPIRVContext &context, uint32_t component_type) {
-  return getTypeVector(context, component_type, 3u);
+const Type *Type::getVec3(SPIRVContext &context, uint32_t component_type) {
+  return getVector(context, component_type, 3u);
 }
-const Type *Type::getTypeVec4(SPIRVContext &context, uint32_t component_type) {
-  return getTypeVector(context, component_type, 4u);
+const Type *Type::getVec4(SPIRVContext &context, uint32_t component_type) {
+  return getVector(context, component_type, 4u);
 }
-const Type *Type::getTypeMatrix(SPIRVContext &context, uint32_t column_type_id,
-                                uint32_t column_count) {
+const Type *Type::getMatrix(SPIRVContext &context, uint32_t column_type_id,
+                            uint32_t column_count) {
   Type t = Type(spv::Op::OpTypeMatrix, {column_type_id, column_count});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeImage(SPIRVContext &context, uint32_t sampled_type,
-                               spv::Dim dim, uint32_t depth, uint32_t arrayed,
-                               uint32_t ms, uint32_t sampled,
-                               spv::ImageFormat image_format,
-                               Option<spv::AccessQualifier> access_qualifier) {
+const Type *
+Type::getImage(SPIRVContext &context, uint32_t sampled_type, spv::Dim dim,
+               uint32_t depth, uint32_t arrayed, uint32_t ms, uint32_t sampled,
+               spv::ImageFormat image_format,
+               llvm::Optional<spv::AccessQualifier> access_qualifier) {
   std::vector<uint32_t> args = {
       sampled_type, uint32_t(dim),         depth, arrayed, ms,
       sampled,      uint32_t(image_format)};
-  if (access_qualifier.isSome()) {
-    args.push_back(static_cast<uint32_t>(access_qualifier.unwrap()));
+  if (access_qualifier.hasValue()) {
+    args.push_back(static_cast<uint32_t>(access_qualifier.getValue()));
   }
   Type t = Type(spv::Op::OpTypeImage, args);
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeSampler(SPIRVContext &context) {
+const Type *Type::getSampler(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeSampler);
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeSampledImage(SPIRVContext &context,
-                                      uint32_t image_type_id) {
+const Type *Type::getSampledImage(SPIRVContext &context,
+                                  uint32_t image_type_id) {
   Type t = Type(spv::Op::OpTypeSampledImage, {image_type_id});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeArray(SPIRVContext &context,
-                               uint32_t component_type_id, uint32_t len_id) {
+const Type *Type::getArray(SPIRVContext &context, uint32_t component_type_id,
+                           uint32_t len_id) {
   Type t = Type(spv::Op::OpTypeArray, {component_type_id, len_id});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeRuntimeArray(SPIRVContext &context,
-                                      uint32_t component_type_id) {
+const Type *Type::getRuntimeArray(SPIRVContext &context,
+                                  uint32_t component_type_id) {
   Type t = Type(spv::Op::OpTypeRuntimeArray, {component_type_id});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeStruct(SPIRVContext &context,
-                                std::initializer_list<uint32_t> members) {
+const Type *Type::getStruct(SPIRVContext &context,
+                            std::initializer_list<uint32_t> members) {
   Type t = Type(spv::Op::OpTypeStruct, std::vector<uint32_t>(members));
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeOpaque(SPIRVContext &context, std::string name) {
-  Type t = Type(spv::Op::OpTypeOpaque, utils::reinterpretStringAsUintVec(name));
+const Type *Type::getOpaque(SPIRVContext &context, std::string name) {
+  Type t = Type(spv::Op::OpTypeOpaque, utils::encodeSPIRVString(name));
   return getUniqueType(context, t);
 }
 const Type *Type::getTyePointer(SPIRVContext &context,
@@ -145,42 +141,42 @@ const Type *Type::getTyePointer(SPIRVContext &context,
                 {static_cast<uint32_t>(storage_class), type});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeFunction(SPIRVContext &context, uint32_t return_type,
-                                  std::initializer_list<uint32_t> params) {
+const Type *Type::getFunction(SPIRVContext &context, uint32_t return_type,
+                              std::initializer_list<uint32_t> params) {
   std::vector<uint32_t> args = {return_type};
   args.insert(args.end(), params.begin(), params.end());
   Type t = Type(spv::Op::OpTypeFunction, args);
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeEvent(SPIRVContext &context) {
+const Type *Type::getEvent(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeEvent);
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeDeviceEvent(SPIRVContext &context) {
+const Type *Type::getDeviceEvent(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeDeviceEvent);
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeQueue(SPIRVContext &context) {
+const Type *Type::getQueue(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeQueue);
   return getUniqueType(context, t);
 }
-const Type *Type::getTypePipe(SPIRVContext &context,
-                              spv::AccessQualifier qualifier) {
+const Type *Type::getPipe(SPIRVContext &context,
+                          spv::AccessQualifier qualifier) {
   Type t = Type(spv::Op::OpTypePipe, {static_cast<uint32_t>(qualifier)});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeForwardPointer(SPIRVContext &context,
-                                        uint32_t pointer_type,
-                                        spv::StorageClass storage_class) {
+const Type *Type::getForwardPointer(SPIRVContext &context,
+                                    uint32_t pointer_type,
+                                    spv::StorageClass storage_class) {
   Type t = Type(spv::Op::OpTypeForwardPointer,
                 {pointer_type, static_cast<uint32_t>(storage_class)});
   return getUniqueType(context, t);
 }
-const Type *Type::getTypePipeStorage(SPIRVContext &context) {
+const Type *Type::getPipeStorage(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypePipeStorage);
   return getUniqueType(context, t);
 }
-const Type *Type::getTypeNamedBarrier(SPIRVContext &context) {
+const Type *Type::getNamedBarrier(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeNamedBarrier);
   return getUniqueType(context, t);
 }
@@ -190,42 +186,22 @@ const Type *Type::getType(SPIRVContext &context, spv::Op op,
   Type t = Type(op, arg, dec);
   return getUniqueType(context, t);
 }
-bool Type::isBooleanType(const Type *t) {
-  return t->getOpcode() == spv::Op::OpTypeBool;
+bool Type::isBooleanType() const { return opcode == spv::Op::OpTypeBool; }
+bool Type::isIntegerType() const { return opcode == spv::Op::OpTypeInt; }
+bool Type::isFloatType() const { return opcode == spv::Op::OpTypeFloat; }
+bool Type::isNumericalType() const { return isFloatType() || isIntegerType(); }
+bool Type::isScalarType() const { return isBooleanType() || isNumericalType(); }
+bool Type::isVectorType() const { return opcode == spv::Op::OpTypeVector; }
+bool Type::isMatrixType() const { return opcode == spv::Op::OpTypeMatrix; }
+bool Type::isArrayType() const { return opcode == spv::Op::OpTypeArray; }
+bool Type::isStructureType() const { return opcode == spv::Op::OpTypeStruct; }
+bool Type::isAggregateType() const {
+  return isStructureType() || isArrayType();
 }
-bool Type::isIntegerType(const Type *t) {
-  return t->getOpcode() == spv::Op::OpTypeInt;
+bool Type::isCompositeType() const {
+  return isAggregateType() || isMatrixType() || isVectorType();
 }
-bool Type::isFloatType(const Type *t) {
-  return t->getOpcode() == spv::Op::OpTypeFloat;
-}
-bool Type::isNumericalType(const Type *t) {
-  return isFloatType(t) || isIntegerType(t);
-}
-bool Type::isScalarType(const Type *t) {
-  return isBooleanType(t) || isNumericalType(t);
-}
-bool Type::isVectorType(const Type *t) {
-  return t->getOpcode() == spv::Op::OpTypeVector;
-}
-bool Type::isMatrixType(const Type *t) {
-  return t->getOpcode() == spv::Op::OpTypeMatrix;
-}
-bool Type::isArrayType(const Type *t) {
-  return t->getOpcode() == spv::Op::OpTypeArray;
-}
-bool Type::isStructureType(const Type *t) {
-  return t->getOpcode() == spv::Op::OpTypeStruct;
-}
-bool Type::isAggregateType(const Type *t) {
-  return isStructureType(t) || isArrayType(t);
-}
-bool Type::isCompositeType(const Type *t) {
-  return isAggregateType(t) || isMatrixType(t) || isVectorType(t);
-}
-bool Type::isImageType(const Type *t) {
-  return t->getOpcode() == spv::Op::OpTypeImage;
-}
+bool Type::isImageType() const { return opcode == spv::Op::OpTypeImage; }
 
 } // end namespace spirv
 } // end namespace clang

--- a/tools/clang/lib/SPIRV/Type.cpp
+++ b/tools/clang/lib/SPIRV/Type.cpp
@@ -1,0 +1,231 @@
+//===--- Type.cpp - SPIR-V Type implementation-----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/SPIRV/Type.h"
+#include "clang/SPIRV/SPIRVContext.h"
+#include "clang/SPIRV/Utils.h"
+#include "clang/SPIRV/spirv.hpp"
+#include "llvm/llvm_assert/assert.h"
+
+namespace clang {
+namespace spirv {
+
+Type::Type(spv::Op op, std::vector<uint32_t> arg,
+           std::set<const Decoration *> decs)
+    : opcode(op), args(arg), decorations(decs) {}
+
+const Type *Type::getUniqueType(SPIRVContext &context, Type &t) {
+  // Insert function will only insert if it doesn't already exist in the set.
+  context.ExistingTypes.insert(t);
+  return &(*context.ExistingTypes.find(t));
+}
+const Type *Type::getTypeVoid(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeVoid);
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeBool(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeBool);
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeInt8(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeInt, {8, 1});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeUnsignedInt8(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeInt, {8, 0});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeInt16(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeInt, {16, 1});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeUnsignedInt16(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeInt, {16, 0});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeInt32(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeInt, {32, 1});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeUnsignedInt32(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeInt, {32, 0});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeInt64(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeInt, {64, 1});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeUnsignedInt64(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeInt, {64, 0});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeFloat16(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeFloat, {16});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeFloat32(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeFloat, {32});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeFloat64(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeFloat, {64});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeVector(SPIRVContext &context, uint32_t component_type,
+                                uint32_t vec_size) {
+  Type t = Type(spv::Op::OpTypeVector, {component_type, vec_size});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeVec2(SPIRVContext &context, uint32_t component_type) {
+  return getTypeVector(context, component_type, 2u);
+}
+const Type *Type::getTypeVec3(SPIRVContext &context, uint32_t component_type) {
+  return getTypeVector(context, component_type, 3u);
+}
+const Type *Type::getTypeVec4(SPIRVContext &context, uint32_t component_type) {
+  return getTypeVector(context, component_type, 4u);
+}
+const Type *Type::getTypeMatrix(SPIRVContext &context, uint32_t column_type_id,
+                                uint32_t column_count) {
+  Type t = Type(spv::Op::OpTypeMatrix, {column_type_id, column_count});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeImage(SPIRVContext &context, uint32_t sampled_type,
+                               spv::Dim dim, uint32_t depth, uint32_t arrayed,
+                               uint32_t ms, uint32_t sampled,
+                               spv::ImageFormat image_format,
+                               Option<spv::AccessQualifier> access_qualifier) {
+  std::vector<uint32_t> args = {
+      sampled_type, uint32_t(dim),         depth, arrayed, ms,
+      sampled,      uint32_t(image_format)};
+  if (access_qualifier.isSome()) {
+    args.push_back(static_cast<uint32_t>(access_qualifier.unwrap()));
+  }
+  Type t = Type(spv::Op::OpTypeImage, args);
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeSampler(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeSampler);
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeSampledImage(SPIRVContext &context,
+                                      uint32_t image_type_id) {
+  Type t = Type(spv::Op::OpTypeSampledImage, {image_type_id});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeArray(SPIRVContext &context,
+                               uint32_t component_type_id, uint32_t len_id) {
+  Type t = Type(spv::Op::OpTypeArray, {component_type_id, len_id});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeRuntimeArray(SPIRVContext &context,
+                                      uint32_t component_type_id) {
+  Type t = Type(spv::Op::OpTypeRuntimeArray, {component_type_id});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeStruct(SPIRVContext &context,
+                                std::initializer_list<uint32_t> members) {
+  Type t = Type(spv::Op::OpTypeStruct, std::vector<uint32_t>(members));
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeOpaque(SPIRVContext &context, std::string name) {
+  Type t = Type(spv::Op::OpTypeOpaque, utils::reinterpretStringAsUintVec(name));
+  return getUniqueType(context, t);
+}
+const Type *Type::getTyePointer(SPIRVContext &context,
+                                spv::StorageClass storage_class,
+                                uint32_t type) {
+  Type t = Type(spv::Op::OpTypePointer,
+                {static_cast<uint32_t>(storage_class), type});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeFunction(SPIRVContext &context, uint32_t return_type,
+                                  std::initializer_list<uint32_t> params) {
+  std::vector<uint32_t> args = {return_type};
+  args.insert(args.end(), params.begin(), params.end());
+  Type t = Type(spv::Op::OpTypeFunction, args);
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeEvent(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeEvent);
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeDeviceEvent(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeDeviceEvent);
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeQueue(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeQueue);
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypePipe(SPIRVContext &context,
+                              spv::AccessQualifier qualifier) {
+  Type t = Type(spv::Op::OpTypePipe, {static_cast<uint32_t>(qualifier)});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeForwardPointer(SPIRVContext &context,
+                                        uint32_t pointer_type,
+                                        spv::StorageClass storage_class) {
+  Type t = Type(spv::Op::OpTypeForwardPointer,
+                {pointer_type, static_cast<uint32_t>(storage_class)});
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypePipeStorage(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypePipeStorage);
+  return getUniqueType(context, t);
+}
+const Type *Type::getTypeNamedBarrier(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeNamedBarrier);
+  return getUniqueType(context, t);
+}
+const Type *Type::getType(SPIRVContext &context, spv::Op op,
+                          std::vector<uint32_t> arg,
+                          std::set<const Decoration *> dec) {
+  Type t = Type(op, arg, dec);
+  return getUniqueType(context, t);
+}
+bool Type::isBooleanType(const Type *t) {
+  return t->getOpcode() == spv::Op::OpTypeBool;
+}
+bool Type::isIntegerType(const Type *t) {
+  return t->getOpcode() == spv::Op::OpTypeInt;
+}
+bool Type::isFloatType(const Type *t) {
+  return t->getOpcode() == spv::Op::OpTypeFloat;
+}
+bool Type::isNumericalType(const Type *t) {
+  return isFloatType(t) || isIntegerType(t);
+}
+bool Type::isScalarType(const Type *t) {
+  return isBooleanType(t) || isNumericalType(t);
+}
+bool Type::isVectorType(const Type *t) {
+  return t->getOpcode() == spv::Op::OpTypeVector;
+}
+bool Type::isMatrixType(const Type *t) {
+  return t->getOpcode() == spv::Op::OpTypeMatrix;
+}
+bool Type::isArrayType(const Type *t) {
+  return t->getOpcode() == spv::Op::OpTypeArray;
+}
+bool Type::isStructureType(const Type *t) {
+  return t->getOpcode() == spv::Op::OpTypeStruct;
+}
+bool Type::isAggregateType(const Type *t) {
+  return isStructureType(t) || isArrayType(t);
+}
+bool Type::isCompositeType(const Type *t) {
+  return isAggregateType(t) || isMatrixType(t) || isVectorType(t);
+}
+bool Type::isImageType(const Type *t) {
+  return t->getOpcode() == spv::Op::OpTypeImage;
+}
+
+} // end namespace spirv
+} // end namespace clang

--- a/tools/clang/lib/SPIRV/Utils.cpp
+++ b/tools/clang/lib/SPIRV/Utils.cpp
@@ -1,0 +1,53 @@
+//===-- Utils.cpp - SPIR-V Utils --------------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/SPIRV/Utils.h"
+#include "llvm/llvm_assert/assert.h"
+
+namespace clang {
+namespace spirv {
+namespace utils {
+
+/// \brief Reinterprets a given string as sequence of words.
+/// Assumes Little Endian architecture.
+std::vector<uint32_t> reinterpretStringAsUintVec(std::string s) {
+  std::vector<uint32_t> results;
+  if (!s.empty()) {
+    unsigned int num_bytes_needed = s.size() + 1;
+    unsigned int num_words_needed = (num_bytes_needed / 4) + 1;
+    std::string full_str(4 * num_words_needed, '\0');
+    full_str.insert(full_str.begin(), s.begin(), s.end());
+    for (unsigned int word_index = 0; word_index < num_words_needed;
+         ++word_index) {
+      int i = 4 * word_index;
+      uint32_t word = 0;
+      word |= full_str[i + 3] << 24;
+      word |= full_str[i + 2] << 16;
+      word |= full_str[i + 1] << 8;
+      word |= full_str[i];
+      results.push_back(word);
+    }
+  }
+  return results;
+}
+
+/// \brief Reinterprets the given vector of 32-bit words as a string.
+/// Expectes that the words represent a NULL-terminated string.
+/// Assumes Little Endian architecture.
+std::string reinterpretUintVecAsString(std::vector<uint32_t>& vec) {
+  std::string result;
+  if (!vec.empty()) {
+    result = std::string(reinterpret_cast<const char*>(&vec[0]));
+  }
+  return result;
+}
+
+} // end namespace utils
+} // end namespace spirv
+} // end namespace clang

--- a/tools/clang/unittests/SPIRV/CMakeLists.txt
+++ b/tools/clang/unittests/SPIRV/CMakeLists.txt
@@ -6,7 +6,11 @@ set(LLVM_LINK_COMPONENTS
 
 add_clang_unittest(clang-spirv-tests
   InstBuilderTest.cpp
+  DecorationTest.cpp
+  SPIRVContextTest.cpp
   ModuleBuilderTest.cpp
+  TypeTest.cpp
+  UtilsTest.cpp
   )
 
 target_link_libraries(clang-spirv-tests

--- a/tools/clang/unittests/SPIRV/DecorationTest.cpp
+++ b/tools/clang/unittests/SPIRV/DecorationTest.cpp
@@ -1,0 +1,54 @@
+//===- unittests/SPIRV/DecorationTest.cpp ----- Decoration tests ----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "gmock/gmock.h"
+#include "clang/SPIRV/Decoration.h"
+#include "clang/SPIRV/SPIRVContext.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+TEST(ValidateType, ValidateSimpleDecorationUniqueness) {
+  using namespace clang::spirv;
+  SPIRVContext ctx;
+  const Decoration *relaxed = Decoration::getDecorationRelaxedPrecision(ctx);
+  const Decoration *relaxed_2 = Decoration::getDecorationRelaxedPrecision(ctx);
+  EXPECT_EQ(relaxed, relaxed_2);
+}
+
+TEST(ValidateType, ValidateComplexDecorationUniqueness) {
+  using namespace clang::spirv;
+  SPIRVContext ctx;
+  const Decoration *mem_0_builtin_pos =
+      Decoration::getDecorationBuiltIn(ctx, spv::BuiltIn::Position, 0);
+  const Decoration *mem_0_builtin_pos_again =
+      Decoration::getDecorationBuiltIn(ctx, spv::BuiltIn::Position, 0);
+
+  // We must get the same pointer for the same decoration signature.
+  EXPECT_EQ(mem_0_builtin_pos, mem_0_builtin_pos_again);
+}
+
+TEST(ValidateType, ValidateMemberDecorationsDiffer) {
+  using namespace clang::spirv;
+  SPIRVContext ctx;
+  // Applied to member 0 of a structure.
+  const Decoration *mem_0_builtin_pos =
+      Decoration::getDecorationBuiltIn(ctx, spv::BuiltIn::Position, 0);
+  // Applied to member 1 of a structure.
+  const Decoration *mem_1_builtin_pos =
+      Decoration::getDecorationBuiltIn(ctx, spv::BuiltIn::Position, 1);
+
+  // We should get different pointers for these decorations as they are
+  // applied to different structure members.
+  EXPECT_NE(mem_0_builtin_pos, mem_1_builtin_pos);
+}
+
+// TODO: Add decorations tests for all decorations
+
+} // anonymous namespace

--- a/tools/clang/unittests/SPIRV/DecorationTest.cpp
+++ b/tools/clang/unittests/SPIRV/DecorationTest.cpp
@@ -12,37 +12,36 @@
 #include "clang/SPIRV/SPIRVContext.h"
 #include "gtest/gtest.h"
 
+using namespace clang::spirv;
+
 namespace {
 
-TEST(ValidateType, ValidateSimpleDecorationUniqueness) {
-  using namespace clang::spirv;
+TEST(Decoration, SameDecorationWoParameterShouldHaveSameAddress) {
   SPIRVContext ctx;
-  const Decoration *relaxed = Decoration::getDecorationRelaxedPrecision(ctx);
-  const Decoration *relaxed_2 = Decoration::getDecorationRelaxedPrecision(ctx);
+  const Decoration *relaxed = Decoration::getRelaxedPrecision(ctx);
+  const Decoration *relaxed_2 = Decoration::getRelaxedPrecision(ctx);
   EXPECT_EQ(relaxed, relaxed_2);
 }
 
-TEST(ValidateType, ValidateComplexDecorationUniqueness) {
-  using namespace clang::spirv;
+TEST(Decoration, SameMemberDecorationWoParameterShouldHaveSameAddress) {
   SPIRVContext ctx;
   const Decoration *mem_0_builtin_pos =
-      Decoration::getDecorationBuiltIn(ctx, spv::BuiltIn::Position, 0);
+      Decoration::getBuiltIn(ctx, spv::BuiltIn::Position, 0);
   const Decoration *mem_0_builtin_pos_again =
-      Decoration::getDecorationBuiltIn(ctx, spv::BuiltIn::Position, 0);
+      Decoration::getBuiltIn(ctx, spv::BuiltIn::Position, 0);
 
   // We must get the same pointer for the same decoration signature.
   EXPECT_EQ(mem_0_builtin_pos, mem_0_builtin_pos_again);
 }
 
-TEST(ValidateType, ValidateMemberDecorationsDiffer) {
-  using namespace clang::spirv;
+TEST(Decoration, DifferentMemberIndexDecorationShouldHaveDifferentAddress) {
   SPIRVContext ctx;
   // Applied to member 0 of a structure.
   const Decoration *mem_0_builtin_pos =
-      Decoration::getDecorationBuiltIn(ctx, spv::BuiltIn::Position, 0);
+      Decoration::getBuiltIn(ctx, spv::BuiltIn::Position, 0);
   // Applied to member 1 of a structure.
   const Decoration *mem_1_builtin_pos =
-      Decoration::getDecorationBuiltIn(ctx, spv::BuiltIn::Position, 1);
+      Decoration::getBuiltIn(ctx, spv::BuiltIn::Position, 1);
 
   // We should get different pointers for these decorations as they are
   // applied to different structure members.

--- a/tools/clang/unittests/SPIRV/SPIRVContextTest.cpp
+++ b/tools/clang/unittests/SPIRV/SPIRVContextTest.cpp
@@ -13,54 +13,52 @@
 #include "clang/SPIRV/Type.h"
 #include "gtest/gtest.h"
 
+using namespace clang::spirv;
+
 namespace {
 
 TEST(ValidateSPIRVContext, ValidateGetNextId) {
-  clang::spirv::SPIRVContext context;
+  SPIRVContext context;
   // Check that the first ID is 1.
-  EXPECT_EQ(context.GetNextId(), 1u);
-  // Check that calling GetNextId() multiple times does not increment the ID
-  EXPECT_EQ(context.GetNextId(), 1u);
+  EXPECT_EQ(context.getNextId(), 1u);
+  // Check that calling getNextId() multiple times does not increment the ID
+  EXPECT_EQ(context.getNextId(), 1u);
 }
 
 TEST(ValidateSPIRVContext, ValidateTakeNextId) {
-  clang::spirv::SPIRVContext context;
-  EXPECT_EQ(context.TakeNextId(), 1u);
-  EXPECT_EQ(context.TakeNextId(), 2u);
-  EXPECT_EQ(context.GetNextId(), 3u);
+  SPIRVContext context;
+  EXPECT_EQ(context.takeNextId(), 1u);
+  EXPECT_EQ(context.takeNextId(), 2u);
+  EXPECT_EQ(context.getNextId(), 3u);
 }
 
 TEST(ValidateSPIRVContext, ValidateUniqueIdForUniqueNonAggregateType) {
-  using namespace clang::spirv;
-  clang::spirv::SPIRVContext ctx;
-  auto NextIdFunc = [&ctx]() { return ctx.TakeNextId(); };
-  const Type *intt = Type::getTypeInt32(ctx);
-  uint32_t intt_id = ctx.GetResultIdForType(intt, NextIdFunc);
-  uint32_t intt_id_again = ctx.GetResultIdForType(intt, NextIdFunc);
+  SPIRVContext ctx;
+  const Type *intt = Type::getInt32(ctx);
+  uint32_t intt_id = ctx.getResultIdForType(intt);
+  uint32_t intt_id_again = ctx.getResultIdForType(intt);
   // We should get the same ID for the same non-aggregate type.
   EXPECT_EQ(intt_id, intt_id_again);
 }
 
 TEST(ValidateSPIRVContext, ValidateUniqueIdForUniqueAggregateType) {
-  using namespace clang::spirv;
-  clang::spirv::SPIRVContext ctx;
-  auto NextIdFunc = [&ctx]() { return ctx.TakeNextId(); };
+  SPIRVContext ctx;
   // In this test we construct a struct which includes an integer member and
   // a boolean member.
   // We also assign RelaxedPrecision decoration to the struct as a whole.
   // We also assign BufferBlock decoration to the struct as a whole.
   // We also assign Offset decoration to each member of the struct.
   // We also assign a BuiltIn decoration to the first member of the struct.
-  const Type *intt = Type::getTypeInt32(ctx);
-  const Type *boolt = Type::getTypeBool(ctx);
-  const uint32_t intt_id = ctx.GetResultIdForType(intt, NextIdFunc);
-  const uint32_t boolt_id = ctx.GetResultIdForType(boolt, NextIdFunc);
-  const Decoration *relaxed = Decoration::getDecorationRelaxedPrecision(ctx);
-  const Decoration *bufferblock = Decoration::getDecorationBufferBlock(ctx);
-  const Decoration *mem_0_offset = Decoration::getDecorationOffset(ctx, 0u, 0);
-  const Decoration *mem_1_offset = Decoration::getDecorationOffset(ctx, 0u, 1);
-  const Decoration *mem_0_position =
-      Decoration::getDecorationBuiltIn(ctx, spv::BuiltIn::Position, 0);
+  const Type *intt = Type::getInt32(ctx);
+  const Type *boolt = Type::getBool(ctx);
+  const uint32_t intt_id = ctx.getResultIdForType(intt);
+  const uint32_t boolt_id = ctx.getResultIdForType(boolt);
+  const auto relaxed = Decoration::getRelaxedPrecision(ctx);
+  const auto bufferblock = Decoration::getBufferBlock(ctx);
+  const auto mem_0_offset = Decoration::getOffset(ctx, 0u, 0);
+  const auto mem_1_offset = Decoration::getOffset(ctx, 0u, 1);
+  const auto mem_0_position =
+      Decoration::getBuiltIn(ctx, spv::BuiltIn::Position, 0);
 
   const Type *struct_1 = Type::getType(
       ctx, spv::Op::OpTypeStruct, {intt_id, boolt_id},
@@ -70,8 +68,8 @@ TEST(ValidateSPIRVContext, ValidateUniqueIdForUniqueAggregateType) {
       ctx, spv::Op::OpTypeStruct, {intt_id, boolt_id},
       {relaxed, bufferblock, mem_0_offset, mem_1_offset, mem_0_position});
 
-  const uint32_t struct_1_id = ctx.GetResultIdForType(struct_1, NextIdFunc);
-  const uint32_t struct_2_id = ctx.GetResultIdForType(struct_2, NextIdFunc);
+  const uint32_t struct_1_id = ctx.getResultIdForType(struct_1);
+  const uint32_t struct_2_id = ctx.getResultIdForType(struct_2);
 
   // We should be able to retrieve the same ID for the same Type.
   EXPECT_EQ(struct_1_id, struct_2_id);

--- a/tools/clang/unittests/SPIRV/SPIRVContextTest.cpp
+++ b/tools/clang/unittests/SPIRV/SPIRVContextTest.cpp
@@ -1,0 +1,82 @@
+//===- unittests/SPIRV/SPIRVContextTest.cpp ----- SPIRVContext tests ------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "gmock/gmock.h"
+#include "clang/SPIRV/Decoration.h"
+#include "clang/SPIRV/SPIRVContext.h"
+#include "clang/SPIRV/Type.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+TEST(ValidateSPIRVContext, ValidateGetNextId) {
+  clang::spirv::SPIRVContext context;
+  // Check that the first ID is 1.
+  EXPECT_EQ(context.GetNextId(), 1u);
+  // Check that calling GetNextId() multiple times does not increment the ID
+  EXPECT_EQ(context.GetNextId(), 1u);
+}
+
+TEST(ValidateSPIRVContext, ValidateTakeNextId) {
+  clang::spirv::SPIRVContext context;
+  EXPECT_EQ(context.TakeNextId(), 1u);
+  EXPECT_EQ(context.TakeNextId(), 2u);
+  EXPECT_EQ(context.GetNextId(), 3u);
+}
+
+TEST(ValidateSPIRVContext, ValidateUniqueIdForUniqueNonAggregateType) {
+  using namespace clang::spirv;
+  clang::spirv::SPIRVContext ctx;
+  auto NextIdFunc = [&ctx]() { return ctx.TakeNextId(); };
+  const Type *intt = Type::getTypeInt32(ctx);
+  uint32_t intt_id = ctx.GetResultIdForType(intt, NextIdFunc);
+  uint32_t intt_id_again = ctx.GetResultIdForType(intt, NextIdFunc);
+  // We should get the same ID for the same non-aggregate type.
+  EXPECT_EQ(intt_id, intt_id_again);
+}
+
+TEST(ValidateSPIRVContext, ValidateUniqueIdForUniqueAggregateType) {
+  using namespace clang::spirv;
+  clang::spirv::SPIRVContext ctx;
+  auto NextIdFunc = [&ctx]() { return ctx.TakeNextId(); };
+  // In this test we construct a struct which includes an integer member and
+  // a boolean member.
+  // We also assign RelaxedPrecision decoration to the struct as a whole.
+  // We also assign BufferBlock decoration to the struct as a whole.
+  // We also assign Offset decoration to each member of the struct.
+  // We also assign a BuiltIn decoration to the first member of the struct.
+  const Type *intt = Type::getTypeInt32(ctx);
+  const Type *boolt = Type::getTypeBool(ctx);
+  const uint32_t intt_id = ctx.GetResultIdForType(intt, NextIdFunc);
+  const uint32_t boolt_id = ctx.GetResultIdForType(boolt, NextIdFunc);
+  const Decoration *relaxed = Decoration::getDecorationRelaxedPrecision(ctx);
+  const Decoration *bufferblock = Decoration::getDecorationBufferBlock(ctx);
+  const Decoration *mem_0_offset = Decoration::getDecorationOffset(ctx, 0u, 0);
+  const Decoration *mem_1_offset = Decoration::getDecorationOffset(ctx, 0u, 1);
+  const Decoration *mem_0_position =
+      Decoration::getDecorationBuiltIn(ctx, spv::BuiltIn::Position, 0);
+
+  const Type *struct_1 = Type::getType(
+      ctx, spv::Op::OpTypeStruct, {intt_id, boolt_id},
+      {relaxed, bufferblock, mem_0_offset, mem_1_offset, mem_0_position});
+
+  const Type *struct_2 = Type::getType(
+      ctx, spv::Op::OpTypeStruct, {intt_id, boolt_id},
+      {relaxed, bufferblock, mem_0_offset, mem_1_offset, mem_0_position});
+
+  const uint32_t struct_1_id = ctx.GetResultIdForType(struct_1, NextIdFunc);
+  const uint32_t struct_2_id = ctx.GetResultIdForType(struct_2, NextIdFunc);
+
+  // We should be able to retrieve the same ID for the same Type.
+  EXPECT_EQ(struct_1_id, struct_2_id);
+}
+
+// TODO: Add more SPIRVContext tests
+
+} // anonymous namespace

--- a/tools/clang/unittests/SPIRV/TypeTest.cpp
+++ b/tools/clang/unittests/SPIRV/TypeTest.cpp
@@ -12,36 +12,35 @@
 #include "clang/SPIRV/Type.h"
 #include "gtest/gtest.h"
 
+using namespace clang::spirv;
+
 namespace {
 
-TEST(ValidateType, ValidateNonAggregateTypeUniqueness) {
-  using namespace clang::spirv;
+TEST(Type, SameTypeWoParameterShouldHaveSameAddress) {
   SPIRVContext context;
-  const Type *pIntFirst = Type::getTypeInt32(context);
-  const Type *pIntSecond = Type::getTypeInt32(context);
+  const Type *pIntFirst = Type::getInt32(context);
+  const Type *pIntSecond = Type::getInt32(context);
   EXPECT_EQ(pIntFirst, pIntSecond);
 }
 
-TEST(ValidateType, ValidateAggregateTypeUniqueness) {
-  using namespace clang::spirv;
+TEST(Type, SameAggregateTypeWithDecorationsShouldHaveSameAddress) {
   clang::spirv::SPIRVContext ctx;
-  auto NextIdFunc = [&ctx]() { return ctx.TakeNextId(); };
   // In this test we will build a struct which includes an integer member and
   // a boolean member.
   // We also assign RelaxedPrecision decoration to the struct as a whole.
   // We also assign BufferBlock decoration to the struct as a whole.
   // We also assign Offset decoration to each member of the struct.
   // We also assign a BuiltIn decoration to the first member of the struct.
-  const Type *intt = Type::getTypeInt32(ctx);
-  const Type *boolt = Type::getTypeBool(ctx);
-  const uint32_t intt_id = ctx.GetResultIdForType(intt, NextIdFunc);
-  const uint32_t boolt_id = ctx.GetResultIdForType(boolt, NextIdFunc);
-  const Decoration *relaxed = Decoration::getDecorationRelaxedPrecision(ctx);
-  const Decoration *bufferblock = Decoration::getDecorationBufferBlock(ctx);
-  const Decoration *mem_0_offset = Decoration::getDecorationOffset(ctx, 0u, 0);
-  const Decoration *mem_1_offset = Decoration::getDecorationOffset(ctx, 0u, 1);
+  const Type *intt = Type::getInt32(ctx);
+  const Type *boolt = Type::getBool(ctx);
+  const uint32_t intt_id = ctx.getResultIdForType(intt);
+  const uint32_t boolt_id = ctx.getResultIdForType(boolt);
+  const Decoration *relaxed = Decoration::getRelaxedPrecision(ctx);
+  const Decoration *bufferblock = Decoration::getBufferBlock(ctx);
+  const Decoration *mem_0_offset = Decoration::getOffset(ctx, 0u, 0);
+  const Decoration *mem_1_offset = Decoration::getOffset(ctx, 0u, 1);
   const Decoration *mem_0_position =
-      Decoration::getDecorationBuiltIn(ctx, spv::BuiltIn::Position, 0);
+      Decoration::getBuiltIn(ctx, spv::BuiltIn::Position, 0);
 
   const Type *struct_1 = Type::getType(
       ctx, spv::Op::OpTypeStruct, {intt_id, boolt_id},

--- a/tools/clang/unittests/SPIRV/TypeTest.cpp
+++ b/tools/clang/unittests/SPIRV/TypeTest.cpp
@@ -1,0 +1,67 @@
+//===- unittests/SPIRV/TypeTest.cpp ----- Type tests ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "gmock/gmock.h"
+#include "clang/SPIRV/SPIRVContext.h"
+#include "clang/SPIRV/Type.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+TEST(ValidateType, ValidateNonAggregateTypeUniqueness) {
+  using namespace clang::spirv;
+  SPIRVContext context;
+  const Type *pIntFirst = Type::getTypeInt32(context);
+  const Type *pIntSecond = Type::getTypeInt32(context);
+  EXPECT_EQ(pIntFirst, pIntSecond);
+}
+
+TEST(ValidateType, ValidateAggregateTypeUniqueness) {
+  using namespace clang::spirv;
+  clang::spirv::SPIRVContext ctx;
+  auto NextIdFunc = [&ctx]() { return ctx.TakeNextId(); };
+  // In this test we will build a struct which includes an integer member and
+  // a boolean member.
+  // We also assign RelaxedPrecision decoration to the struct as a whole.
+  // We also assign BufferBlock decoration to the struct as a whole.
+  // We also assign Offset decoration to each member of the struct.
+  // We also assign a BuiltIn decoration to the first member of the struct.
+  const Type *intt = Type::getTypeInt32(ctx);
+  const Type *boolt = Type::getTypeBool(ctx);
+  const uint32_t intt_id = ctx.GetResultIdForType(intt, NextIdFunc);
+  const uint32_t boolt_id = ctx.GetResultIdForType(boolt, NextIdFunc);
+  const Decoration *relaxed = Decoration::getDecorationRelaxedPrecision(ctx);
+  const Decoration *bufferblock = Decoration::getDecorationBufferBlock(ctx);
+  const Decoration *mem_0_offset = Decoration::getDecorationOffset(ctx, 0u, 0);
+  const Decoration *mem_1_offset = Decoration::getDecorationOffset(ctx, 0u, 1);
+  const Decoration *mem_0_position =
+      Decoration::getDecorationBuiltIn(ctx, spv::BuiltIn::Position, 0);
+
+  const Type *struct_1 = Type::getType(
+      ctx, spv::Op::OpTypeStruct, {intt_id, boolt_id},
+      {relaxed, bufferblock, mem_0_offset, mem_1_offset, mem_0_position});
+
+  const Type *struct_2 = Type::getType(
+      ctx, spv::Op::OpTypeStruct, {intt_id, boolt_id},
+      {relaxed, bufferblock, mem_0_offset, mem_1_offset, mem_0_position});
+
+  const Type *struct_3 = Type::getType(
+      ctx, spv::Op::OpTypeStruct, {intt_id, boolt_id},
+      {bufferblock, mem_0_offset, mem_0_position, mem_1_offset, relaxed});
+
+  // 2 types with the same signature. We should get the same pointer.
+  EXPECT_EQ(struct_1, struct_2);
+
+  // The order of decorations does not matter.
+  EXPECT_EQ(struct_1, struct_3);
+}
+
+// TODO: Add Type tests for all types
+
+} // anonymous namespace

--- a/tools/clang/unittests/SPIRV/UtilsTest.cpp
+++ b/tools/clang/unittests/SPIRV/UtilsTest.cpp
@@ -1,0 +1,61 @@
+//===- unittests/SPIRV/UtilsTest.cpp ------ Utils tests -------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/SPIRV/Utils.h"
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+namespace {
+
+using ::testing::ElementsAre;
+
+TEST(ValidateUtils, ValidateStringToUintVecConversion) {
+  // Bin  01110100   01110011    01100101    01010100 = unsigned(1,953,719,636)
+  // Hex     74         73          65          54
+  //          t          s           e           T
+  // Bin  01101001   01110010    01110100    01010011 =  unsigned(1,769,108,563)
+  // Hex     69         72          74          53
+  //          i          r           t           S
+  // Bin  00000000   00000000    01100111    01101110 =  unsigned(26,478)
+  // Hex      0          0          67          6E
+  //          \0         \0          g           n
+  std::string str = "TestString";
+  std::vector<uint32_t> words =
+      clang::spirv::utils::reinterpretStringAsUintVec(str);
+  EXPECT_THAT(words, ElementsAre(1953719636, 1769108563, 26478));
+}
+TEST(ValidateUtils, ValidateUintVecToStringConversion) {
+  // Bin  01110100   01110011    01100101    01010100 = unsigned(1,953,719,636)
+  // Hex     74         73          65          54
+  //          t          s           e           T
+  // Bin  01101001   01110010    01110100    01010011 =  unsigned(1,769,108,563)
+  // Hex     69         72          74          53
+  //          i          r           t           S
+  // Bin  00000000   00000000    01100111    01101110 =  unsigned(26,478)
+  // Hex      0          0          67          6E
+  //          \0         \0          g           n
+  std::vector<uint32_t> words = { 1953719636, 1769108563, 26478 };
+  std::string str = clang::spirv::utils::reinterpretUintVecAsString(words);
+  EXPECT_EQ(str, "TestString");
+}
+TEST(ValidateUtils, ValidateTwoWayUintVecToStringConversion) {
+  std::string str = "TestString";
+  // Convert to vector
+  std::vector<uint32_t> words =
+      clang::spirv::utils::reinterpretStringAsUintVec(str);
+
+  // Convert back to string
+  std::string result = clang::spirv::utils::reinterpretUintVecAsString(words);
+
+  EXPECT_EQ(str, result);
+}
+
+// TODO: Add more ModuleBuilder tests
+
+} // anonymous namespace

--- a/tools/clang/unittests/SPIRV/UtilsTest.cpp
+++ b/tools/clang/unittests/SPIRV/UtilsTest.cpp
@@ -7,42 +7,38 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "gmock/gmock.h"
 #include "clang/SPIRV/Utils.h"
 #include "gtest/gtest.h"
-#include "gmock/gmock.h"
 
 namespace {
 
+using namespace clang::spirv;
 using ::testing::ElementsAre;
 
 TEST(Utils, EncodeEmptyString) {
   std::string str = "";
-  std::vector<uint32_t> words =
-      clang::spirv::utils::encodeSPIRVString(str);
+  std::vector<uint32_t> words = utils::encodeSPIRVString(str);
   EXPECT_THAT(words, ElementsAre(0u));
 }
 TEST(Utils, EncodeOneCharString) {
   std::string str = "m";
-  std::vector<uint32_t> words =
-      clang::spirv::utils::encodeSPIRVString(str);
+  std::vector<uint32_t> words = utils::encodeSPIRVString(str);
   EXPECT_THAT(words, ElementsAre(109u));
 }
 TEST(Utils, EncodeTwoCharString) {
   std::string str = "ma";
-  std::vector<uint32_t> words =
-      clang::spirv::utils::encodeSPIRVString(str);
+  std::vector<uint32_t> words = utils::encodeSPIRVString(str);
   EXPECT_THAT(words, ElementsAre(24941u));
 }
 TEST(Utils, EncodeThreeCharString) {
   std::string str = "mai";
-  std::vector<uint32_t> words =
-      clang::spirv::utils::encodeSPIRVString(str);
+  std::vector<uint32_t> words = utils::encodeSPIRVString(str);
   EXPECT_THAT(words, ElementsAre(6906221u));
 }
 TEST(Utils, EncodeFourCharString) {
   std::string str = "main";
-  std::vector<uint32_t> words =
-      clang::spirv::utils::encodeSPIRVString(str);
+  std::vector<uint32_t> words = utils::encodeSPIRVString(str);
   EXPECT_THAT(words, ElementsAre(1852399981u, 0u));
 }
 TEST(Utils, EncodeString) {
@@ -56,8 +52,7 @@ TEST(Utils, EncodeString) {
   // Hex      0          0          67          6E
   //          \0         \0          g           n
   std::string str = "TestString";
-  std::vector<uint32_t> words =
-      clang::spirv::utils::encodeSPIRVString(str);
+  std::vector<uint32_t> words = utils::encodeSPIRVString(str);
   EXPECT_THAT(words, ElementsAre(1953719636, 1769108563, 26478));
 }
 TEST(Utils, DecodeString) {
@@ -70,18 +65,17 @@ TEST(Utils, DecodeString) {
   // Bin  00000000   00000000    01100111    01101110 =  unsigned(26,478)
   // Hex      0          0          67          6E
   //          \0         \0          g           n
-  std::vector<uint32_t> words = { 1953719636, 1769108563, 26478 };
-  std::string str = clang::spirv::utils::decodeSPIRVString(words);
+  std::vector<uint32_t> words = {1953719636, 1769108563, 26478};
+  std::string str = utils::decodeSPIRVString(words);
   EXPECT_EQ(str, "TestString");
 }
 TEST(Utils, EncodeAndDecodeString) {
   std::string str = "TestString";
   // Convert to vector
-  std::vector<uint32_t> words =
-      clang::spirv::utils::encodeSPIRVString(str);
+  std::vector<uint32_t> words = utils::encodeSPIRVString(str);
 
   // Convert back to string
-  std::string result = clang::spirv::utils::decodeSPIRVString(words);
+  std::string result = utils::decodeSPIRVString(words);
 
   EXPECT_EQ(str, result);
 }

--- a/tools/clang/unittests/SPIRV/UtilsTest.cpp
+++ b/tools/clang/unittests/SPIRV/UtilsTest.cpp
@@ -15,7 +15,37 @@ namespace {
 
 using ::testing::ElementsAre;
 
-TEST(ValidateUtils, ValidateStringToUintVecConversion) {
+TEST(Utils, EncodeEmptyString) {
+  std::string str = "";
+  std::vector<uint32_t> words =
+      clang::spirv::utils::encodeSPIRVString(str);
+  EXPECT_THAT(words, ElementsAre(0u));
+}
+TEST(Utils, EncodeOneCharString) {
+  std::string str = "m";
+  std::vector<uint32_t> words =
+      clang::spirv::utils::encodeSPIRVString(str);
+  EXPECT_THAT(words, ElementsAre(109u));
+}
+TEST(Utils, EncodeTwoCharString) {
+  std::string str = "ma";
+  std::vector<uint32_t> words =
+      clang::spirv::utils::encodeSPIRVString(str);
+  EXPECT_THAT(words, ElementsAre(24941u));
+}
+TEST(Utils, EncodeThreeCharString) {
+  std::string str = "mai";
+  std::vector<uint32_t> words =
+      clang::spirv::utils::encodeSPIRVString(str);
+  EXPECT_THAT(words, ElementsAre(6906221u));
+}
+TEST(Utils, EncodeFourCharString) {
+  std::string str = "main";
+  std::vector<uint32_t> words =
+      clang::spirv::utils::encodeSPIRVString(str);
+  EXPECT_THAT(words, ElementsAre(1852399981u, 0u));
+}
+TEST(Utils, EncodeString) {
   // Bin  01110100   01110011    01100101    01010100 = unsigned(1,953,719,636)
   // Hex     74         73          65          54
   //          t          s           e           T
@@ -27,10 +57,10 @@ TEST(ValidateUtils, ValidateStringToUintVecConversion) {
   //          \0         \0          g           n
   std::string str = "TestString";
   std::vector<uint32_t> words =
-      clang::spirv::utils::reinterpretStringAsUintVec(str);
+      clang::spirv::utils::encodeSPIRVString(str);
   EXPECT_THAT(words, ElementsAre(1953719636, 1769108563, 26478));
 }
-TEST(ValidateUtils, ValidateUintVecToStringConversion) {
+TEST(Utils, DecodeString) {
   // Bin  01110100   01110011    01100101    01010100 = unsigned(1,953,719,636)
   // Hex     74         73          65          54
   //          t          s           e           T
@@ -41,17 +71,17 @@ TEST(ValidateUtils, ValidateUintVecToStringConversion) {
   // Hex      0          0          67          6E
   //          \0         \0          g           n
   std::vector<uint32_t> words = { 1953719636, 1769108563, 26478 };
-  std::string str = clang::spirv::utils::reinterpretUintVecAsString(words);
+  std::string str = clang::spirv::utils::decodeSPIRVString(words);
   EXPECT_EQ(str, "TestString");
 }
-TEST(ValidateUtils, ValidateTwoWayUintVecToStringConversion) {
+TEST(Utils, EncodeAndDecodeString) {
   std::string str = "TestString";
   // Convert to vector
   std::vector<uint32_t> words =
-      clang::spirv::utils::reinterpretStringAsUintVec(str);
+      clang::spirv::utils::encodeSPIRVString(str);
 
   // Convert back to string
-  std::string result = clang::spirv::utils::reinterpretUintVecAsString(words);
+  std::string result = clang::spirv::utils::decodeSPIRVString(words);
 
   EXPECT_EQ(str, result);
 }


### PR DESCRIPTION
* Added support for decorations and types.
* Introduced clang::spirv::utils
* Avoid static members in Type and Decoration based on design doc
comments. Types and Decorations are unique in the context in which
they are defined. Therefore, each context should track its own types, etc.
* getTypeXXX and getDecorationXXX functions should take a context
argument (similar to LLVM).
* Added a number of unit tests (TODO: more unit tests).