### PR TITLE
[linux-port] Allow GCC5 compiling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,11 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - ninja-build
-      - g++-6
+      - g++-5
 
 before_script:
   - git submodule update --init
-  - if [ ${CC} = gcc ]; then CC=gcc-6; CXX=g++-6; fi
+  - if [ ${CC} = gcc ]; then CC=gcc-5; CXX=g++-5; fi
 
 script:
   - mkdir build && cd build

--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -377,6 +377,7 @@ elseif( LLVM_COMPILER_IS_GCC_COMPATIBLE )
     # Colorize GCC output even with ninja's stdout redirection.
     if (CMAKE_COMPILER_IS_GNUCXX)
        append("-fdiagnostics-color" CMAKE_C_FLAGS CMAKE_CXX_FLAGS) # SPIRV Change
+       append("-std=c++11" CMAKE_CXX_FLAGS) # SPIRV Change
     endif (CMAKE_COMPILER_IS_GNUCXX)
 
     # Turn off missing field initializer warnings for gcc to avoid noise from

--- a/lib/HLSL/DxilDebugInstrumentation.cpp
+++ b/lib/HLSL/DxilDebugInstrumentation.cpp
@@ -158,7 +158,7 @@ private:
       unsigned PrimitiveId;
       unsigned InstanceId;
     } GeometryShader;
-  } m_Parameters = { 0,0,0 };
+  } m_Parameters = { {0,0,0} };
 
   union SystemValueIndices {
     struct PixelShaderParameters {

--- a/lib/HLSL/DxilOperations.cpp
+++ b/lib/HLSL/DxilOperations.cpp
@@ -317,9 +317,9 @@ const char *OP::GetOverloadTypeName(unsigned TypeSlot) {
   return m_OverloadTypeName[TypeSlot];
 }
 
-const char *OP::GetOpCodeName(OpCode OpCode) {
-  DXASSERT(0 <= (unsigned)OpCode && OpCode < OpCode::NumOpCodes, "otherwise caller passed OOB index");
-  return m_OpCodeProps[(unsigned)OpCode].pOpCodeName;
+const char *OP::GetOpCodeName(OpCode opCode) {
+  DXASSERT(0 <= (unsigned)opCode && opCode < OpCode::NumOpCodes, "otherwise caller passed OOB index");
+  return m_OpCodeProps[(unsigned)opCode].pOpCodeName;
 }
 
 const char *OP::GetAtomicOpName(DXIL::AtomicBinOpCode OpCode) {
@@ -328,20 +328,20 @@ const char *OP::GetAtomicOpName(DXIL::AtomicBinOpCode OpCode) {
   return AtomicBinOpCodeName[static_cast<unsigned>(OpCode)];
 }
 
-OP::OpCodeClass OP::GetOpCodeClass(OpCode OpCode) {
-  DXASSERT(0 <= (unsigned)OpCode && OpCode < OpCode::NumOpCodes, "otherwise caller passed OOB index");
-  return m_OpCodeProps[(unsigned)OpCode].opCodeClass;
+OP::OpCodeClass OP::GetOpCodeClass(OpCode opCode) {
+  DXASSERT(0 <= (unsigned)opCode && opCode < OpCode::NumOpCodes, "otherwise caller passed OOB index");
+  return m_OpCodeProps[(unsigned)opCode].opCodeClass;
 }
 
-const char *OP::GetOpCodeClassName(OpCode OpCode) {
-  DXASSERT(0 <= (unsigned)OpCode && OpCode < OpCode::NumOpCodes, "otherwise caller passed OOB index");
-  return m_OpCodeProps[(unsigned)OpCode].pOpCodeClassName;
+const char *OP::GetOpCodeClassName(OpCode opCode) {
+  DXASSERT(0 <= (unsigned)opCode && opCode < OpCode::NumOpCodes, "otherwise caller passed OOB index");
+  return m_OpCodeProps[(unsigned)opCode].pOpCodeClassName;
 }
 
-bool OP::IsOverloadLegal(OpCode OpCode, Type *pType) {
-  DXASSERT(0 <= (unsigned)OpCode && OpCode < OpCode::NumOpCodes, "otherwise caller passed OOB index");
+bool OP::IsOverloadLegal(OpCode opCode, Type *pType) {
+  DXASSERT(0 <= (unsigned)opCode && opCode < OpCode::NumOpCodes, "otherwise caller passed OOB index");
   unsigned TypeSlot = GetTypeSlot(pType);
-  return TypeSlot != UINT_MAX && m_OpCodeProps[(unsigned)OpCode].bAllowOverload[TypeSlot];
+  return TypeSlot != UINT_MAX && m_OpCodeProps[(unsigned)opCode].bAllowOverload[TypeSlot];
 }
 
 bool OP::CheckOpCodeTable() {
@@ -502,12 +502,12 @@ void OP::UpdateCache(OpCodeClass opClass, unsigned typeSlot, llvm::Function *F) 
   m_FunctionToOpClass[F] = opClass;
 }
 
-Function *OP::GetOpFunc(OpCode OpCode, Type *pOverloadType) {
-  DXASSERT(0 <= (unsigned)OpCode && OpCode < OpCode::NumOpCodes, "otherwise caller passed OOB OpCode");
-  _Analysis_assume_(0 <= (unsigned)OpCode && OpCode < OpCode::NumOpCodes);
-  DXASSERT(IsOverloadLegal(OpCode, pOverloadType), "otherwise the caller requested illegal operation overload (eg HLSL function with unsupported types for mapped intrinsic function)");
+Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
+  DXASSERT(0 <= (unsigned)opCode && opCode < OpCode::NumOpCodes, "otherwise caller passed OOB OpCode");
+  _Analysis_assume_(0 <= (unsigned)opCode && opCode < OpCode::NumOpCodes);
+  DXASSERT(IsOverloadLegal(opCode, pOverloadType), "otherwise the caller requested illegal operation overload (eg HLSL function with unsupported types for mapped intrinsic function)");
   unsigned TypeSlot = GetTypeSlot(pOverloadType);
-  OpCodeClass opClass = m_OpCodeProps[(unsigned)OpCode].opCodeClass;
+  OpCodeClass opClass = m_OpCodeProps[(unsigned)opCode].opCodeClass;
   Function *&F = m_OpCodeClassCache[(unsigned)opClass].pOverloads[TypeSlot];
   if (F != nullptr) {
     UpdateCache(opClass, TypeSlot, F);
@@ -535,7 +535,7 @@ Function *OP::GetOpFunc(OpCode OpCode, Type *pOverloadType) {
   Type *pSDT = GetSplitDoubleType();  // Split double type.
   Type *pI4S = GetInt4Type(); // 4 i32s in a struct.
 
-  std::string funcName = (Twine(OP::m_NamePrefix) + Twine(GetOpCodeClassName(OpCode))).str();
+  std::string funcName = (Twine(OP::m_NamePrefix) + Twine(GetOpCodeClassName(opCode))).str();
   // Add ret type to the name.
   if (pOverloadType != pV) {
     funcName = Twine(funcName).concat(".").concat(GetOverloadTypeName(TypeSlot)).str();
@@ -552,7 +552,7 @@ Function *OP::GetOpFunc(OpCode OpCode, Type *pOverloadType) {
 #define CBRT(_y) A(GetCBufferRetType(_y))
 
 /* <py::lines('OPCODE-OLOAD-FUNCS')>hctdb_instrhelp.get_oloads_funcs()</py>*/
-  switch (OpCode) {            // return     OpCode
+  switch (opCode) {            // return     opCode
 // OPCODE-OLOAD-FUNCS:BEGIN
     // Temporary, indexable, input, output registers
   case OpCode::TempRegLoad:            A(pETy);     A(pI32); A(pI32); break;
@@ -791,16 +791,16 @@ Function *OP::GetOpFunc(OpCode OpCode, Type *pOverloadType) {
   UpdateCache(opClass, TypeSlot, F);
   F->setCallingConv(CallingConv::C);
   F->addFnAttr(Attribute::NoUnwind);
-  if (m_OpCodeProps[(unsigned)OpCode].FuncAttr != Attribute::None)
-    F->addFnAttr(m_OpCodeProps[(unsigned)OpCode].FuncAttr);
+  if (m_OpCodeProps[(unsigned)opCode].FuncAttr != Attribute::None)
+    F->addFnAttr(m_OpCodeProps[(unsigned)opCode].FuncAttr);
 
   return F;
 }
 
-llvm::ArrayRef<llvm::Function *> OP::GetOpFuncList(OpCode OpCode) const {
-  DXASSERT(0 <= (unsigned)OpCode && OpCode < OpCode::NumOpCodes, "otherwise caller passed OOB OpCode");
-  _Analysis_assume_(0 <= (unsigned)OpCode && OpCode < OpCode::NumOpCodes);
-  return m_OpCodeClassCache[(unsigned)m_OpCodeProps[(unsigned)OpCode].opCodeClass].pOverloads;
+llvm::ArrayRef<llvm::Function *> OP::GetOpFuncList(OpCode opCode) const {
+  DXASSERT(0 <= (unsigned)opCode && opCode < OpCode::NumOpCodes, "otherwise caller passed OOB OpCode");
+  _Analysis_assume_(0 <= (unsigned)opCode && opCode < OpCode::NumOpCodes);
+  return llvm::ArrayRef<llvm::Function *>(m_OpCodeClassCache[(unsigned)m_OpCodeProps[(unsigned)opCode].opCodeClass].pOverloads);
 }
 
 void OP::RemoveFunction(Function *F) {
@@ -847,12 +847,12 @@ uint64_t OP::GetAllocSizeForType(llvm::Type *Ty) {
   return m_pModule->getDataLayout().getTypeAllocSize(Ty);
 }
 
-llvm::Type *OP::GetOverloadType(OpCode OpCode, llvm::Function *F) {
+llvm::Type *OP::GetOverloadType(OpCode opCode, llvm::Function *F) {
   DXASSERT(F, "not work on nullptr");
   Type *Ty = F->getReturnType();
   FunctionType *FT = F->getFunctionType();
 /* <py::lines('OPCODE-OLOAD-TYPES')>hctdb_instrhelp.get_funcs_oload_type()</py>*/
-  switch (OpCode) {            // return     OpCode
+  switch (opCode) {            // return     OpCode
   // OPCODE-OLOAD-TYPES:BEGIN
   case OpCode::TempRegStore:
     DXASSERT_NOMSG(FT->getNumParams() > 2);

--- a/lib/HLSL/DxilShaderModel.cpp
+++ b/lib/HLSL/DxilShaderModel.cpp
@@ -87,19 +87,19 @@ const ShaderModel *ShaderModel::Get(Kind Kind, unsigned Major, unsigned Minor) {
 
 const ShaderModel *ShaderModel::GetByName(const char *pszName) {
   // [ps|vs|gs|hs|ds|cs]_[major]_[minor]
-  Kind Kind;
+  Kind kind;
   switch (pszName[0]) {
-  case 'p':   Kind = Kind::Pixel;     break;
-  case 'v':   Kind = Kind::Vertex;    break;
-  case 'g':   Kind = Kind::Geometry;  break;
-  case 'h':   Kind = Kind::Hull;      break;
-  case 'd':   Kind = Kind::Domain;    break;
-  case 'c':   Kind = Kind::Compute;   break;
-  case 'l':   Kind = Kind::Library;   break;
+  case 'p':   kind = Kind::Pixel;     break;
+  case 'v':   kind = Kind::Vertex;    break;
+  case 'g':   kind = Kind::Geometry;  break;
+  case 'h':   kind = Kind::Hull;      break;
+  case 'd':   kind = Kind::Domain;    break;
+  case 'c':   kind = Kind::Compute;   break;
+  case 'l':   kind = Kind::Library;   break;
   default:    return GetInvalid();
   }
   unsigned Idx = 3;
-  if (Kind != Kind::Library) {
+  if (kind != Kind::Library) {
     if (pszName[1] != 's' || pszName[2] != '_')
       return GetInvalid();
   } else {
@@ -139,7 +139,7 @@ const ShaderModel *ShaderModel::GetByName(const char *pszName) {
   if (pszName[Idx++] != 0)
     return GetInvalid();
 
-  return Get(Kind, Major, Minor);
+  return Get(kind, Major, Minor);
 }
 
 void ShaderModel::GetDxilVersion(unsigned &DxilMajor, unsigned &DxilMinor) const {

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -3620,7 +3620,7 @@ struct PointerStatus {
     /// This ptr is stored to by multiple values or something else that we
     /// cannot track.
     Stored
-  } StoredType;
+  } storedType;
   /// Keep track of what loaded from the pointer look like.
   enum LoadedType {
     /// There is no load to this pointer.  It can thus be marked constant.
@@ -3632,7 +3632,7 @@ struct PointerStatus {
     /// This ptr is loaded to by multiple instructions or something else that we
     /// cannot track.
     Loaded
-  } LoadedType;
+  } loadedType;
   /// If only one value (besides the initializer constant) is ever stored to
   /// this global, keep track of what value it is.
   Value *StoredOnceValue;
@@ -3657,15 +3657,15 @@ struct PointerStatus {
                              DxilTypeSystem &typeSys, bool bStructElt);
 
   PointerStatus(unsigned size)
-      : StoredType(NotStored), LoadedType(NotLoaded), StoredOnceValue(nullptr),
+      : storedType(StoredType::NotStored), loadedType(NotLoaded), StoredOnceValue(nullptr),
         StoringMemcpy(nullptr), LoadingMemcpy(nullptr),
         AccessingFunction(nullptr), HasMultipleAccessingFunctions(false),
         Size(size) {}
   void MarkAsStored() {
-    StoredType = StoredType::Stored;
+    storedType = StoredType::Stored;
     StoredOnceValue = nullptr;
   }
-  void MarkAsLoaded() { LoadedType = LoadedType::Loaded; }
+  void MarkAsLoaded() { loadedType = LoadedType::Loaded; }
 };
 
 void PointerStatus::analyzePointer(const Value *V, PointerStatus &PS,
@@ -3696,8 +3696,8 @@ void PointerStatus::analyzePointer(const Value *V, PointerStatus &PS,
         }
         if (MC->getRawDest() == V) {
           if (bFullCopy &&
-              PS.StoredType == StoredType::NotStored) {
-            PS.StoredType = StoredType::MemcopyDestOnce;
+              PS.storedType == StoredType::NotStored) {
+            PS.storedType = StoredType::MemcopyDestOnce;
             PS.StoringMemcpy = MI;
           } else {
             PS.MarkAsStored();
@@ -3705,8 +3705,8 @@ void PointerStatus::analyzePointer(const Value *V, PointerStatus &PS,
           }
         } else if (MC->getRawSource() == V) {
           if (bFullCopy &&
-              PS.LoadedType == LoadedType::NotLoaded) {
-            PS.LoadedType = LoadedType::MemcopySrcOnce;
+              PS.loadedType == LoadedType::NotLoaded) {
+            PS.loadedType = LoadedType::MemcopySrcOnce;
             PS.LoadingMemcpy = MI;
           } else {
             PS.MarkAsLoaded();
@@ -3732,8 +3732,8 @@ void PointerStatus::analyzePointer(const Value *V, PointerStatus &PS,
     } else if (const StoreInst *SI = dyn_cast<StoreInst>(U)) {
       Value *V = SI->getOperand(0);
 
-      if (PS.StoredType == StoredType::NotStored) {
-        PS.StoredType = StoredType::StoredOnce;
+      if (PS.storedType == StoredType::NotStored) {
+        PS.storedType = StoredType::StoredOnce;
         PS.StoredOnceValue = V;
       } else {
         PS.MarkAsStored();
@@ -3983,9 +3983,9 @@ bool SROA_Helper::LowerMemcpy(Value *V, DxilFieldAnnotation *annotation,
 
   if (GlobalVariable *GV = dyn_cast<GlobalVariable>(V)) {
     if (GV->hasInitializer() && !isa<UndefValue>(GV->getInitializer())) {
-      if (PS.StoredType == PointerStatus::StoredType::NotStored) {
-        PS.StoredType = PointerStatus::StoredType::InitializerStored;
-      } else if (PS.StoredType == PointerStatus::StoredType::MemcopyDestOnce) {
+      if (PS.storedType == PointerStatus::StoredType::NotStored) {
+        PS.storedType = PointerStatus::StoredType::InitializerStored;
+      } else if (PS.storedType == PointerStatus::StoredType::MemcopyDestOnce) {
         // For single mem store, if the store not dominator all users.
         // Makr it as Stored.
         // Case like:
@@ -3997,17 +3997,17 @@ bool SROA_Helper::LowerMemcpy(Value *V, DxilFieldAnnotation *annotation,
         if (isa<ConstantAggregateZero>(GV->getInitializer())) {
           Instruction * Memcpy = PS.StoringMemcpy;
           if (!ReplaceUseOfZeroInitBeforeDef(Memcpy, GV)) {
-            PS.StoredType = PointerStatus::StoredType::Stored;
+            PS.storedType = PointerStatus::StoredType::Stored;
           }
         }
       } else {
-        PS.StoredType = PointerStatus::StoredType::Stored;
+        PS.storedType = PointerStatus::StoredType::Stored;
       }
     }
   }
 
   if (bAllowReplace && !PS.HasMultipleAccessingFunctions) {
-    if (PS.StoredType == PointerStatus::StoredType::MemcopyDestOnce &&
+    if (PS.storedType == PointerStatus::StoredType::MemcopyDestOnce &&
         // Skip argument for input argument has input value, it is not dest once anymore.
         !isa<Argument>(V)) {
       // Replace with src of memcpy.
@@ -4041,13 +4041,13 @@ bool SROA_Helper::LowerMemcpy(Value *V, DxilFieldAnnotation *annotation,
           // Check Src only have 1 store now.
           PointerStatus SrcPS(size);
           PointerStatus::analyzePointer(Src, SrcPS, typeSys, bStructElt);
-          if (SrcPS.StoredType != PointerStatus::StoredType::Stored) {
+          if (SrcPS.storedType != PointerStatus::StoredType::Stored) {
             ReplaceMemcpy(V, Src, MC);
             return true;
           }
         }
       }
-    } else if (PS.LoadedType == PointerStatus::LoadedType::MemcopySrcOnce) {
+    } else if (PS.loadedType == PointerStatus::LoadedType::MemcopySrcOnce) {
       // Replace dst of memcpy.
       MemCpyInst *MC = PS.LoadingMemcpy;
       if (MC->getSourceAddressSpace() == MC->getDestAddressSpace()) {
@@ -4064,7 +4064,7 @@ bool SROA_Helper::LowerMemcpy(Value *V, DxilFieldAnnotation *annotation,
           // Check Dest only have 1 store now.
           PointerStatus DestPS(size);
           PointerStatus::analyzePointer(Dest, DestPS, typeSys, bStructElt);
-          if (DestPS.StoredType != PointerStatus::StoredType::Stored) {
+          if (DestPS.storedType != PointerStatus::StoredType::Stored) {
             ReplaceMemcpy(Dest, V, MC);
             // V still need to be flatten.
             // Lower memcpy come from Dest.
@@ -6552,8 +6552,8 @@ bool LowerStaticGlobalIntoAlloca::lowerStaticGlobalIntoAlloca(GlobalVariable *GV
   PointerStatus PS(size);
   GV->removeDeadConstantUsers();
   PS.analyzePointer(GV, PS, typeSys, /*bStructElt*/ false);
-  bool NotStored = (PS.StoredType == PointerStatus::NotStored) ||
-                   (PS.StoredType == PointerStatus::InitializerStored);
+  bool NotStored = (PS.storedType == PointerStatus::StoredType::NotStored) ||
+                   (PS.storedType == PointerStatus::StoredType::InitializerStored);
   // Make sure GV only used in one function.
   // Skip GV which don't have store.
   if (PS.HasMultipleAccessingFunctions || NotStored)


### PR DESCRIPTION
GCC5 has a few limitations that later versions do not. The
most pervasive issue is the confusion of scoped operators on enum
names when the name of the enum is shared with a local variable.

The only other issue concerns intialization of a union containing
structs and how many curly braces is enough.

Added the --std=c++11 flag because it is not enabled by default in
GCC prior to 6 and 6 doesn't mind if you specify it redundantly.

Addresses https://github.com/google/DirectXShaderCompiler/issues/196