### PR TITLE
[linux-port] fix refcounting on imalloc and others

### DIFF
--- a/include/llvm/Support/WinMacros.h
+++ b/include/llvm/Support/WinMacros.h
@@ -22,8 +22,8 @@
 
 
 // TODO (ehsann): These are not atomic.
-#define InterlockedIncrement(x) *x+1
-#define InterlockedDecrement(x) *x-1
+#define InterlockedIncrement(x) ++*x
+#define InterlockedDecrement(x) --*x
 
 #define UNREFERENCED_PARAMETER(P) (P)
 

--- a/include/llvm/Support/WinTypes.h
+++ b/include/llvm/Support/WinTypes.h
@@ -289,8 +289,7 @@ struct IMalloc : public IUnknown {
   }
 };
 
-#define CoGetMalloc(dwMemContext, ppMalloc) \
-  (*ppMalloc = new IMalloc) && true
+HRESULT CoGetMalloc(DWORD dwMemContext, IMalloc **ppMalloc);
 
 // Stuff...
 typedef void *HANDLE;

--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -827,7 +827,7 @@ public:
   ULONG STDMETHODCALLTYPE Release() {
     // Because memory streams are also used by tests and utilities,
     // we avoid using TLS.
-    ULONG result = InterlockedDecrement(&m_dwRef); \
+    ULONG result = InterlockedDecrement(&m_dwRef);
     if (result == 0) {
       CComPtr<IMalloc> pTmp(m_pMalloc);
       this->~MemoryStream();

--- a/lib/DxcSupport/dxcmem.cpp
+++ b/lib/DxcSupport/dxcmem.cpp
@@ -135,3 +135,11 @@ IMalloc *DxcSwapThreadMalloc(IMalloc *pMalloc, IMalloc **ppPrior) throw() {
 IMalloc *DxcSwapThreadMallocOrDefault(IMalloc *pMallocOrNull, IMalloc **ppPrior) throw() {
   return DxcSwapThreadMalloc(pMallocOrNull ? pMallocOrNull : g_pDefaultMalloc, ppPrior);
 }
+
+#ifndef _WIN32
+HRESULT CoGetMalloc(DWORD dwMemContext, IMalloc **ppMalloc) {
+  *ppMalloc = new IMalloc;
+  (*ppMalloc)->AddRef();
+  return S_OK;
+}
+#endif


### PR DESCRIPTION
The previous macro for InterlockedIncrement and InterlockedDecrement
didn't affect the parameter, rather it only returned the correct
result. This caused some subtle memory leaks, that, when fixed,
caused segfaults because an IMalloc structure was being used after
it had been freed because a refcount increment was missing during
CoGetMalloc, which allocates a brand new malloc and assigns it to
the given parameter, which creates a new reference.

Specifically, in the run I was debugging, DxcCreateBlobFromFile
created a null CComPtr, which it almost immediately assigned IMalloc
to, but since CoGetMalloc didn't increment the refcount, when the
function ended, the CComPtrBase destructor decremented the count
on the IMalloc without a corresponding increment when it was associated
with the CComPtr. So it got freed just a bit early, causing a segfault.

Prerequisite for https://github.com/google/DirectXShaderCompiler/issues/198
Though it's not directly related, but the change for that would
introduce the segfault otherwise and I prefer to discuss these
changes independently.