### PR TITLE
[linux-port] Implement CA2W/CW2A conversion (#172)

### DIFF
--- a/include/dxc/Support/dxcapi.use.h
+++ b/include/dxc/Support/dxcapi.use.h
@@ -28,7 +28,7 @@ protected:
     ::dlclose(handle);
   }
   HMODULE LoadLibraryW(LPCWSTR name) {
-    return ::dlopen(CW2A(name).c_str(), RTLD_LAZY);
+    return ::dlopen(CW2A(name).m_psz, RTLD_LAZY);
   }
   HMODULE GetProcAddress(HMODULE dll, LPCSTR fnName) {
     return ::dlsym(dll, fnName);

--- a/include/llvm/Support/WinMacros.h
+++ b/include/llvm/Support/WinMacros.h
@@ -111,7 +111,7 @@
 #define vsprintf_s vsprintf
 #define strcat_s strcat
 
-#define OutputDebugStringW(msg) fprintf(stdout, CW2A(msg).c_str())
+#define OutputDebugStringW(msg) fprintf(stdout, CW2A(msg).m_psz)
 #define OutputDebugFormatA(...) fprintf(stdout, __VA_ARGS__)
 
 // Note: This will *disable* the CRITICAL_SECTION structures in the code.

--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -130,7 +130,7 @@ void ReadBinaryFile(IMalloc *pMalloc, LPCWSTR pFileName, void **ppData,
 
   #else
   // Open file
-  std::ifstream ifs(CW2A(pFileName).c_str(), std::ios::binary|std::ios::ate);
+  std::ifstream ifs(CW2A(pFileName).m_psz, std::ios::binary|std::ios::ate);
   if(ifs.fail()) {
     fprintf(stderr, "The system cannot file the file specified:");
     throw ::hlsl::Exception(GetLastError());

--- a/lib/DxcSupport/dxcapi.use.cpp
+++ b/lib/DxcSupport/dxcapi.use.cpp
@@ -118,7 +118,7 @@ void WriteBlobToFile(_In_opt_ IDxcBlob *pBlob, _In_ LPCWSTR pFileName) {
     IFT_Data(HRESULT_FROM_WIN32(GetLastError()), pFileName);
   }
   #else
-  std::ofstream outputFile (CW2A(pFileName).c_str(), std::ios::out | std::ios::binary);
+  std::ofstream outputFile (CW2A(pFileName).m_psz, std::ios::out | std::ios::binary);
   void *file = static_cast<void*>(&outputFile);
   #endif
   WriteBlobToHandle(pBlob, file, pFileName);

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -2203,21 +2203,9 @@ private:
 
     _firstChecked = true;
 
-#ifdef LLVM_ON_WIN32 // SPIRV change
     // TODO: review this - this will allocate at least once per string
     CA2WEX<> typeName(_typeName.str().c_str(), CP_UTF8);
     CA2WEX<> functionName(_functionName.str().c_str(), CP_UTF8);
-// SPIRV change starts
-#else
-    // Need to use mbstowcs as we don'thave CA2WEX.
-    const char* typeNameUtf8 = _typeName.str().c_str();
-    const char* functionNameUtf8 = _functionName.str().c_str();
-    wchar_t typeName[80];
-    wchar_t functionName[80];
-    std::mbstowcs(typeName, typeNameUtf8, strlen(typeNameUtf8) + 1);
-    std::mbstowcs(functionName, functionNameUtf8, strlen(functionNameUtf8) + 1);
-#endif
-// SPIRV change ends
 
     if (FAILED(_tables[_tableIndex]->LookupIntrinsic(
             typeName, functionName, &_tableIntrinsic, &_tableLookupCookie))) {
@@ -3490,17 +3478,8 @@ public:
       const HLSL_INTRINSIC *pIntrinsic = nullptr;
       const HLSL_INTRINSIC *pPrior = nullptr;
       UINT64 lookupCookie = 0;
-#ifdef LLVM_ON_WIN32 // SPIRV change
       CA2W wideTypeName(typeName);
       HRESULT found = table->LookupIntrinsic(wideTypeName, L"*", &pIntrinsic, &lookupCookie);
-// SPIRV change starts
-#else
-      // Need to use mbstowcs as we don'thave CA2WEX.
-      wchar_t wideTypeName[80];
-      std::mbstowcs(wideTypeName, typeName, strlen(typeName) + 1);
-      HRESULT found = table->LookupIntrinsic(wideTypeName, L"*", &pIntrinsic, &lookupCookie);
-#endif
-// SPIRV change ends
       while (pIntrinsic != nullptr && SUCCEEDED(found)) {
         if (!AreIntrinsicTemplatesEquivalent(pIntrinsic, pPrior)) {
           AddObjectIntrinsicTemplate(recordDecl, startDepth, pIntrinsic);

--- a/tools/clang/tools/dxc/dxc.cpp
+++ b/tools/clang/tools/dxc/dxc.cpp
@@ -939,7 +939,7 @@ void DxcContext::WriteHeader(IDxcBlobEncoding *pDisassembly, IDxcBlob *pCode,
     IFT_Data(HRESULT_FROM_WIN32(GetLastError()), pFileName);
   }
   #else
-  std::ofstream outputFile (CW2A(pFileName).c_str(), std::ios::out | std::ios::binary);
+  std::ofstream outputFile (CW2A(pFileName).m_psz, std::ios::out | std::ios::binary);
   void *file = static_cast<void*>(&outputFile);
   #endif
 


### PR DESCRIPTION
Add a non-windows implementation of CW2AEX and CA2WEX using std::
character conversion functions to WinTypes.h header. Includes
CW2A and CW2A macros the same way Windows does

fix https://github.com/google/DirectXShaderCompiler/issues/172