### PR TITLE
[spirv] Add CL option for stage I/O location assignment order

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -229,9 +229,6 @@ HLSL variables and resources
 
 This section lists how various HLSL variables and resources are mapped.
 
-Variable definition
-+++++++++++++++++++
-
 Variables are defined in HLSL using the following
 `syntax <https://msdn.microsoft.com/en-us/library/windows/desktop/bb509706(v=vs.85).aspx>`_
 rules::
@@ -328,7 +325,7 @@ to ``Location`` 1.
 
 [TODO] Another explicit way: using command-line options
 
-Please note that the compiler does prohibits mixing the explicit and implicit
+Please note that the compiler prohibits mixing the explicit and implicit
 approach for the same SigPoint to avoid complexity and fallibility. However,
 for a certain shader stage, one SigPoint using the explicit approach while the
 other adopting the implicit approach is permitted.
@@ -372,8 +369,10 @@ corresponding SPIR-V ``Builtin``  decorations according to the above table.
 SV semantic strings not translated into SPIR-V BuiltIn decorations will be
 handled similarly as non-SV (arbitrary) semantic strings: a SPIR-V variable
 of the ``Input``/``Output`` storage class will be created for each entity with
-such semantic string. Then sort all semantic strings alphabetically, and assign
-``Location`` numbers sequentially to each SPIR-V variable. Note that this means
+such semantic string. Then sort all semantic strings according to declaration
+(the default, or if ``-fvk-stage-io-order=decl`` is given) or alphabetical
+(if ``-fvk-stage-io-order=alpha`` is given) order, and assign ``Location``
+numbers sequentially to the corresponding SPIR-V variables. Note that this means
 flattening all structs if structs are used as function parameters or returns.
 
 There is an exception to the above rule for SV_Target[N]. It will always be

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -109,7 +109,6 @@ public:
 
   bool AllResourcesBound; // OPT_all_resources_bound
   bool AstDump; // OPT_ast_dump
-  bool GenSPIRV; // OPT_spirv // SPIRV change
   bool ColorCodeAssembly; // OPT_Cc
   bool CodeGenHighLevel; // OPT_fcgl
   bool DebugInfo; // OPT__SLASH_Zi
@@ -151,6 +150,13 @@ public:
   bool DisassembleByteOffset; //OPT_No
   bool DisaseembleHex; //OPT_Lx
   bool IsRootSignatureProfile();
+
+  // SPIRV Change Starts
+#ifdef ENABLE_SPIRV_CODEGEN
+  bool GenSPIRV; // OPT_spirv
+  llvm::StringRef VkStageIoOrder;
+#endif
+  // SPIRV Change Ends
 };
 
 /// Use this class to capture, convert and handle the lifetime for the

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -67,6 +67,8 @@ def hlsloptz_Group : OptionGroup<"HLSL Optimization">, HelpText<"Optimization Op
 def hlslutil_Group : OptionGroup<"HLSL Utility">, HelpText<"Utility Options">;
 def hlslcore_Group : OptionGroup<"HLSL Core">, HelpText<"Common Options">;
 
+def spirv_Group : OptionGroup<"SPIR-V CodeGen">, HelpText<"SPIR-V CodeGen Options">; // SPIRV Change
+
 //////////////////////////////////////////////////////////////////////////////
 // Options
 
@@ -209,8 +211,6 @@ def _help_question : Flag<["-", "/"], "?">, Flags<[DriverOption]>, Alias<help>;
 
 def ast_dump : Flag<["-", "/"], "ast-dump">, Flags<[CoreOption, DriverOption, HelpHidden]>,
   HelpText<"Dumps the parsed Abstract Syntax Tree.">; // should not be core, but handy workaround until explicit API written
-def spirv : Flag<["-"], "spirv">, Flags<[CoreOption, DriverOption, HelpHidden]>, // SPIRV change: temporary solution to support
-  HelpText<"Generates SPIR-V binary code">;                                      // SPIRV change: SPIR-V gen in a command line tool
 def external_lib : Separate<["-", "/"], "external">, Group<hlslcore_Group>, Flags<[DriverOption, HelpHidden]>,
   HelpText<"External DLL name to load for compiler support">;
 def external_fn : Separate<["-", "/"], "external-fn">, Group<hlslcore_Group>, Flags<[DriverOption, HelpHidden]>,
@@ -229,6 +229,13 @@ def no_warnings : Flag<["-", "/"], "no-warnings">, Group<hlslcomp_Group>, Flags<
   HelpText<"Suppress warnings">;
 def rootsig_define : Separate<["-", "/"], "rootsig-define">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
   HelpText<"Read root signature from a #define">;
+
+// SPIRV Change Starts
+def spirv : Flag<["-"], "spirv">, Group<spirv_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,
+  HelpText<"Generate SPIR-V binary code">;
+def fvk_stage_io_order_EQ : Joined<["-"], "fvk-stage-io-order=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,
+  HelpText<"Specify Vulkan stage I/O location assignment order">;
+// SPIRV Change Ends
 
 //////////////////////////////////////////////////////////////////////////////
 // fxc-based flags that don't match those previously defined.

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -249,7 +249,6 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.UseHexLiterals = Args.hasFlag(OPT_Lx, OPT_INVALID);
   opts.Preprocess = Args.getLastArgValue(OPT_P);
   opts.AstDump = Args.hasFlag(OPT_ast_dump, OPT_INVALID, false);
-  opts.GenSPIRV = Args.hasFlag(OPT_spirv, OPT_INVALID, false); // SPIRV change
   opts.CodeGenHighLevel = Args.hasFlag(OPT_fcgl, OPT_INVALID, false);
   opts.DebugInfo = Args.hasFlag(OPT__SLASH_Zi, OPT_INVALID, false);
   opts.DebugNameForBinary = Args.hasFlag(OPT_Zsb, OPT_INVALID, false);
@@ -384,6 +383,23 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
     errors << "Cannot specify both /Zss and /Zsb";
     return 1;
   }
+
+  // SPIRV Change Starts
+#ifdef ENABLE_SPIRV_CODEGEN
+  opts.GenSPIRV = Args.hasFlag(OPT_spirv, OPT_INVALID, false);
+  opts.VkStageIoOrder = Args.getLastArgValue(OPT_fvk_stage_io_order_EQ, "decl");
+  if (opts.VkStageIoOrder != "alpha" && opts.VkStageIoOrder != "decl") {
+    errors << "Unknown Vulkan stage I/O location assignment order : "
+           << opts.VkStageIoOrder;
+    return 1;
+  }
+#else
+  if (Args.hasFlag(OPT_spirv) || Args.hasFlag(OPT_fvk_stage_io_order_EQ)) {
+    errors << "SPIR-V CodeGen not configured via ENABLE_SPIRV_CODEGEN";
+    return 1;
+  }
+#endif
+  // SPIRV Change Ends
 
   opts.Args = std::move(Args);
   return 0;

--- a/tools/clang/include/clang/SPIRV/EmitSPIRVAction.h
+++ b/tools/clang/include/clang/SPIRV/EmitSPIRVAction.h
@@ -11,12 +11,20 @@
 
 #include "clang/Frontend/FrontendAction.h"
 
+#include "clang/SPIRV/EmitSPIRVOptions.h"
+
 namespace clang {
 
 class EmitSPIRVAction : public ASTFrontendAction {
+public:
+  EmitSPIRVAction(const EmitSPIRVOptions &opts) : options(opts) {}
+
 protected:
   std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
                                                  StringRef InFile) override;
+
+private:
+  EmitSPIRVOptions options;
 };
 
 } // end namespace clang

--- a/tools/clang/include/clang/SPIRV/EmitSPIRVOptions.h
+++ b/tools/clang/include/clang/SPIRV/EmitSPIRVOptions.h
@@ -1,0 +1,21 @@
+//===-- EmitSPIRVOptions.h - Options for SPIR-V CodeGen ---------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_CLANG_SPIRV_EMITSPIRVOPTIONS_H
+#define LLVM_CLANG_SPIRV_EMITSPIRVOPTIONS_H
+
+#include "llvm/ADT/StringRef.h"
+
+namespace clang {
+/// Structs for controlling behaviors of SPIR-V codegen.
+struct EmitSPIRVOptions {
+  llvm::StringRef stageIoOrder;
+};
+} // end namespace clang
+
+#endif

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -306,12 +306,13 @@ bool DeclResultIdMapper::finalizeStageIOLocations(bool forInput) {
     }
   }
 
-  // Sort stage input/output variables alphabetically
-  const auto comp = [](const StageVar *a, const StageVar *b) {
-    return a->getSemanticStr() < b->getSemanticStr();
-  };
-
-  std::sort(vars.begin(), vars.end(), comp);
+  if (spirvOptions.stageIoOrder == "alpha") {
+    // Sort stage input/output variables alphabetically
+    std::sort(vars.begin(), vars.end(),
+              [](const StageVar *a, const StageVar *b) {
+                return a->getSemanticStr() < b->getSemanticStr();
+              });
+  }
 
   for (const auto *var : vars)
     theBuilder.decorateLocation(var->getSpirvId(), locSet.useNextLoc());

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -17,6 +17,7 @@
 #include "dxc/HLSL/DxilSigPoint.h"
 #include "spirv/1.0/spirv.hpp11"
 #include "clang/AST/Attr.h"
+#include "clang/SPIRV/EmitSPIRVOptions.h"
 #include "clang/SPIRV/ModuleBuilder.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Optional.h"
@@ -104,7 +105,8 @@ StageVar::StageVar(const hlsl::SigPoint *sig, llvm::StringRef semaStr,
 class DeclResultIdMapper {
 public:
   inline DeclResultIdMapper(const hlsl::ShaderModel &stage, ASTContext &context,
-                            ModuleBuilder &builder, DiagnosticsEngine &diag);
+                            ModuleBuilder &builder, DiagnosticsEngine &diag,
+                            const EmitSPIRVOptions &spirvOptions);
 
   /// \brief Creates the stage output variables by parsing the semantics
   /// attached to the given function's parameter or return value and returns
@@ -221,8 +223,10 @@ private:
 private:
   const hlsl::ShaderModel &shaderModel;
   ModuleBuilder &theBuilder;
-  TypeTranslator typeTranslator;
+  const EmitSPIRVOptions &spirvOptions;
   DiagnosticsEngine &diags;
+
+  TypeTranslator typeTranslator;
 
   uint32_t entryFunctionId;
 
@@ -235,9 +239,10 @@ private:
 DeclResultIdMapper::DeclResultIdMapper(const hlsl::ShaderModel &model,
                                        ASTContext &context,
                                        ModuleBuilder &builder,
-                                       DiagnosticsEngine &diag)
-    : shaderModel(model), theBuilder(builder),
-      typeTranslator(context, builder, diag), diags(diag), entryFunctionId(0) {}
+                                       DiagnosticsEngine &diag,
+                                       const EmitSPIRVOptions &options)
+    : shaderModel(model), theBuilder(builder), spirvOptions(options),
+      diags(diag), typeTranslator(context, builder, diag), entryFunctionId(0) {}
 
 bool DeclResultIdMapper::decorateStageIOLocations() {
   // Try both input and output even if input location assignment failed

--- a/tools/clang/lib/SPIRV/EmitSPIRVAction.cpp
+++ b/tools/clang/lib/SPIRV/EmitSPIRVAction.cpp
@@ -18,6 +18,6 @@ namespace clang {
 
 std::unique_ptr<ASTConsumer>
 EmitSPIRVAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
-  return llvm::make_unique<spirv::SPIRVEmitter>(CI);
+  return llvm::make_unique<spirv::SPIRVEmitter>(CI, options);
 }
 } // end namespace clang

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -135,14 +135,15 @@ bool isLoopStmt(const Stmt *stmt) {
 
 } // namespace
 
-SPIRVEmitter::SPIRVEmitter(CompilerInstance &ci)
+SPIRVEmitter::SPIRVEmitter(CompilerInstance &ci,
+                           const EmitSPIRVOptions &options)
     : theCompilerInstance(ci), astContext(ci.getASTContext()),
-      diags(ci.getDiagnostics()),
+      diags(ci.getDiagnostics()), spirvOptions(options),
       entryFunctionName(ci.getCodeGenOpts().HLSLEntryFunction),
       shaderModel(*hlsl::ShaderModel::GetByName(
           ci.getCodeGenOpts().HLSLProfile.c_str())),
       theContext(), theBuilder(&theContext),
-      declIdMapper(shaderModel, astContext, theBuilder, diags),
+      declIdMapper(shaderModel, astContext, theBuilder, diags, spirvOptions),
       typeTranslator(astContext, theBuilder, diags), entryFunctionId(0),
       curFunction(nullptr) {
   if (shaderModel.GetKind() == hlsl::ShaderModel::Kind::Invalid)

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -26,6 +26,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Frontend/CompilerInstance.h"
+#include "clang/SPIRV/EmitSPIRVOptions.h"
 #include "clang/SPIRV/ModuleBuilder.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
@@ -42,7 +43,7 @@ namespace spirv {
 /// through the AST is done manually instead of using ASTConsumer's harness.
 class SPIRVEmitter : public ASTConsumer {
 public:
-  explicit SPIRVEmitter(CompilerInstance &ci);
+  explicit SPIRVEmitter(CompilerInstance &ci, const EmitSPIRVOptions &options);
 
   void HandleTranslationUnit(ASTContext &context) override;
 
@@ -432,6 +433,8 @@ private:
   CompilerInstance &theCompilerInstance;
   ASTContext &astContext;
   DiagnosticsEngine &diags;
+
+  EmitSPIRVOptions spirvOptions;
 
   /// Entry function name and shader stage. Both of them are derived from the
   /// command line and should be const.

--- a/tools/clang/test/CodeGenSPIRV/passthru-vs.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/passthru-vs.hlsl2spv
@@ -37,8 +37,8 @@ PSInput VSmain(float4 position: POSITION, float4 color: COLOR) {
 // OpName %color "color"
 // OpName %result "result"
 // OpDecorate %gl_Position BuiltIn Position
-// OpDecorate %in_var_COLOR Location 0
-// OpDecorate %in_var_POSITION Location 1
+// OpDecorate %in_var_POSITION Location 0
+// OpDecorate %in_var_COLOR Location 1
 // OpDecorate %out_var_COLOR Location 0
 // %int = OpTypeInt 32 1
 // %void = OpTypeVoid

--- a/tools/clang/test/CodeGenSPIRV/semantic.arbitrary.location.alpha.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.arbitrary.location.alpha.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T vs_6_0 -E main
+// Run: %dxc -T vs_6_0 -E main -fvk-stage-io-order=alpha
 
 struct S {
     float c: C;

--- a/tools/clang/test/CodeGenSPIRV/semantic.arbitrary.location.decl.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.arbitrary.location.decl.hlsl
@@ -1,0 +1,44 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct S {
+    float c: C;
+    float a: A;
+    float b: B;
+};
+
+struct T {
+    float e: E;
+    S     s;
+    float d: D;
+};
+
+// CHECK:      OpDecorate %in_var_N Location 0
+// CHECK-NEXT: OpDecorate %in_var_E Location 1
+// CHECK-NEXT: OpDecorate %in_var_C Location 2
+// CHECK-NEXT: OpDecorate %in_var_A Location 3
+// CHECK-NEXT: OpDecorate %in_var_B Location 4
+// CHECK-NEXT: OpDecorate %in_var_D Location 5
+// CHECK-NEXT: OpDecorate %in_var_M Location 6
+
+// CHECK-NEXT: OpDecorate %out_var_E Location 0
+// CHECK-NEXT: OpDecorate %out_var_C Location 1
+// CHECK-NEXT: OpDecorate %out_var_A Location 2
+// CHECK-NEXT: OpDecorate %out_var_B Location 3
+// CHECK-NEXT: OpDecorate %out_var_D Location 4
+// CHECK-NEXT: OpDecorate %out_var_Q Location 5
+// CHECK-NEXT: OpDecorate %out_var_P Location 6
+
+// Input semantics by declaration order: N, E, C, A, B, D, M
+//                 by alphabetic order:  A, B, C, D, E, M, N
+
+// Output semantics by declaration order: E, C, A, B, D, Q, P
+//                  by alphabetic order:  A, B, C, D, E, P, Q
+
+void main(in  float input1 : N,
+          in  T     input2 ,
+          in  float input3 : M,
+          out T     output1,
+          out float output2: Q,
+          out float output3: P
+         ) {
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.location.exp-in.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.location.exp-in.hlsl
@@ -28,7 +28,7 @@ float main([[vk::location(0)]] in  uint   m: M, // On function parameter --- M -
 // CHECK: OpDecorate %in_var_B Location 1
 // CHECK: OpDecorate %in_var_A Location 2
 
-// Alphabetical assignment
-// CHECK: OpDecorate %out_var_C Location 0
+// Declaration order assignment
+// CHECK: OpDecorate %out_var_R Location 0
 // CHECK: OpDecorate %out_var_N Location 1
-// CHECK: OpDecorate %out_var_R Location 2
+// CHECK: OpDecorate %out_var_C Location 2

--- a/tools/clang/test/CodeGenSPIRV/vk.location.exp-out.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.location.exp-out.hlsl
@@ -24,13 +24,12 @@ float main(                    in  uint   m: M,
     return 1.0;
 }
 
-// Alphabetical assignment
-// CHECK: OpDecorate %in_var_A Location 0
+// Declaration order assignment
+// CHECK: OpDecorate %in_var_M Location 0
 // CHECK: OpDecorate %in_var_B Location 1
-// CHECK: OpDecorate %in_var_M Location 2
+// CHECK: OpDecorate %in_var_A Location 2
 
 // Explicit assignment
 // CHECK: OpDecorate %out_var_R Location 2
 // CHECK: OpDecorate %out_var_N Location 0
 // CHECK: OpDecorate %out_var_C Location 1
-

--- a/tools/clang/tools/dxc/dxc.cpp
+++ b/tools/clang/tools/dxc/dxc.cpp
@@ -888,11 +888,6 @@ int __cdecl wmain(int argc, const wchar_t **argv_) {
       fprintf(stderr, "-spirv requires -Fo for output object file name.");
       return 1;
     }
-#else
-    if (dxcOpts.GenSPIRV) {
-      fprintf(stderr, "SPIR-V codegen not configured via ENABLE_SPIRV_CODEGEN");
-      return 1;
-    }
 #endif
     // SPIRV change ends
 

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -2362,7 +2362,9 @@ public:
       // SPIRV change starts
 #ifdef ENABLE_SPIRV_CODEGEN
       else if (opts.GenSPIRV) {
-          clang::EmitSPIRVAction action;
+          clang::EmitSPIRVOptions spirvOpts;
+          spirvOpts.stageIoOrder = opts.VkStageIoOrder;
+          clang::EmitSPIRVAction action(spirvOpts);
           FrontendInputFile file(utf8SourceName.m_psz, IK_HLSL);
           action.BeginSourceFile(compiler, file);
           action.Execute();

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -283,8 +283,11 @@ TEST_F(FileTest, SemanticIsFrontFacePS) {
   runFileTest("semantic.is-front-face.ps.hlsl");
 }
 TEST_F(FileTest, SemanticArbitrary) { runFileTest("semantic.arbitrary.hlsl"); }
-TEST_F(FileTest, SemanticArbitraryLocation) {
-  runFileTest("semantic.arbitrary.location.hlsl");
+TEST_F(FileTest, SemanticArbitraryDeclLocation) {
+  runFileTest("semantic.arbitrary.location.decl.hlsl");
+}
+TEST_F(FileTest, SemanticArbitraryAlphaLocation) {
+  runFileTest("semantic.arbitrary.location.alpha.hlsl");
 }
 TEST_F(FileTest, SemanticDuplication) {
   runFileTest("semantic.duplication.hlsl", /*expectSuccess*/ false);

--- a/tools/clang/unittests/SPIRV/FileTestFixture.cpp
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.cpp
@@ -46,8 +46,8 @@ bool FileTest::parseInputFile() {
   if (runCmdStartPos != std::string::npos) {
     const auto runCmdEndPos = checkCommands.find('\n', runCmdStartPos);
     const auto runCommand = checkCommands.substr(runCmdStartPos, runCmdEndPos);
-    if (!utils::processRunCommandArgs(runCommand, &targetProfile,
-                                      &entryPoint)) {
+    if (!utils::processRunCommandArgs(runCommand, &targetProfile, &entryPoint,
+                                      &restArgs)) {
       // An error has occured when parsing the Run command.
       return false;
     }
@@ -71,7 +71,7 @@ void FileTest::runFileTest(llvm::StringRef filename, bool expectSuccess,
 
   // Feed the HLSL source into the Compiler.
   const bool compileOk = utils::runCompilerWithSpirvGeneration(
-      inputFilePath, entryPoint, targetProfile, &generatedBinary,
+      inputFilePath, entryPoint, targetProfile, restArgs, &generatedBinary,
       &errorMessages);
 
   effcee::Result result(effcee::Result::Status::Ok);

--- a/tools/clang/unittests/SPIRV/FileTestFixture.h
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.h
@@ -34,6 +34,7 @@ private:
 
   std::string targetProfile;             ///< Target profile (argument of -T)
   std::string entryPoint;                ///< Entry point name (argument of -E)
+  std::string restArgs;                  ///< All the other arguments
   std::string inputFilePath;             ///< Path to the input test file
   std::vector<uint32_t> generatedBinary; ///< The generated SPIR-V Binary
   std::string checkCommands;             ///< CHECK commands that verify output

--- a/tools/clang/unittests/SPIRV/FileTestUtils.h
+++ b/tools/clang/unittests/SPIRV/FileTestUtils.h
@@ -35,10 +35,11 @@ bool disassembleSpirvBinary(std::vector<uint32_t> &binary,
 bool validateSpirvBinary(std::vector<uint32_t> &binary);
 
 /// \brief Parses the Target Profile and Entry Point from the Run command
-/// Returns the target profile and entry point via arguments.
+/// Returns the target profile, entry point, and the rest via arguments.
 /// Returns true on success, and false otherwise.
 bool processRunCommandArgs(const llvm::StringRef runCommandLine,
-                           std::string *targetProfile, std::string *entryPoint);
+                           std::string *targetProfile, std::string *entryPoint,
+                           std::string *restArgs);
 
 /// \brief Converts an IDxcBlob into a vector of 32-bit unsigned integers which
 /// is returned via the 'binaryWords' argument.
@@ -57,6 +58,7 @@ std::string getAbsPathOfInputDataFile(const llvm::StringRef filename);
 bool runCompilerWithSpirvGeneration(const llvm::StringRef inputFilePath,
                                     const llvm::StringRef entryPoint,
                                     const llvm::StringRef targetProfile,
+                                    const llvm::StringRef restArgs,
                                     std::vector<uint32_t> *generatedBinary,
                                     std::string *errorMessages);
 

--- a/tools/clang/unittests/SPIRV/WholeFileTestFixture.cpp
+++ b/tools/clang/unittests/SPIRV/WholeFileTestFixture.cpp
@@ -31,7 +31,8 @@ bool WholeFileTest::parseInputFile() {
     for (std::string line; std::getline(inputFile, line);) {
       if (line.find(hlslStartLabel) != std::string::npos) {
         foundRunCommand = true;
-        if (!utils::processRunCommandArgs(line, &targetProfile, &entryPoint)) {
+        if (!utils::processRunCommandArgs(line, &targetProfile, &entryPoint,
+                                          &restArgs)) {
           // An error has occured when parsing the Run command.
           return false;
         }
@@ -94,7 +95,7 @@ void WholeFileTest::runWholeFileTest(llvm::StringRef filename,
 
   // Feed the HLSL source into the Compiler.
   ASSERT_TRUE(utils::runCompilerWithSpirvGeneration(
-      inputFilePath, entryPoint, targetProfile, &generatedBinary,
+      inputFilePath, entryPoint, targetProfile, restArgs, &generatedBinary,
       &errorMessages));
 
   // Disassemble the generated SPIR-V binary.

--- a/tools/clang/unittests/SPIRV/WholeFileTestFixture.h
+++ b/tools/clang/unittests/SPIRV/WholeFileTestFixture.h
@@ -58,6 +58,7 @@ private:
 
   std::string targetProfile;             ///< Target profile (argument of -T)
   std::string entryPoint;                ///< Entry point name (argument of -E)
+  std::string restArgs;                  ///< All the other arguments
   std::string inputFilePath;             ///< Path to the input test file
   std::vector<uint32_t> generatedBinary; ///< The generated SPIR-V Binary
   std::string expectedSpirvAsm;          ///< Expected SPIR-V parsed from input


### PR DESCRIPTION
A new CL option -fvk-stage-io-order={alpha|decl} is added to
control the order for assigning stage I/O location numbers.
The default is also changed to declaration order (decl) instead
of alphabetical order (alpha).

Also extended testing fixtures to support additional CL options.