### PR TITLE
[linux-port] Fix DiagnosticPrinter use of std::hex

### DIFF
--- a/include/llvm/IR/DiagnosticPrinter.h
+++ b/include/llvm/IR/DiagnosticPrinter.h
@@ -55,6 +55,7 @@ public:
 
   // Other types.
   virtual DiagnosticPrinter &operator<<(const SMDiagnostic &Diag) = 0;
+  virtual DiagnosticPrinter &operator<<(std::ios_base &(*iomanip)(std::ios_base&)) = 0; // HLSL Change
 };
 
 /// \brief Basic diagnostic printer that uses an underlying raw_ostream.
@@ -88,6 +89,7 @@ public:
 
   // Other types.
   DiagnosticPrinter &operator<<(const SMDiagnostic &Diag) override;
+  DiagnosticPrinter &operator<<(std::ios_base &(*iomanip)(std::ios_base&)) override; // HLSL Change
 };
 } // End namespace llvm
 

--- a/include/llvm/Support/raw_ostream.h
+++ b/include/llvm/Support/raw_ostream.h
@@ -62,6 +62,9 @@ private:
   /// this buffer.
   char *OutBufStart, *OutBufEnd, *OutBufCur;
 
+  /// base in which numbers will be written. default is 10. 8 and 16 are also possible
+  int writeBase;  // HLSL Change
+
   enum BufferKind {
     Unbuffered = 0,
     InternalBuffer,
@@ -86,6 +89,7 @@ public:
       : BufferMode(unbuffered ? Unbuffered : InternalBuffer) {
     // Start out ready to flush.
     OutBufStart = OutBufEnd = OutBufCur = nullptr;
+    writeBase = 10; // HLSL Change
   }
 
   virtual ~raw_ostream();
@@ -215,6 +219,9 @@ public:
   /// Output \p N in hexadecimal, without any prefix or padding.
   raw_ostream &write_hex(unsigned long long N);
 
+  /// Output \p N in writeBase, without any prefix or padding.
+  raw_ostream &write_base(unsigned long long N); // HLSL Change
+
   /// Output \p Str, turning '\\', '\t', '\n', '"', and anything that doesn't
   /// satisfy std::isprint into an escape sequence.
   raw_ostream &write_escaped(StringRef Str, bool UseHexEscapes = false);
@@ -231,6 +238,8 @@ public:
   // Formatted output, see the formatHex() function in Support/Format.h.
   raw_ostream &operator<<(const FormattedNumber &);
   
+  raw_ostream &operator<<(std::ios_base &(*iomanip)(std::ios_base&));  // HLSL Change
+
   /// indent - Insert 'NumSpaces' spaces.
   raw_ostream &indent(unsigned NumSpaces);
 
@@ -404,7 +413,7 @@ public:
 
   /// Manually flush the stream and close the file. Note that this does not call
   /// fsync.
-  void close();
+  void close() override;
 
   bool supportsSeeking() { return SupportsSeeking; }
 

--- a/lib/HLSL/DxilRootSignature.cpp
+++ b/lib/HLSL/DxilRootSignature.cpp
@@ -483,8 +483,6 @@ void RootSignatureVerifier::AddRegisterRange(unsigned iRP,
   if (!m_bAllowReservedRegisterSpace &&
        (RegisterSpace >= DxilSystemReservedRegisterSpaceValuesStart) &&
        (RegisterSpace <= DxilSystemReservedRegisterSpaceValuesEnd)) {
-    // TODO(ehsann): Looks like llvm::DiagnosticPrinter does not play well with std::hex.
-    /*
     if (nt == DESCRIPTOR_TABLE_ENTRY) {
       EAT(DiagPrinter << "Root parameter [" << iRP << "] descriptor table entry [" << iDTS
                       << "] specifies RegisterSpace=" << std::hex << RegisterSpace
@@ -501,7 +499,6 @@ void RootSignatureVerifier::AddRegisterRange(unsigned iRP,
                       << "," << std::hex << DxilSystemReservedRegisterSpaceValuesEnd
                       << "] are reserved for system use.\n");
     }
-    */
   }
 
   const RegisterRange *pNode = nullptr;
@@ -634,11 +631,8 @@ void RootSignatureVerifier::VerifyRootSignature(
 
   // Flags (assume they are bits that can be combined with OR).
   if ((pRootSignature->Flags & ~DxilRootSignatureFlags::ValidFlags) != DxilRootSignatureFlags::None) {
-    // TODO(ehsann): Looks like llvm::DiagnosticPrinter does not play well with std::hex.
-    /*
     EAT(DiagPrinter << "Unsupported bit-flag set (root signature flags " 
                     << std::hex << (uint32_t)pRootSignature->Flags << ").\n");
-                    */
   }
 
   m_RootSignatureFlags = pRootSignature->Flags;

--- a/lib/IR/DiagnosticPrinter.cpp
+++ b/lib/IR/DiagnosticPrinter.cpp
@@ -96,6 +96,13 @@ DiagnosticPrinter &DiagnosticPrinterRawOStream::operator<<(const Twine &Str) {
   return *this;
 }
 
+// HLSL Change Starts
+DiagnosticPrinter &DiagnosticPrinterRawOStream::operator<<(std::ios_base &(*iomanip)(std::ios_base&)) {
+  Stream << iomanip;
+  return *this;
+}
+// HLSL Change Ends.
+
 // IR related types.
 DiagnosticPrinter &DiagnosticPrinterRawOStream::operator<<(const Value &V) {
   Stream << V.getName();

--- a/lib/Support/raw_ostream.cpp
+++ b/lib/Support/raw_ostream.cpp
@@ -107,6 +107,17 @@ void raw_ostream::SetBufferAndMode(_In_opt_ char *BufferStart, size_t Size,
 }
 
 raw_ostream &raw_ostream::operator<<(unsigned long N) {
+
+  // HLSL Change Starts - Handle non-base10 printing
+  if (writeBase != 10) {
+    *this << '0';
+    if (writeBase == 16)
+      *this << 'x';
+    return write_base((unsigned long long)N);
+  }
+  // HLSL Change Ends
+
+
   // Zero is a special case.
   if (N == 0)
     return *this << '0';
@@ -123,7 +134,7 @@ raw_ostream &raw_ostream::operator<<(unsigned long N) {
 }
 
 raw_ostream &raw_ostream::operator<<(long N) {
-  if (N <  0) {
+  if (N <  0 && writeBase == 10) {
     *this << '-';
     // Avoid undefined behavior on LONG_MIN with a cast.
     N = -(unsigned long)N;
@@ -137,6 +148,16 @@ raw_ostream &raw_ostream::operator<<(unsigned long long N) {
   if (N == static_cast<unsigned long>(N))
     return this->operator<<(static_cast<unsigned long>(N));
 
+
+  // HLSL Change Starts - Handle non-base10 printing
+  if (writeBase != 10) {
+    *this << '0';
+    if (writeBase == 16)
+      *this << 'x';
+    return write_base((unsigned long long)N);
+  }
+  // HLSL Change Ends
+
   char NumberBuffer[20];
   char *EndPtr = NumberBuffer+sizeof(NumberBuffer);
   char *CurPtr = EndPtr;
@@ -149,7 +170,7 @@ raw_ostream &raw_ostream::operator<<(unsigned long long N) {
 }
 
 raw_ostream &raw_ostream::operator<<(long long N) {
-  if (N < 0) {
+  if (N < 0 && writeBase == 10) {
     *this << '-';
     // Avoid undefined behavior on INT64_MIN with a cast.
     N = -(unsigned long long)N;
@@ -158,7 +179,16 @@ raw_ostream &raw_ostream::operator<<(long long N) {
   return this->operator<<(static_cast<unsigned long long>(N));
 }
 
+// HLSL Change Starts - Generalize non-base10 printing.
 raw_ostream &raw_ostream::write_hex(unsigned long long N) {
+  int oldBase = writeBase;
+  writeBase = 16;
+  raw_ostream &rv = write_base(N);
+  writeBase = oldBase;
+  return rv;
+}
+
+raw_ostream &raw_ostream::write_base(unsigned long long N) {
   // Zero is a special case.
   if (N == 0)
     return *this << '0';
@@ -168,13 +198,14 @@ raw_ostream &raw_ostream::write_hex(unsigned long long N) {
   char *CurPtr = EndPtr;
 
   while (N) {
-    uintptr_t x = N % 16;
+    uintptr_t x = N % writeBase;
     *--CurPtr = (x < 10 ? '0' + x : 'a' + x - 10);
-    N /= 16;
+    N /= writeBase;
   }
 
   return write(CurPtr, EndPtr-CurPtr);
 }
+// HLSL Change Ends
 
 raw_ostream &raw_ostream::write_escaped(StringRef Str,
                                         bool UseHexEscapes) {
@@ -456,6 +487,22 @@ raw_ostream &raw_ostream::operator<<(const FormattedNumber &FN) {
     return write(CurPtr, Len);
   }
 }
+
+
+// HLSL Change Starts - Add handling of numerical base IO manipulators.
+raw_ostream &raw_ostream::operator<<(std::ios_base &(*iomanip)(std::ios_base&))
+{
+  if (iomanip == std::hex)
+    writeBase = 16;
+  else if (iomanip == std::oct)
+    writeBase = 8;
+  else
+    writeBase = 10;
+
+  return *this;
+
+}
+// HLSL Change Ends
 
 
 /// indent - Insert 'NumSpaces' spaces.


### PR DESCRIPTION
DiagnosticPrinter doesn't support io manipulators like std::hex,
in spite of that, including them in the output stream with MSVC
succeeded because it interpretted std::hex as a void pointer, which
is supported.

This adds support of it by adding an overloaded operator<< that takes
the type of std::hex and its friends and sets a base number which is
used when the base is not 10 to print numbers in the specified base,
which can only be 8 or 16 according to what is passed in.

Fixes https://github.com/google/DirectXShaderCompiler/issues/170