### PR TITLE
[linux-port] Disable unknown pragma warnings

### DIFF
--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -371,6 +371,8 @@ elseif( LLVM_COMPILER_IS_GCC_COMPATIBLE )
     append("-Wall -W -Wno-unused-parameter -Wwrite-strings" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
     append("-Wcast-qual" CMAKE_CXX_FLAGS)
 
+    append("-Wno-unknown-pragmas" CMAKE_C_FLAGS CMAKE_CXX_FLAGS) # SPIRV Change
+
     # Turn off missing field initializer warnings for gcc to avoid noise from
     # false positives with empty {}. Turn them on otherwise (they're off by
     # default for clang).


### PR DESCRIPTION
The source code contains lots of pragmas specific to MSVC, which
causes GCC/Clang to flood the build output channel.