### PR TITLE
[linux-port] Fix a handful of warnings in headers

### DIFF
--- a/include/dxc/HLSL/DxilConstants.h
+++ b/include/dxc/HLSL/DxilConstants.h
@@ -965,22 +965,12 @@ namespace DXIL {
   };
 
 
-  // TODO: revisit data layout descriptions for the following:
-  //      - x64 pointers?
-  //      - Keep elf manging(m:e)?
-
-  // For legacy data layout, everything less than 32 align to 32.
-  static const char* kLegacyLayoutString = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f:64:64-n8:16:32:64";
-
-  // New data layout with native low precision types
-  static const char* kNewLayoutString = "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64";
-
-  // Function Attributes
-  // TODO: consider generating attributes from hctdb
-  static const char* kFP32DenormKindString          = "fp32-denorm-mode";
-  static const char* kFP32DenormValueAnyString      = "any";
-  static const char* kFP32DenormValuePreserveString = "preserve";
-  static const char* kFP32DenormValueFtzString      = "ftz";
+  extern const char* kLegacyLayoutString;
+  extern const char* kNewLayoutString;
+  extern const char* kFP32DenormKindString;
+  extern const char* kFP32DenormValueAnyString;
+  extern const char* kFP32DenormValuePreserveString;
+  extern const char* kFP32DenormValueFtzString;
 
 } // namespace DXIL
 

--- a/include/dxc/Support/Global.h
+++ b/include/dxc/Support/Global.h
@@ -210,7 +210,7 @@ inline void OutputDebugFormatA(_In_ _Printf_format_string_ _Null_terminated_ con
 #define DXASSERT(expr, msg) do { if (!(expr)) { assert(false && msg); } } while (0);
 #define DXASSERT_LOCALVAR(local, exp, msg) DXASSERT(exp, msg)
 #define DXVERIFY_NOMSG assert
-#define DXASSERT(expr, fmt, ...) do { if (!(expr)) { char msg[80]; sprintf(msg, fmt, ##__VA_ARGS__); assert(false && msg); } } while (0);
+#define DXASSERT(expr, fmt, ...) do { if (!(expr)) { fprintf(stderr, fmt, ##__VA_ARGS__); assert(false); } } while (0);
 #endif
 
 #else

--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -120,15 +120,15 @@ struct MatrixMemberAccessPositions {
     default:
     case 3: *row = R3_Row; *col = R3_Col; break;
     }
-    assert(0 <= *row && *row <= 3);
-    assert(0 <= *col && *col <= 3);
+    assert(*row <= 3);
+    assert(*col <= 3);
   }
 
   void SetPosition(uint32_t index, uint32_t row, uint32_t col)
   {
     assert(index < 4);
-    assert(0 <= row && row <= 3);
-    assert(0 <= col && col <= 3);
+    assert(row <= 3);
+    assert(col <= 3);
     switch (index)
     {
     case 0: R0_Row = row; R0_Col = col; break;
@@ -171,13 +171,13 @@ struct VectorMemberAccessPositions {
     default:
     case 3: *col = Swz3; break;
     }
-    assert(0 <= *col && *col <= 3);
+    assert(*col <= 3);
   }
 
   void SetPosition(uint32_t index, uint32_t col)
   {
     assert(index < 4);
-    assert(0 <= col && col <= 3);
+    assert(col <= 3);
     switch (index)
     {
     case 0: Swz0 = col; break;

--- a/tools/clang/include/clang/AST/Type.h
+++ b/tools/clang/include/clang/AST/Type.h
@@ -3298,7 +3298,7 @@ public:
   }
   const hlsl::ParameterModifier *parammods_begin() const {
     // param modifiers begin where exceptions end
-    return (hlsl::ParameterModifier*)exception_end();
+    return (const hlsl::ParameterModifier*)exception_end();
   }
   const hlsl::ParameterModifier *parammods_end() const {
     // modifiers begin where arguments end (in place of exceptions, in HLSL)

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -53,6 +53,28 @@ using std::unique_ptr;
 
 static const bool KeepUndefinedTrue = true; // Keep interpolation mode undefined if not set explicitly.
 
+// Define constant variables exposed in DxilConstants.h
+namespace hlsl {
+namespace DXIL {
+  // TODO: revisit data layout descriptions for the following:
+  //      - x64 pointers?
+  //      - Keep elf manging(m:e)?
+
+  // For legacy data layout, everything less than 32 align to 32.
+  const char* kLegacyLayoutString = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f:64:64-n8:16:32:64";
+
+  // New data layout with native low precision types
+  const char* kNewLayoutString = "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64";
+
+  // Function Attributes
+  // TODO: consider generating attributes from hctdb
+  const char* kFP32DenormKindString          = "fp32-denorm-mode";
+  const char* kFP32DenormValueAnyString      = "any";
+  const char* kFP32DenormValuePreserveString = "preserve";
+  const char* kFP32DenormValueFtzString      = "ftz";
+} // DXIL
+} // hlsl
+
 namespace {
 
 /// Use this class to represent HLSL cbuffer in high-level DXIL.


### PR DESCRIPTION
Just a few warning conditions in a handful of common headers
was producing pages and pages of warning messages. By fixing them,
the output spew is reduced significantly.

Static variables in a header produce a separate variable for every
file that includes it. In many of these, these variables were unused.
Instead, variables used in multiple files should be defined only
once in a source file and declared as extern in the header.

The implementation of DXASSERT for non-MS platforms in Global.h
included a character array as part of the assert conditional
which is always true, producing a warning. Furthermore, I don't
think this would do what was expected as it would present no
string. Instead, the message is printed out and an assert is raised.

Many unsigned variables were checked to be greater than zero and less
than 3 in HlslTypes.h. If they were somehow assigned a negative
value, it would appear as much greater than 3 in unsigned form.
So we can just check that they are less than or equal to 3.

In Type.h, parammods_begin() was casting its return value to the
proper pointer, but without const, producing an error. The best
part is that the function returned a const pointer. The cast was
just wrong. Adding const silences the warning.

Facilitates https://github.com/google/DirectXShaderCompiler/issues/184