### PR TITLE
[spirv] Fix function parameter evaluation order.

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1428,9 +1428,10 @@ bool DeclResultIdMapper::createStageVars(const hlsl::SigPoint *sigPoint,
       // represents a Boolean value where false must be exactly 0, but true can
       // be any odd (i.e. bit 0 set) non-zero value)."
       else if (semanticKind == hlsl::Semantic::Kind::InnerCoverage) {
+        const auto constOne = theBuilder.getConstantUint32(1);
+        const auto constZero = theBuilder.getConstantUint32(0);
         *value = theBuilder.createSelect(theBuilder.getUint32Type(), *value,
-                                         theBuilder.getConstantUint32(1),
-                                         theBuilder.getConstantUint32(0));
+                                         constOne, constZero);
       }
       // Special handling of SV_Barycentrics, which is a float3, but the
       // underlying stage input variable is a float2 (only provides the first

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -9438,11 +9438,12 @@ bool SPIRVEmitter::processHSEntryPointOutputAndPCF(
   // Now create a barrier before calling the Patch Constant Function (PCF).
   // Flags are:
   // Execution Barrier scope = Workgroup (2)
-  // Memory Barrier scope = Device (1)
+  // Memory Barrier scope = Invocation (4)
   // Memory Semantics Barrier scope = None (0)
-  theBuilder.createBarrier(theBuilder.getConstantUint32(2),
-                           theBuilder.getConstantUint32(4),
-                           theBuilder.getConstantUint32(0));
+  const auto constZero = theBuilder.getConstantUint32(0);
+  const auto constFour = theBuilder.getConstantUint32(4);
+  const auto constTwo = theBuilder.getConstantUint32(2);
+  theBuilder.createBarrier(constTwo, constFour, constZero);
 
   // The PCF should be called only once. Therefore, we check the invocationID,
   // and we only allow ID 0 to call the PCF.


### PR DESCRIPTION
I have already posted this to upstream. It'll be needed in order get SPIRV CodeGen tests passing.
Since it was reviewed there, I'll merge it once the bots pass.
