### PR TITLE
Fix cmake for non-appveyor buildbot environments.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ option(HLSL_ENABLE_ANALYZE "Enables compiler analysis during compilation." OFF) 
 option(HLSL_OPTIONAL_PROJS_IN_DEFAULT "Include optional projects in default build target." OFF) # HLSL Change
 
 # HLSL Change Starts - set flag for Appveyor CI
-if ( $ENV{CI} AND $ENV{APPVEYOR} )
+if ( "$ENV{CI}" AND "$ENV{APPVEYOR}" )
   add_definitions(-DDXC_ON_APPVEYOR_CI)
 endif()
 # HLSL Change ends


### PR DESCRIPTION
This should fix the Travis failures we are seeing.