### PR TITLE
Adding Type Unit Tests.

### DIFF
--- a/tools/clang/include/clang/SPIRV/Type.h
+++ b/tools/clang/include/clang/SPIRV/Type.h
@@ -35,8 +35,14 @@ class SPIRVContext;
 /// context).
 class Type {
 public:
+  using DecorationSet = std::set<const Decoration *>;
+
   spv::Op getOpcode() const { return opcode; }
   const std::vector<uint32_t> &getArgs() const { return args; }
+  const std::set<const Decoration *> &getDecorations() const {
+    return decorations;
+  }
+  bool hasDecoration(const Decoration *) const;
 
   bool isBooleanType() const;
   bool isIntegerType() const;
@@ -51,56 +57,63 @@ public:
   bool isCompositeType() const;
   bool isImageType() const;
 
-  static const Type *getType(SPIRVContext &ctx, spv::Op op,
-                             std::vector<uint32_t> arg = {},
-                             std::set<const Decoration *> decs = {});
-
-  static const Type *getVoid(SPIRVContext &ctx);
-  static const Type *getBool(SPIRVContext &ctx);
-  static const Type *getInt8(SPIRVContext &ctx);
-  static const Type *getUint8(SPIRVContext &ctx);
-  static const Type *getInt16(SPIRVContext &ctx);
-  static const Type *getUint16(SPIRVContext &ctx);
-  static const Type *getInt32(SPIRVContext &ctx);
-  static const Type *getUint32(SPIRVContext &ctx);
-  static const Type *getInt64(SPIRVContext &ctx);
-  static const Type *getUint64(SPIRVContext &ctx);
-  static const Type *getFloat16(SPIRVContext &ctx);
-  static const Type *getFloat32(SPIRVContext &ctx);
-  static const Type *getFloat64(SPIRVContext &ctx);
+  static const Type *getVoid(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getBool(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getInt8(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getUint8(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getInt16(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getUint16(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getInt32(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getUint32(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getInt64(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getUint64(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getFloat16(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getFloat32(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getFloat64(SPIRVContext &ctx, DecorationSet decs = {});
   static const Type *getVector(SPIRVContext &ctx, uint32_t component_type,
-                               uint32_t vec_size);
-  static const Type *getVec2(SPIRVContext &ctx, uint32_t component_type);
-  static const Type *getVec3(SPIRVContext &ctx, uint32_t component_type);
-  static const Type *getVec4(SPIRVContext &ctx, uint32_t component_type);
+                               uint32_t vec_size, DecorationSet decs = {});
+  static const Type *getVec2(SPIRVContext &ctx, uint32_t component_type,
+                             DecorationSet decs = {});
+  static const Type *getVec3(SPIRVContext &ctx, uint32_t component_type,
+                             DecorationSet decs = {});
+  static const Type *getVec4(SPIRVContext &ctx, uint32_t component_type,
+                             DecorationSet decs = {});
   static const Type *getMatrix(SPIRVContext &ctx, uint32_t column_type_id,
-                               uint32_t column_count);
+                               uint32_t column_count, DecorationSet decs = {});
   static const Type *
   getImage(SPIRVContext &ctx, uint32_t sampled_type, spv::Dim dim,
            uint32_t depth, uint32_t arrayed, uint32_t ms, uint32_t sampled,
            spv::ImageFormat image_format,
-           llvm::Optional<spv::AccessQualifier> access_qualifier);
-  static const Type *getSampler(SPIRVContext &ctx);
-  static const Type *getSampledImage(SPIRVContext &ctx, uint32_t imag_type_id);
+           llvm::Optional<spv::AccessQualifier> access_qualifier = llvm::None,
+           DecorationSet decs = {});
+  static const Type *getSampler(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getSampledImage(SPIRVContext &ctx, uint32_t imag_type_id,
+                                     DecorationSet decs = {});
   static const Type *getArray(SPIRVContext &ctx, uint32_t component_type_id,
-                              uint32_t len_id);
+                              uint32_t len_id, DecorationSet decs = {});
   static const Type *getRuntimeArray(SPIRVContext &ctx,
-                                     uint32_t component_type_id);
+                                     uint32_t component_type_id,
+                                     DecorationSet decs = {});
   static const Type *getStruct(SPIRVContext &ctx,
-                               std::initializer_list<uint32_t> members);
-  static const Type *getOpaque(SPIRVContext &ctx, std::string name);
-  static const Type *getTyePointer(SPIRVContext &ctx,
-                                   spv::StorageClass storage_class,
-                                   uint32_t type);
+                               std::initializer_list<uint32_t> members,
+                               DecorationSet d = {});
+  static const Type *getOpaque(SPIRVContext &ctx, std::string name,
+                               DecorationSet decs = {});
+  static const Type *getPointer(SPIRVContext &ctx,
+                                spv::StorageClass storage_class, uint32_t type,
+                                DecorationSet decs = {});
   static const Type *getFunction(SPIRVContext &ctx, uint32_t return_type,
-                                 std::initializer_list<uint32_t> params);
-  static const Type *getEvent(SPIRVContext &ctx);
-  static const Type *getDeviceEvent(SPIRVContext &ctx);
-  static const Type *getQueue(SPIRVContext &ctx);
-  static const Type *getPipe(SPIRVContext &ctx, spv::AccessQualifier qualifier);
+                                 std::initializer_list<uint32_t> params,
+                                 DecorationSet decs = {});
+  static const Type *getEvent(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getDeviceEvent(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getReserveId(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getQueue(SPIRVContext &ctx, DecorationSet decs = {});
+  static const Type *getPipe(SPIRVContext &ctx, spv::AccessQualifier qualifier,
+                             DecorationSet decs = {});
   static const Type *getForwardPointer(SPIRVContext &ctx, uint32_t pointer_type,
-                                       spv::StorageClass storage_class);
-
+                                       spv::StorageClass storage_class,
+                                       DecorationSet decs = {});
   bool operator==(const Type &other) const {
     return opcode == other.opcode && args == other.args &&
            decorations == other.decorations;

--- a/tools/clang/include/clang/SPIRV/Type.h
+++ b/tools/clang/include/clang/SPIRV/Type.h
@@ -57,19 +57,21 @@ public:
   bool isCompositeType() const;
   bool isImageType() const;
 
-  static const Type *getVoid(SPIRVContext &ctx, DecorationSet decs = {});
-  static const Type *getBool(SPIRVContext &ctx, DecorationSet decs = {});
-  static const Type *getInt8(SPIRVContext &ctx, DecorationSet decs = {});
-  static const Type *getUint8(SPIRVContext &ctx, DecorationSet decs = {});
-  static const Type *getInt16(SPIRVContext &ctx, DecorationSet decs = {});
-  static const Type *getUint16(SPIRVContext &ctx, DecorationSet decs = {});
-  static const Type *getInt32(SPIRVContext &ctx, DecorationSet decs = {});
-  static const Type *getUint32(SPIRVContext &ctx, DecorationSet decs = {});
-  static const Type *getInt64(SPIRVContext &ctx, DecorationSet decs = {});
-  static const Type *getUint64(SPIRVContext &ctx, DecorationSet decs = {});
-  static const Type *getFloat16(SPIRVContext &ctx, DecorationSet decs = {});
-  static const Type *getFloat32(SPIRVContext &ctx, DecorationSet decs = {});
-  static const Type *getFloat64(SPIRVContext &ctx, DecorationSet decs = {});
+  // Scalar types do not take any decorations.
+  static const Type *getVoid(SPIRVContext &ctx);
+  static const Type *getBool(SPIRVContext &ctx);
+  static const Type *getInt8(SPIRVContext &ctx);
+  static const Type *getUint8(SPIRVContext &ctx);
+  static const Type *getInt16(SPIRVContext &ctx);
+  static const Type *getUint16(SPIRVContext &ctx);
+  static const Type *getInt32(SPIRVContext &ctx);
+  static const Type *getUint32(SPIRVContext &ctx);
+  static const Type *getInt64(SPIRVContext &ctx);
+  static const Type *getUint64(SPIRVContext &ctx);
+  static const Type *getFloat16(SPIRVContext &ctx);
+  static const Type *getFloat32(SPIRVContext &ctx);
+  static const Type *getFloat64(SPIRVContext &ctx);
+
   static const Type *getVector(SPIRVContext &ctx, uint32_t component_type,
                                uint32_t vec_size, DecorationSet decs = {});
   static const Type *getVec2(SPIRVContext &ctx, uint32_t component_type,

--- a/tools/clang/include/clang/SPIRV/Type.h
+++ b/tools/clang/include/clang/SPIRV/Type.h
@@ -71,17 +71,12 @@ public:
   static const Type *getFloat16(SPIRVContext &ctx);
   static const Type *getFloat32(SPIRVContext &ctx);
   static const Type *getFloat64(SPIRVContext &ctx);
-
-  static const Type *getVector(SPIRVContext &ctx, uint32_t component_type,
-                               uint32_t vec_size, DecorationSet decs = {});
-  static const Type *getVec2(SPIRVContext &ctx, uint32_t component_type,
-                             DecorationSet decs = {});
-  static const Type *getVec3(SPIRVContext &ctx, uint32_t component_type,
-                             DecorationSet decs = {});
-  static const Type *getVec4(SPIRVContext &ctx, uint32_t component_type,
-                             DecorationSet decs = {});
+  static const Type *getVec2(SPIRVContext &ctx, uint32_t component_type);
+  static const Type *getVec3(SPIRVContext &ctx, uint32_t component_type);
+  static const Type *getVec4(SPIRVContext &ctx, uint32_t component_type);
   static const Type *getMatrix(SPIRVContext &ctx, uint32_t column_type_id,
-                               uint32_t column_count, DecorationSet decs = {});
+                               uint32_t column_count);
+
   static const Type *
   getImage(SPIRVContext &ctx, uint32_t sampled_type, spv::Dim dim,
            uint32_t depth, uint32_t arrayed, uint32_t ms, uint32_t sampled,

--- a/tools/clang/include/clang/SPIRV/Utils.h
+++ b/tools/clang/include/clang/SPIRV/Utils.h
@@ -23,7 +23,7 @@ std::vector<uint32_t> encodeSPIRVString(std::string s);
 /// \brief Reinterprets the given vector of 32-bit words as a string.
 /// Expectes that the words represent a NULL-terminated string.
 /// It follows the SPIR-V string encoding requirements.
-std::string decodeSPIRVString(std::vector<uint32_t> &vec);
+std::string decodeSPIRVString(const std::vector<uint32_t> &vec);
 
 } // end namespace utils
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/Type.cpp
+++ b/tools/clang/lib/SPIRV/Type.cpp
@@ -21,56 +21,56 @@ Type::Type(spv::Op op, std::vector<uint32_t> arg,
 const Type *Type::getUniqueType(SPIRVContext &context, const Type &t) {
   return context.registerType(t);
 }
-const Type *Type::getVoid(SPIRVContext &context, DecorationSet d) {
-  Type t = Type(spv::Op::OpTypeVoid, {}, d);
+const Type *Type::getVoid(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeVoid, {});
   return getUniqueType(context, t);
 }
-const Type *Type::getBool(SPIRVContext &context, DecorationSet d) {
-  Type t = Type(spv::Op::OpTypeBool, {}, d);
+const Type *Type::getBool(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeBool, {});
   return getUniqueType(context, t);
 }
-const Type *Type::getInt8(SPIRVContext &context, DecorationSet d) {
-  Type t = Type(spv::Op::OpTypeInt, {8, 1}, d);
+const Type *Type::getInt8(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeInt, {8, 1});
   return getUniqueType(context, t);
 }
-const Type *Type::getUint8(SPIRVContext &context, DecorationSet d) {
-  Type t = Type(spv::Op::OpTypeInt, {8, 0}, d);
+const Type *Type::getUint8(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeInt, {8, 0});
   return getUniqueType(context, t);
 }
-const Type *Type::getInt16(SPIRVContext &context, DecorationSet d) {
-  Type t = Type(spv::Op::OpTypeInt, {16, 1}, d);
+const Type *Type::getInt16(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeInt, {16, 1});
   return getUniqueType(context, t);
 }
-const Type *Type::getUint16(SPIRVContext &context, DecorationSet d) {
-  Type t = Type(spv::Op::OpTypeInt, {16, 0}, d);
+const Type *Type::getUint16(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeInt, {16, 0});
   return getUniqueType(context, t);
 }
-const Type *Type::getInt32(SPIRVContext &context, DecorationSet d) {
-  Type t = Type(spv::Op::OpTypeInt, {32, 1}, d);
+const Type *Type::getInt32(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeInt, {32, 1});
   return getUniqueType(context, t);
 }
-const Type *Type::getUint32(SPIRVContext &context, DecorationSet d) {
-  Type t = Type(spv::Op::OpTypeInt, {32, 0}, d);
+const Type *Type::getUint32(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeInt, {32, 0});
   return getUniqueType(context, t);
 }
-const Type *Type::getInt64(SPIRVContext &context, DecorationSet d) {
-  Type t = Type(spv::Op::OpTypeInt, {64, 1}, d);
+const Type *Type::getInt64(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeInt, {64, 1});
   return getUniqueType(context, t);
 }
-const Type *Type::getUint64(SPIRVContext &context, DecorationSet d) {
-  Type t = Type(spv::Op::OpTypeInt, {64, 0}, d);
+const Type *Type::getUint64(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeInt, {64, 0});
   return getUniqueType(context, t);
 }
-const Type *Type::getFloat16(SPIRVContext &context, DecorationSet d) {
-  Type t = Type(spv::Op::OpTypeFloat, {16}, d);
+const Type *Type::getFloat16(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeFloat, {16});
   return getUniqueType(context, t);
 }
-const Type *Type::getFloat32(SPIRVContext &context, DecorationSet d) {
-  Type t = Type(spv::Op::OpTypeFloat, {32}, d);
+const Type *Type::getFloat32(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeFloat, {32});
   return getUniqueType(context, t);
 }
-const Type *Type::getFloat64(SPIRVContext &context, DecorationSet d) {
-  Type t = Type(spv::Op::OpTypeFloat, {64}, d);
+const Type *Type::getFloat64(SPIRVContext &context) {
+  Type t = Type(spv::Op::OpTypeFloat, {64});
   return getUniqueType(context, t);
 }
 const Type *Type::getVector(SPIRVContext &context, uint32_t component_type,

--- a/tools/clang/lib/SPIRV/Type.cpp
+++ b/tools/clang/lib/SPIRV/Type.cpp
@@ -21,163 +21,170 @@ Type::Type(spv::Op op, std::vector<uint32_t> arg,
 const Type *Type::getUniqueType(SPIRVContext &context, const Type &t) {
   return context.registerType(t);
 }
-const Type *Type::getVoid(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeVoid);
+const Type *Type::getVoid(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeVoid, {}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getBool(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeBool);
+const Type *Type::getBool(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeBool, {}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getInt8(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeInt, {8, 1});
+const Type *Type::getInt8(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeInt, {8, 1}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getUint8(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeInt, {8, 0});
+const Type *Type::getUint8(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeInt, {8, 0}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getInt16(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeInt, {16, 1});
+const Type *Type::getInt16(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeInt, {16, 1}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getUint16(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeInt, {16, 0});
+const Type *Type::getUint16(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeInt, {16, 0}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getInt32(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeInt, {32, 1});
+const Type *Type::getInt32(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeInt, {32, 1}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getUint32(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeInt, {32, 0});
+const Type *Type::getUint32(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeInt, {32, 0}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getInt64(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeInt, {64, 1});
+const Type *Type::getInt64(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeInt, {64, 1}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getUint64(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeInt, {64, 0});
+const Type *Type::getUint64(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeInt, {64, 0}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getFloat16(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeFloat, {16});
+const Type *Type::getFloat16(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeFloat, {16}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getFloat32(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeFloat, {32});
+const Type *Type::getFloat32(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeFloat, {32}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getFloat64(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeFloat, {64});
+const Type *Type::getFloat64(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeFloat, {64}, d);
   return getUniqueType(context, t);
 }
 const Type *Type::getVector(SPIRVContext &context, uint32_t component_type,
-                            uint32_t vec_size) {
-  Type t = Type(spv::Op::OpTypeVector, {component_type, vec_size});
+                            uint32_t vec_size, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeVector, {component_type, vec_size}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getVec2(SPIRVContext &context, uint32_t component_type) {
-  return getVector(context, component_type, 2u);
+const Type *Type::getVec2(SPIRVContext &context, uint32_t component_type,
+                          DecorationSet d) {
+  return getVector(context, component_type, 2u, d);
 }
-const Type *Type::getVec3(SPIRVContext &context, uint32_t component_type) {
-  return getVector(context, component_type, 3u);
+const Type *Type::getVec3(SPIRVContext &context, uint32_t component_type,
+                          DecorationSet d) {
+  return getVector(context, component_type, 3u, d);
 }
-const Type *Type::getVec4(SPIRVContext &context, uint32_t component_type) {
-  return getVector(context, component_type, 4u);
+const Type *Type::getVec4(SPIRVContext &context, uint32_t component_type,
+                          DecorationSet d) {
+  return getVector(context, component_type, 4u, d);
 }
 const Type *Type::getMatrix(SPIRVContext &context, uint32_t column_type_id,
-                            uint32_t column_count) {
-  Type t = Type(spv::Op::OpTypeMatrix, {column_type_id, column_count});
+                            uint32_t column_count, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeMatrix, {column_type_id, column_count}, d);
   return getUniqueType(context, t);
 }
 const Type *
 Type::getImage(SPIRVContext &context, uint32_t sampled_type, spv::Dim dim,
                uint32_t depth, uint32_t arrayed, uint32_t ms, uint32_t sampled,
                spv::ImageFormat image_format,
-               llvm::Optional<spv::AccessQualifier> access_qualifier) {
+               llvm::Optional<spv::AccessQualifier> access_qualifier,
+               DecorationSet d) {
   std::vector<uint32_t> args = {
       sampled_type, uint32_t(dim),         depth, arrayed, ms,
       sampled,      uint32_t(image_format)};
   if (access_qualifier.hasValue()) {
     args.push_back(static_cast<uint32_t>(access_qualifier.getValue()));
   }
-  Type t = Type(spv::Op::OpTypeImage, args);
+  Type t = Type(spv::Op::OpTypeImage, args, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getSampler(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeSampler);
+const Type *Type::getSampler(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeSampler, {}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getSampledImage(SPIRVContext &context,
-                                  uint32_t image_type_id) {
-  Type t = Type(spv::Op::OpTypeSampledImage, {image_type_id});
+const Type *Type::getSampledImage(SPIRVContext &context, uint32_t image_type_id,
+                                  DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeSampledImage, {image_type_id}, d);
   return getUniqueType(context, t);
 }
 const Type *Type::getArray(SPIRVContext &context, uint32_t component_type_id,
-                           uint32_t len_id) {
-  Type t = Type(spv::Op::OpTypeArray, {component_type_id, len_id});
+                           uint32_t len_id, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeArray, {component_type_id, len_id}, d);
   return getUniqueType(context, t);
 }
 const Type *Type::getRuntimeArray(SPIRVContext &context,
-                                  uint32_t component_type_id) {
-  Type t = Type(spv::Op::OpTypeRuntimeArray, {component_type_id});
+                                  uint32_t component_type_id, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeRuntimeArray, {component_type_id}, d);
   return getUniqueType(context, t);
 }
 const Type *Type::getStruct(SPIRVContext &context,
-                            std::initializer_list<uint32_t> members) {
-  Type t = Type(spv::Op::OpTypeStruct, std::vector<uint32_t>(members));
+                            std::initializer_list<uint32_t> members,
+                            DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeStruct, std::vector<uint32_t>(members), d);
   return getUniqueType(context, t);
 }
-const Type *Type::getOpaque(SPIRVContext &context, std::string name) {
-  Type t = Type(spv::Op::OpTypeOpaque, utils::encodeSPIRVString(name));
+const Type *Type::getOpaque(SPIRVContext &context, std::string name,
+                            DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeOpaque, utils::encodeSPIRVString(name), d);
   return getUniqueType(context, t);
 }
-const Type *Type::getTyePointer(SPIRVContext &context,
-                                spv::StorageClass storage_class,
-                                uint32_t type) {
+const Type *Type::getPointer(SPIRVContext &context,
+                             spv::StorageClass storage_class, uint32_t type,
+                             DecorationSet d) {
   Type t = Type(spv::Op::OpTypePointer,
-                {static_cast<uint32_t>(storage_class), type});
+                {static_cast<uint32_t>(storage_class), type}, d);
   return getUniqueType(context, t);
 }
 const Type *Type::getFunction(SPIRVContext &context, uint32_t return_type,
-                              std::initializer_list<uint32_t> params) {
+                              std::initializer_list<uint32_t> params,
+                              DecorationSet d) {
   std::vector<uint32_t> args = {return_type};
   args.insert(args.end(), params.begin(), params.end());
-  Type t = Type(spv::Op::OpTypeFunction, args);
+  Type t = Type(spv::Op::OpTypeFunction, args, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getEvent(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeEvent);
+const Type *Type::getEvent(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeEvent, {}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getDeviceEvent(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeDeviceEvent);
+const Type *Type::getDeviceEvent(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeDeviceEvent, {}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getQueue(SPIRVContext &context) {
-  Type t = Type(spv::Op::OpTypeQueue);
+const Type *Type::getReserveId(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeReserveId, {}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getPipe(SPIRVContext &context,
-                          spv::AccessQualifier qualifier) {
-  Type t = Type(spv::Op::OpTypePipe, {static_cast<uint32_t>(qualifier)});
+const Type *Type::getQueue(SPIRVContext &context, DecorationSet d) {
+  Type t = Type(spv::Op::OpTypeQueue, {}, d);
+  return getUniqueType(context, t);
+}
+const Type *Type::getPipe(SPIRVContext &context, spv::AccessQualifier qualifier,
+                          DecorationSet d) {
+  Type t = Type(spv::Op::OpTypePipe, {static_cast<uint32_t>(qualifier)}, d);
   return getUniqueType(context, t);
 }
 const Type *Type::getForwardPointer(SPIRVContext &context,
                                     uint32_t pointer_type,
-                                    spv::StorageClass storage_class) {
+                                    spv::StorageClass storage_class,
+                                    DecorationSet d) {
   Type t = Type(spv::Op::OpTypeForwardPointer,
-                {pointer_type, static_cast<uint32_t>(storage_class)});
+                {pointer_type, static_cast<uint32_t>(storage_class)}, d);
   return getUniqueType(context, t);
 }
-const Type *Type::getType(SPIRVContext &context, spv::Op op,
-                          std::vector<uint32_t> arg,
-                          std::set<const Decoration *> dec) {
-  Type t = Type(op, arg, dec);
-  return getUniqueType(context, t);
-}
+
 bool Type::isBooleanType() const { return opcode == spv::Op::OpTypeBool; }
 bool Type::isIntegerType() const { return opcode == spv::Op::OpTypeInt; }
 bool Type::isFloatType() const { return opcode == spv::Op::OpTypeFloat; }
@@ -194,6 +201,10 @@ bool Type::isCompositeType() const {
   return isAggregateType() || isMatrixType() || isVectorType();
 }
 bool Type::isImageType() const { return opcode == spv::Op::OpTypeImage; }
+
+bool Type::hasDecoration(const Decoration *d) const {
+  return decorations.find(d) != decorations.end();
+}
 
 } // end namespace spirv
 } // end namespace clang

--- a/tools/clang/lib/SPIRV/Type.cpp
+++ b/tools/clang/lib/SPIRV/Type.cpp
@@ -73,26 +73,21 @@ const Type *Type::getFloat64(SPIRVContext &context) {
   Type t = Type(spv::Op::OpTypeFloat, {64});
   return getUniqueType(context, t);
 }
-const Type *Type::getVector(SPIRVContext &context, uint32_t component_type,
-                            uint32_t vec_size, DecorationSet d) {
-  Type t = Type(spv::Op::OpTypeVector, {component_type, vec_size}, d);
+const Type *Type::getVec2(SPIRVContext &context, uint32_t component_type) {
+  Type t = Type(spv::Op::OpTypeVector, {component_type, 2u});
   return getUniqueType(context, t);
 }
-const Type *Type::getVec2(SPIRVContext &context, uint32_t component_type,
-                          DecorationSet d) {
-  return getVector(context, component_type, 2u, d);
+const Type *Type::getVec3(SPIRVContext &context, uint32_t component_type) {
+  Type t = Type(spv::Op::OpTypeVector, {component_type, 3u});
+  return getUniqueType(context, t);
 }
-const Type *Type::getVec3(SPIRVContext &context, uint32_t component_type,
-                          DecorationSet d) {
-  return getVector(context, component_type, 3u, d);
-}
-const Type *Type::getVec4(SPIRVContext &context, uint32_t component_type,
-                          DecorationSet d) {
-  return getVector(context, component_type, 4u, d);
+const Type *Type::getVec4(SPIRVContext &context, uint32_t component_type) {
+  Type t = Type(spv::Op::OpTypeVector, {component_type, 4u});
+  return getUniqueType(context, t);
 }
 const Type *Type::getMatrix(SPIRVContext &context, uint32_t column_type_id,
-                            uint32_t column_count, DecorationSet d) {
-  Type t = Type(spv::Op::OpTypeMatrix, {column_type_id, column_count}, d);
+                            uint32_t column_count) {
+  Type t = Type(spv::Op::OpTypeMatrix, {column_type_id, column_count});
   return getUniqueType(context, t);
 }
 const Type *

--- a/tools/clang/lib/SPIRV/Utils.cpp
+++ b/tools/clang/lib/SPIRV/Utils.cpp
@@ -39,10 +39,10 @@ std::vector<uint32_t> encodeSPIRVString(std::string s) {
 /// \brief Reinterprets the given vector of 32-bit words as a string.
 /// Expectes that the words represent a NULL-terminated string.
 /// Assumes Little Endian architecture.
-std::string decodeSPIRVString(std::vector<uint32_t>& vec) {
+std::string decodeSPIRVString(const std::vector<uint32_t> &vec) {
   std::string result;
   if (!vec.empty()) {
-    result = std::string(reinterpret_cast<const char*>(vec.data()));
+    result = std::string(reinterpret_cast<const char *>(vec.data()));
   }
   return result;
 }

--- a/tools/clang/unittests/SPIRV/SPIRVContextTest.cpp
+++ b/tools/clang/unittests/SPIRV/SPIRVContextTest.cpp
@@ -60,12 +60,12 @@ TEST(ValidateSPIRVContext, ValidateUniqueIdForUniqueAggregateType) {
   const auto mem_0_position =
       Decoration::getBuiltIn(ctx, spv::BuiltIn::Position, 0);
 
-  const Type *struct_1 = Type::getType(
-      ctx, spv::Op::OpTypeStruct, {intt_id, boolt_id},
+  const Type *struct_1 = Type::getStruct(
+      ctx, {intt_id, boolt_id},
       {relaxed, bufferblock, mem_0_offset, mem_1_offset, mem_0_position});
 
-  const Type *struct_2 = Type::getType(
-      ctx, spv::Op::OpTypeStruct, {intt_id, boolt_id},
+  const Type *struct_2 = Type::getStruct(
+      ctx, {intt_id, boolt_id},
       {relaxed, bufferblock, mem_0_offset, mem_1_offset, mem_0_position});
 
   const uint32_t struct_1_id = ctx.getResultIdForType(struct_1);

--- a/tools/clang/unittests/SPIRV/TypeTest.cpp
+++ b/tools/clang/unittests/SPIRV/TypeTest.cpp
@@ -10,11 +10,13 @@
 #include "gmock/gmock.h"
 #include "clang/SPIRV/SPIRVContext.h"
 #include "clang/SPIRV/Type.h"
+#include "clang/SPIRV/Utils.h"
 #include "gtest/gtest.h"
 
 using namespace clang::spirv;
 
 namespace {
+using ::testing::ElementsAre;
 
 TEST(Type, SameTypeWoParameterShouldHaveSameAddress) {
   SPIRVContext context;
@@ -42,16 +44,16 @@ TEST(Type, SameAggregateTypeWithDecorationsShouldHaveSameAddress) {
   const Decoration *mem_0_position =
       Decoration::getBuiltIn(ctx, spv::BuiltIn::Position, 0);
 
-  const Type *struct_1 = Type::getType(
-      ctx, spv::Op::OpTypeStruct, {intt_id, boolt_id},
+  const Type *struct_1 = Type::getStruct(
+      ctx, {intt_id, boolt_id},
       {relaxed, bufferblock, mem_0_offset, mem_1_offset, mem_0_position});
 
-  const Type *struct_2 = Type::getType(
-      ctx, spv::Op::OpTypeStruct, {intt_id, boolt_id},
+  const Type *struct_2 = Type::getStruct(
+      ctx, {intt_id, boolt_id},
       {relaxed, bufferblock, mem_0_offset, mem_1_offset, mem_0_position});
 
-  const Type *struct_3 = Type::getType(
-      ctx, spv::Op::OpTypeStruct, {intt_id, boolt_id},
+  const Type *struct_3 = Type::getStruct(
+      ctx, {intt_id, boolt_id},
       {bufferblock, mem_0_offset, mem_0_position, mem_1_offset, relaxed});
 
   // 2 types with the same signature. We should get the same pointer.
@@ -61,6 +63,738 @@ TEST(Type, SameAggregateTypeWithDecorationsShouldHaveSameAddress) {
   EXPECT_EQ(struct_1, struct_3);
 }
 
-// TODO: Add Type tests for all types
+TEST(Type, Void) {
+  SPIRVContext ctx;
+  const Type *t = Type::getVoid(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVoid);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedVoid) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getVoid(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVoid);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Bool) {
+  SPIRVContext ctx;
+  const Type *t = Type::getBool(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeBool);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedBool) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getBool(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeBool);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Int8) {
+  SPIRVContext ctx;
+  const Type *t = Type::getInt8(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
+  EXPECT_THAT(t->getArgs(), ElementsAre(8, 1));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedInt8) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getInt8(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
+  EXPECT_THAT(t->getArgs(), ElementsAre(8, 1));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Uint8) {
+  SPIRVContext ctx;
+  const Type *t = Type::getUint8(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
+  EXPECT_THAT(t->getArgs(), ElementsAre(8, 0));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedUint8) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getUint8(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
+  EXPECT_THAT(t->getArgs(), ElementsAre(8, 0));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Int16) {
+  SPIRVContext ctx;
+  const Type *t = Type::getInt16(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
+  EXPECT_THAT(t->getArgs(), ElementsAre(16, 1));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedInt16) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getInt16(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
+  EXPECT_THAT(t->getArgs(), ElementsAre(16, 1));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Uint16) {
+  SPIRVContext ctx;
+  const Type *t = Type::getUint16(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
+  EXPECT_THAT(t->getArgs(), ElementsAre(16, 0));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedUint16) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getUint16(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
+  EXPECT_THAT(t->getArgs(), ElementsAre(16, 0));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Int32) {
+  SPIRVContext ctx;
+  const Type *t = Type::getInt32(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
+  EXPECT_THAT(t->getArgs(), ElementsAre(32, 1));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedInt32) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getInt32(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
+  EXPECT_THAT(t->getArgs(), ElementsAre(32, 1));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Uint32) {
+  SPIRVContext ctx;
+  const Type *t = Type::getUint32(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
+  EXPECT_THAT(t->getArgs(), ElementsAre(32, 0));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedUint32) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getUint32(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
+  EXPECT_THAT(t->getArgs(), ElementsAre(32, 0));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Int64) {
+  SPIRVContext ctx;
+  const Type *t = Type::getInt64(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
+  EXPECT_THAT(t->getArgs(), ElementsAre(64, 1));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedInt64) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getInt64(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
+  EXPECT_THAT(t->getArgs(), ElementsAre(64, 1));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Uint64) {
+  SPIRVContext ctx;
+  const Type *t = Type::getUint64(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
+  EXPECT_THAT(t->getArgs(), ElementsAre(64, 0));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedUint64) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getUint64(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
+  EXPECT_THAT(t->getArgs(), ElementsAre(64, 0));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Float16) {
+  SPIRVContext ctx;
+  const Type *t = Type::getFloat16(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeFloat);
+  EXPECT_THAT(t->getArgs(), ElementsAre(16));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedFloat16) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getFloat16(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeFloat);
+  EXPECT_THAT(t->getArgs(), ElementsAre(16));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Float32) {
+  SPIRVContext ctx;
+  const Type *t = Type::getFloat32(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeFloat);
+  EXPECT_THAT(t->getArgs(), ElementsAre(32));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedFloat32) {
+  SPIRVContext ctx;
+
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getFloat32(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeFloat);
+  EXPECT_THAT(t->getArgs(), ElementsAre(32));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Float64) {
+  SPIRVContext ctx;
+  const Type *t = Type::getFloat64(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeFloat);
+  EXPECT_THAT(t->getArgs(), ElementsAre(64));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedFloat64) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getFloat64(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeFloat);
+  EXPECT_THAT(t->getArgs(), ElementsAre(64));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, VectorBasic) {
+  SPIRVContext ctx;
+  const Type *t = Type::getVector(ctx, 1, 3);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVector);
+  EXPECT_THAT(t->getArgs(), ElementsAre(1, 3));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedVectorBasic) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getVector(ctx, 1, 3, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVector);
+  EXPECT_THAT(t->getArgs(), ElementsAre(1, 3));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Vec2) {
+  SPIRVContext ctx;
+  const Type *t = Type::getVec2(ctx, 1);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVector);
+  EXPECT_THAT(t->getArgs(), ElementsAre(1, 2));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedVec2) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getVec2(ctx, 1, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVector);
+  EXPECT_THAT(t->getArgs(), ElementsAre(1, 2));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Vec3) {
+  SPIRVContext ctx;
+  const Type *t = Type::getVec3(ctx, 1);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVector);
+  EXPECT_THAT(t->getArgs(), ElementsAre(1, 3));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedVec3) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getVec3(ctx, 1, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVector);
+  EXPECT_THAT(t->getArgs(), ElementsAre(1, 3));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Vec4) {
+  SPIRVContext ctx;
+  const Type *t = Type::getVec4(ctx, 1);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVector);
+  EXPECT_THAT(t->getArgs(), ElementsAre(1, 4));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedVec4) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getVec4(ctx, 1, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVector);
+  EXPECT_THAT(t->getArgs(), ElementsAre(1, 4));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, VectorWithTwoComponenetsAndVec2AreTheSameType) {
+  SPIRVContext ctx;
+  const Type *v1 = Type::getVector(ctx, /*type-id*/ 1, /*num-components*/ 2);
+  const Type *v2 = Type::getVec2(ctx, /*type-id*/ 1);
+  EXPECT_EQ(v1, v2);
+}
+
+TEST(Type, DecoratedVectorWithTwoComponenetsAndVec2AreTheSameType) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getBufferBlock(ctx);
+  const Type *v1 =
+      Type::getVector(ctx, /*type-id*/ 1, /*num-components*/ 2, {d});
+  const Type *v2 = Type::getVec2(ctx, /*type-id*/ 1, {d});
+  EXPECT_EQ(v1, v2);
+}
+
+TEST(Type, VectorWithThreeComponenetsAndVec3AreTheSameType) {
+  SPIRVContext ctx;
+  const Type *v1 = Type::getVector(ctx, /*type-id*/ 7, /*num-components*/ 3);
+  const Type *v2 = Type::getVec3(ctx, /*type-id*/ 7);
+  EXPECT_EQ(v1, v2);
+}
+
+TEST(Type, DecoratedVectorWithThreeComponenetsAndVec3AreTheSameType) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getBufferBlock(ctx);
+  const Type *v1 =
+      Type::getVector(ctx, /*type-id*/ 7, /*num-components*/ 3, {d});
+  const Type *v2 = Type::getVec3(ctx, /*type-id*/ 7, {d});
+  EXPECT_EQ(v1, v2);
+}
+
+TEST(Type, VectorWithFourComponenetsAndVec4AreTheSameType) {
+  SPIRVContext ctx;
+  const Type *v1 = Type::getVector(ctx, /*type-id*/ 7, /*num-components*/ 4);
+  const Type *v2 = Type::getVec4(ctx, /*type-id*/ 7);
+  EXPECT_EQ(v1, v2);
+}
+
+TEST(Type, DecoratedVectorWithFourComponenetsAndVec4AreTheSameType) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getBufferBlock(ctx);
+  const Type *v1 =
+      Type::getVector(ctx, /*type-id*/ 7, /*num-components*/ 4, {d});
+  const Type *v2 = Type::getVec4(ctx, /*type-id*/ 7, {d});
+  EXPECT_EQ(v1, v2);
+}
+
+TEST(Type, Matrix) {
+  SPIRVContext ctx;
+  const Type *t = Type::getMatrix(ctx, /*type-id*/ 7, /*column-count*/ 4);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeMatrix);
+  EXPECT_THAT(t->getArgs(), ElementsAre(7, 4));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedMatrix) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getMatrix(ctx, /*type-id*/ 7, /*column-count*/ 4, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeMatrix);
+  EXPECT_THAT(t->getArgs(), ElementsAre(7, 4));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, ImageWithoutAccessQualifier) {
+  SPIRVContext ctx;
+  const Type *t = Type::getImage(ctx, /*sampled-type*/ 5, spv::Dim::Cube,
+                                 /*depth*/ 1, /*arrayed*/ 1, /*multisampled*/ 0,
+                                 /*sampled*/ 2, spv::ImageFormat::Rgba32f);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeImage);
+  EXPECT_THAT(t->getArgs(),
+              ElementsAre(5, static_cast<uint32_t>(spv::Dim::Cube), 1, 1, 0, 2,
+                          static_cast<uint32_t>(spv::ImageFormat::Rgba32f)));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedImageWithoutAccessQualifier) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t =
+      Type::getImage(ctx, /*sampled-type*/ 5, spv::Dim::Cube, /*depth*/ 1,
+                     /*arrayed*/ 1, /*multisampled*/ 0, /*sampled*/ 2,
+                     spv::ImageFormat::Rgba32f, llvm::None, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeImage);
+  EXPECT_THAT(t->getArgs(),
+              ElementsAre(5, static_cast<uint32_t>(spv::Dim::Cube), 1, 1, 0, 2,
+                          static_cast<uint32_t>(spv::ImageFormat::Rgba32f)));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, ImageWithAccessQualifier) {
+  SPIRVContext ctx;
+  const Type *t = Type::getImage(
+      ctx, /*sampled-type*/ 5, spv::Dim::Cube, /*depth*/ 1, /*arrayed*/ 1,
+      /*multisampled*/ 0, /*sampled*/ 2, spv::ImageFormat::Rgba32f,
+      /*access-qualifier*/ spv::AccessQualifier::ReadWrite);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeImage);
+  EXPECT_THAT(
+      t->getArgs(),
+      ElementsAre(5, static_cast<uint32_t>(spv::Dim::Cube), 1, 1, 0, 2,
+                  static_cast<uint32_t>(spv::ImageFormat::Rgba32f),
+                  static_cast<uint32_t>(spv::AccessQualifier::ReadWrite)));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedImageWithAccessQualifier) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getImage(
+      ctx, /*sampled-type*/ 5, spv::Dim::Cube, /*depth*/ 1, /*arrayed*/ 1,
+      /*multisampled*/ 0, /*sampled*/ 2, spv::ImageFormat::Rgba32f,
+      /*access-qualifier*/ spv::AccessQualifier::ReadWrite, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeImage);
+  EXPECT_THAT(
+      t->getArgs(),
+      ElementsAre(5, static_cast<uint32_t>(spv::Dim::Cube), 1, 1, 0, 2,
+                  static_cast<uint32_t>(spv::ImageFormat::Rgba32f),
+                  static_cast<uint32_t>(spv::AccessQualifier::ReadWrite)));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, ImageWithAndWithoutAccessQualifierAreDifferentTypes) {
+  SPIRVContext ctx;
+  const Type *img1 =
+      Type::getImage(ctx, /*sampled-type*/ 5, spv::Dim::Cube,
+                     /*depth*/ 1, /*arrayed*/ 1, /*multisampled*/ 0,
+                     /*sampled*/ 2, spv::ImageFormat::Rgba32f);
+  const Type *img2 =
+      Type::getImage(ctx, /*sampled-type*/ 5, spv::Dim::Cube,
+                     /*depth*/ 1, /*arrayed*/ 1, /*multisampled*/ 0,
+                     /*sampled*/ 2, spv::ImageFormat::Rgba32f,
+                     /*access-qualifier*/ spv::AccessQualifier::ReadWrite);
+
+  // The only difference between these two types is the Access Qualifier which
+  // is an optional argument.
+  EXPECT_NE(img1, img2);
+}
+
+TEST(Type, Sampler) {
+  SPIRVContext ctx;
+  const Type *t = Type::getSampler(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeSampler);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedSampler) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getSampler(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeSampler);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, SampledImage) {
+  SPIRVContext ctx;
+  const Type *t = Type::getSampledImage(ctx, 1);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeSampledImage);
+  EXPECT_THAT(t->getArgs(), ElementsAre(1));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedSampledImage) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getSampledImage(ctx, 1, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeSampledImage);
+  EXPECT_THAT(t->getArgs(), ElementsAre(1));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Array) {
+  SPIRVContext ctx;
+  const Type *t = Type::getArray(ctx, 2, 4);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeArray);
+  EXPECT_THAT(t->getArgs(), ElementsAre(2, 4));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedArray) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getArray(ctx, 2, 4, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeArray);
+  EXPECT_THAT(t->getArgs(), ElementsAre(2, 4));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, RuntimeArray) {
+  SPIRVContext ctx;
+  const Type *t = Type::getRuntimeArray(ctx, 2);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeRuntimeArray);
+  EXPECT_THAT(t->getArgs(), ElementsAre(2));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedRuntimeArray) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getRuntimeArray(ctx, 2, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeRuntimeArray);
+  EXPECT_THAT(t->getArgs(), ElementsAre(2));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, StructBasic) {
+  SPIRVContext ctx;
+  const Type *t = Type::getStruct(ctx, {2, 3, 4});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeStruct);
+  EXPECT_THAT(t->getArgs(), ElementsAre(2, 3, 4));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, StructWithDecoration) {
+  SPIRVContext ctx;
+  const Decoration *bufferblock = Decoration::getBufferBlock(ctx);
+  const Type *t = Type::getStruct(ctx, {2, 3, 4}, {bufferblock});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeStruct);
+  EXPECT_THAT(t->getArgs(), ElementsAre(2, 3, 4));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(bufferblock));
+}
+
+TEST(Type, StructWithDecoratedMembers) {
+  SPIRVContext ctx;
+  const Decoration *relaxed = Decoration::getRelaxedPrecision(ctx);
+  const Decoration *bufferblock = Decoration::getBufferBlock(ctx);
+  const Decoration *mem_0_offset = Decoration::getOffset(ctx, 0u, 0);
+  const Decoration *mem_1_offset = Decoration::getOffset(ctx, 0u, 1);
+  const Decoration *mem_0_position =
+      Decoration::getBuiltIn(ctx, spv::BuiltIn::Position, 0);
+
+  const Type *t = Type::getStruct(
+      ctx, {2, 3, 4},
+      {relaxed, bufferblock, mem_0_position, mem_0_offset, mem_1_offset});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeStruct);
+  EXPECT_THAT(t->getArgs(), ElementsAre(2, 3, 4));
+  // Since decorations are an ordered set of pointers, it's better not to use
+  // ElementsAre()
+  EXPECT_EQ(t->getDecorations().size(), 5u);
+  EXPECT_TRUE(t->hasDecoration(relaxed));
+  EXPECT_TRUE(t->hasDecoration(bufferblock));
+  EXPECT_TRUE(t->hasDecoration(mem_0_offset));
+  EXPECT_TRUE(t->hasDecoration(mem_0_position));
+  EXPECT_TRUE(t->hasDecoration(mem_1_offset));
+}
+
+TEST(Type, Opaque) {
+  SPIRVContext ctx;
+  const Type *t = Type::getOpaque(ctx, "opaque_type");
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeOpaque);
+  EXPECT_EQ(utils::decodeSPIRVString(t->getArgs()), "opaque_type");
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedOpaque) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getOpaque(ctx, "opaque_type", {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeOpaque);
+  EXPECT_EQ(utils::decodeSPIRVString(t->getArgs()), "opaque_type");
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Pointer) {
+  SPIRVContext ctx;
+  const Type *t = Type::getPointer(ctx, spv::StorageClass::Uniform, 2);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypePointer);
+  EXPECT_THAT(
+      t->getArgs(),
+      ElementsAre(static_cast<uint32_t>(spv::StorageClass::Uniform), 2));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedPointer) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getPointer(ctx, spv::StorageClass::Uniform, 2, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypePointer);
+  EXPECT_THAT(
+      t->getArgs(),
+      ElementsAre(static_cast<uint32_t>(spv::StorageClass::Uniform), 2));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Function) {
+  SPIRVContext ctx;
+  const Type *t = Type::getFunction(ctx, 1, {2, 3, 4});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeFunction);
+  EXPECT_THAT(t->getArgs(), ElementsAre(1, 2, 3, 4));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedFunction) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getFunction(ctx, 1, {2, 3, 4}, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeFunction);
+  EXPECT_THAT(t->getArgs(), ElementsAre(1, 2, 3, 4));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Event) {
+  SPIRVContext ctx;
+  const Type *t = Type::getEvent(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeEvent);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedEvent) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getEvent(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeEvent);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, DeviceEvent) {
+  SPIRVContext ctx;
+  const Type *t = Type::getDeviceEvent(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeDeviceEvent);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedDeviceEvent) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getDeviceEvent(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeDeviceEvent);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, ReserveId) {
+  SPIRVContext ctx;
+  const Type *t = Type::getReserveId(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeReserveId);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedReserveId) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getReserveId(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeReserveId);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Queue) {
+  SPIRVContext ctx;
+  const Type *t = Type::getQueue(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeQueue);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedQueue) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getQueue(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeQueue);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, Pipe) {
+  SPIRVContext ctx;
+  const Type *t = Type::getPipe(ctx, spv::AccessQualifier::WriteOnly);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypePipe);
+  EXPECT_THAT(t->getArgs(), ElementsAre(static_cast<uint32_t>(
+                                spv::AccessQualifier::WriteOnly)));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedPipe) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getPipe(ctx, spv::AccessQualifier::WriteOnly, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypePipe);
+  EXPECT_THAT(t->getArgs(), ElementsAre(static_cast<uint32_t>(
+                                spv::AccessQualifier::WriteOnly)));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, ForwardPointer) {
+  SPIRVContext ctx;
+  const Type *t = Type::getForwardPointer(ctx, 6, spv::StorageClass::Workgroup);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeForwardPointer);
+  EXPECT_THAT(t->getArgs(), ElementsAre(6, static_cast<uint32_t>(
+                                               spv::StorageClass::Workgroup)));
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedForwardPointer) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t =
+      Type::getForwardPointer(ctx, 6, spv::StorageClass::Workgroup, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeForwardPointer);
+  EXPECT_THAT(t->getArgs(), ElementsAre(6, static_cast<uint32_t>(
+                                               spv::StorageClass::Workgroup)));
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, PipeStorage) {
+  SPIRVContext ctx;
+  const Type *t = Type::getPipeStorage(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypePipeStorage);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedPipeStorage) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getPipeStorage(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypePipeStorage);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
+
+TEST(Type, NamedBarrier) {
+  SPIRVContext ctx;
+  const Type *t = Type::getNamedBarrier(ctx);
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeNamedBarrier);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_TRUE(t->getDecorations().empty());
+}
+
+TEST(Type, DecoratedNamedBarrier) {
+  SPIRVContext ctx;
+  const Decoration *d = Decoration::getAliased(ctx);
+  const Type *t = Type::getNamedBarrier(ctx, {d});
+  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeNamedBarrier);
+  EXPECT_TRUE(t->getArgs().empty());
+  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
+}
 
 } // anonymous namespace

--- a/tools/clang/unittests/SPIRV/TypeTest.cpp
+++ b/tools/clang/unittests/SPIRV/TypeTest.cpp
@@ -71,30 +71,12 @@ TEST(Type, Void) {
   EXPECT_TRUE(t->getDecorations().empty());
 }
 
-TEST(Type, DecoratedVoid) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getVoid(ctx, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVoid);
-  EXPECT_TRUE(t->getArgs().empty());
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
-}
-
 TEST(Type, Bool) {
   SPIRVContext ctx;
   const Type *t = Type::getBool(ctx);
   EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeBool);
   EXPECT_TRUE(t->getArgs().empty());
   EXPECT_TRUE(t->getDecorations().empty());
-}
-
-TEST(Type, DecoratedBool) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getBool(ctx, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeBool);
-  EXPECT_TRUE(t->getArgs().empty());
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
 }
 
 TEST(Type, Int8) {
@@ -105,30 +87,12 @@ TEST(Type, Int8) {
   EXPECT_TRUE(t->getDecorations().empty());
 }
 
-TEST(Type, DecoratedInt8) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getInt8(ctx, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
-  EXPECT_THAT(t->getArgs(), ElementsAre(8, 1));
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
-}
-
 TEST(Type, Uint8) {
   SPIRVContext ctx;
   const Type *t = Type::getUint8(ctx);
   EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
   EXPECT_THAT(t->getArgs(), ElementsAre(8, 0));
   EXPECT_TRUE(t->getDecorations().empty());
-}
-
-TEST(Type, DecoratedUint8) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getUint8(ctx, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
-  EXPECT_THAT(t->getArgs(), ElementsAre(8, 0));
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
 }
 
 TEST(Type, Int16) {
@@ -139,30 +103,12 @@ TEST(Type, Int16) {
   EXPECT_TRUE(t->getDecorations().empty());
 }
 
-TEST(Type, DecoratedInt16) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getInt16(ctx, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
-  EXPECT_THAT(t->getArgs(), ElementsAre(16, 1));
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
-}
-
 TEST(Type, Uint16) {
   SPIRVContext ctx;
   const Type *t = Type::getUint16(ctx);
   EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
   EXPECT_THAT(t->getArgs(), ElementsAre(16, 0));
   EXPECT_TRUE(t->getDecorations().empty());
-}
-
-TEST(Type, DecoratedUint16) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getUint16(ctx, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
-  EXPECT_THAT(t->getArgs(), ElementsAre(16, 0));
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
 }
 
 TEST(Type, Int32) {
@@ -173,30 +119,12 @@ TEST(Type, Int32) {
   EXPECT_TRUE(t->getDecorations().empty());
 }
 
-TEST(Type, DecoratedInt32) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getInt32(ctx, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
-  EXPECT_THAT(t->getArgs(), ElementsAre(32, 1));
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
-}
-
 TEST(Type, Uint32) {
   SPIRVContext ctx;
   const Type *t = Type::getUint32(ctx);
   EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
   EXPECT_THAT(t->getArgs(), ElementsAre(32, 0));
   EXPECT_TRUE(t->getDecorations().empty());
-}
-
-TEST(Type, DecoratedUint32) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getUint32(ctx, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
-  EXPECT_THAT(t->getArgs(), ElementsAre(32, 0));
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
 }
 
 TEST(Type, Int64) {
@@ -207,30 +135,12 @@ TEST(Type, Int64) {
   EXPECT_TRUE(t->getDecorations().empty());
 }
 
-TEST(Type, DecoratedInt64) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getInt64(ctx, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
-  EXPECT_THAT(t->getArgs(), ElementsAre(64, 1));
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
-}
-
 TEST(Type, Uint64) {
   SPIRVContext ctx;
   const Type *t = Type::getUint64(ctx);
   EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
   EXPECT_THAT(t->getArgs(), ElementsAre(64, 0));
   EXPECT_TRUE(t->getDecorations().empty());
-}
-
-TEST(Type, DecoratedUint64) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getUint64(ctx, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeInt);
-  EXPECT_THAT(t->getArgs(), ElementsAre(64, 0));
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
 }
 
 TEST(Type, Float16) {
@@ -241,15 +151,6 @@ TEST(Type, Float16) {
   EXPECT_TRUE(t->getDecorations().empty());
 }
 
-TEST(Type, DecoratedFloat16) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getFloat16(ctx, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeFloat);
-  EXPECT_THAT(t->getArgs(), ElementsAre(16));
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
-}
-
 TEST(Type, Float32) {
   SPIRVContext ctx;
   const Type *t = Type::getFloat32(ctx);
@@ -258,31 +159,12 @@ TEST(Type, Float32) {
   EXPECT_TRUE(t->getDecorations().empty());
 }
 
-TEST(Type, DecoratedFloat32) {
-  SPIRVContext ctx;
-
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getFloat32(ctx, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeFloat);
-  EXPECT_THAT(t->getArgs(), ElementsAre(32));
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
-}
-
 TEST(Type, Float64) {
   SPIRVContext ctx;
   const Type *t = Type::getFloat64(ctx);
   EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeFloat);
   EXPECT_THAT(t->getArgs(), ElementsAre(64));
   EXPECT_TRUE(t->getDecorations().empty());
-}
-
-TEST(Type, DecoratedFloat64) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getFloat64(ctx, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeFloat);
-  EXPECT_THAT(t->getArgs(), ElementsAre(64));
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
 }
 
 TEST(Type, VectorBasic) {

--- a/tools/clang/unittests/SPIRV/TypeTest.cpp
+++ b/tools/clang/unittests/SPIRV/TypeTest.cpp
@@ -763,38 +763,4 @@ TEST(Type, DecoratedForwardPointer) {
   EXPECT_THAT(t->getDecorations(), ElementsAre(d));
 }
 
-TEST(Type, PipeStorage) {
-  SPIRVContext ctx;
-  const Type *t = Type::getPipeStorage(ctx);
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypePipeStorage);
-  EXPECT_TRUE(t->getArgs().empty());
-  EXPECT_TRUE(t->getDecorations().empty());
-}
-
-TEST(Type, DecoratedPipeStorage) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getPipeStorage(ctx, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypePipeStorage);
-  EXPECT_TRUE(t->getArgs().empty());
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
-}
-
-TEST(Type, NamedBarrier) {
-  SPIRVContext ctx;
-  const Type *t = Type::getNamedBarrier(ctx);
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeNamedBarrier);
-  EXPECT_TRUE(t->getArgs().empty());
-  EXPECT_TRUE(t->getDecorations().empty());
-}
-
-TEST(Type, DecoratedNamedBarrier) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getNamedBarrier(ctx, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeNamedBarrier);
-  EXPECT_TRUE(t->getArgs().empty());
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
-}
-
 } // anonymous namespace

--- a/tools/clang/unittests/SPIRV/TypeTest.cpp
+++ b/tools/clang/unittests/SPIRV/TypeTest.cpp
@@ -167,38 +167,12 @@ TEST(Type, Float64) {
   EXPECT_TRUE(t->getDecorations().empty());
 }
 
-TEST(Type, VectorBasic) {
-  SPIRVContext ctx;
-  const Type *t = Type::getVector(ctx, 1, 3);
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVector);
-  EXPECT_THAT(t->getArgs(), ElementsAre(1, 3));
-  EXPECT_TRUE(t->getDecorations().empty());
-}
-
-TEST(Type, DecoratedVectorBasic) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getVector(ctx, 1, 3, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVector);
-  EXPECT_THAT(t->getArgs(), ElementsAre(1, 3));
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
-}
-
 TEST(Type, Vec2) {
   SPIRVContext ctx;
   const Type *t = Type::getVec2(ctx, 1);
   EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVector);
   EXPECT_THAT(t->getArgs(), ElementsAre(1, 2));
   EXPECT_TRUE(t->getDecorations().empty());
-}
-
-TEST(Type, DecoratedVec2) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getVec2(ctx, 1, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVector);
-  EXPECT_THAT(t->getArgs(), ElementsAre(1, 2));
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
 }
 
 TEST(Type, Vec3) {
@@ -209,15 +183,6 @@ TEST(Type, Vec3) {
   EXPECT_TRUE(t->getDecorations().empty());
 }
 
-TEST(Type, DecoratedVec3) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getVec3(ctx, 1, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVector);
-  EXPECT_THAT(t->getArgs(), ElementsAre(1, 3));
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
-}
-
 TEST(Type, Vec4) {
   SPIRVContext ctx;
   const Type *t = Type::getVec4(ctx, 1);
@@ -226,78 +191,12 @@ TEST(Type, Vec4) {
   EXPECT_TRUE(t->getDecorations().empty());
 }
 
-TEST(Type, DecoratedVec4) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getVec4(ctx, 1, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeVector);
-  EXPECT_THAT(t->getArgs(), ElementsAre(1, 4));
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
-}
-
-TEST(Type, VectorWithTwoComponenetsAndVec2AreTheSameType) {
-  SPIRVContext ctx;
-  const Type *v1 = Type::getVector(ctx, /*type-id*/ 1, /*num-components*/ 2);
-  const Type *v2 = Type::getVec2(ctx, /*type-id*/ 1);
-  EXPECT_EQ(v1, v2);
-}
-
-TEST(Type, DecoratedVectorWithTwoComponenetsAndVec2AreTheSameType) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getBufferBlock(ctx);
-  const Type *v1 =
-      Type::getVector(ctx, /*type-id*/ 1, /*num-components*/ 2, {d});
-  const Type *v2 = Type::getVec2(ctx, /*type-id*/ 1, {d});
-  EXPECT_EQ(v1, v2);
-}
-
-TEST(Type, VectorWithThreeComponenetsAndVec3AreTheSameType) {
-  SPIRVContext ctx;
-  const Type *v1 = Type::getVector(ctx, /*type-id*/ 7, /*num-components*/ 3);
-  const Type *v2 = Type::getVec3(ctx, /*type-id*/ 7);
-  EXPECT_EQ(v1, v2);
-}
-
-TEST(Type, DecoratedVectorWithThreeComponenetsAndVec3AreTheSameType) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getBufferBlock(ctx);
-  const Type *v1 =
-      Type::getVector(ctx, /*type-id*/ 7, /*num-components*/ 3, {d});
-  const Type *v2 = Type::getVec3(ctx, /*type-id*/ 7, {d});
-  EXPECT_EQ(v1, v2);
-}
-
-TEST(Type, VectorWithFourComponenetsAndVec4AreTheSameType) {
-  SPIRVContext ctx;
-  const Type *v1 = Type::getVector(ctx, /*type-id*/ 7, /*num-components*/ 4);
-  const Type *v2 = Type::getVec4(ctx, /*type-id*/ 7);
-  EXPECT_EQ(v1, v2);
-}
-
-TEST(Type, DecoratedVectorWithFourComponenetsAndVec4AreTheSameType) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getBufferBlock(ctx);
-  const Type *v1 =
-      Type::getVector(ctx, /*type-id*/ 7, /*num-components*/ 4, {d});
-  const Type *v2 = Type::getVec4(ctx, /*type-id*/ 7, {d});
-  EXPECT_EQ(v1, v2);
-}
-
 TEST(Type, Matrix) {
   SPIRVContext ctx;
   const Type *t = Type::getMatrix(ctx, /*type-id*/ 7, /*column-count*/ 4);
   EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeMatrix);
   EXPECT_THAT(t->getArgs(), ElementsAre(7, 4));
   EXPECT_TRUE(t->getDecorations().empty());
-}
-
-TEST(Type, DecoratedMatrix) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getAliased(ctx);
-  const Type *t = Type::getMatrix(ctx, /*type-id*/ 7, /*column-count*/ 4, {d});
-  EXPECT_EQ(t->getOpcode(), spv::Op::OpTypeMatrix);
-  EXPECT_THAT(t->getArgs(), ElementsAre(7, 4));
-  EXPECT_THAT(t->getDecorations(), ElementsAre(d));
 }
 
 TEST(Type, ImageWithoutAccessQualifier) {

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -41,6 +41,7 @@ if "%BUILD_ARCH%"=="" (
 )
 
 set BUILD_GENERATOR=Visual Studio 14 2015
+set BUILD_VS_VER=2015
 set BUILD_CONFIG=Debug
 set DO_SETUP=1
 set DO_BUILD=1
@@ -98,6 +99,7 @@ if "%1"=="-Release" (
 )
 if "%1"=="-vs2017" (
   set BUILD_GENERATOR=Visual Studio 15 2017
+  set BUILD_VS_VER=2017
   shift /1
 )
 
@@ -113,6 +115,16 @@ if "%1"=="-spirvtest" (
   shift /1
 )
 rem End SPIRV change
+
+rem If only VS 2017 is available, pick that by default.
+if "%BUILD_VS_VER%"=="2015" (
+  reg query HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\DevDiv\vs\Servicing\14.0\devenv /v Install /reg:32 1>nul 2>nul
+  if errorlevel 1 (
+    echo Visual Studio 2015 not available, setting up build for Visual Studio 2017.
+    set BUILD_GENERATOR=Visual Studio 15 2017
+    set BUILD_VS_VER=2017
+  )
+)
 
 if "%BUILD_ARCH%"=="x64" (
   set BUILD_GENERATOR=%BUILD_GENERATOR% %BUILD_ARCH:x64=Win64%
@@ -238,9 +250,14 @@ if "%DO_SETUP%"=="1" (
 if "%DO_BUILD%"=="1" (
   rem Should add support for the non-x86-qualified programfiles.
   echo Building solution files for %2 with %1 configuration.
-  if exist "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" (
-    call :buildvs_x86dir %1 %2 %3
+  if "%BUILD_VS_VER%"=="2015" (
+    if exist "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" (
+      call :buildvs_x86dir %1 %2 %3
+    ) else (
+      cmake --build . --config %1
+    )
   ) else (
+    rem Just defer to cmake for now.
     cmake --build . --config %1
   )
   if errorlevel 1 (


### PR DESCRIPTION
Also made a change to the Type class as follows:
a) Type::getType function has been removed in order to prevent users from
constructing invalid types.

b) All Type::get...() functions have been updated to accept decorations
as argument in order to allow building any valid arbitrary type.