### PR TITLE
[linux-port] Thread-safe increment/decrement

### DIFF
--- a/include/llvm/Support/WinMacros.h
+++ b/include/llvm/Support/WinMacros.h
@@ -21,10 +21,6 @@
 #define STDMETHODIMP_(type)     type STDMETHODCALLTYPE
 
 
-// TODO (ehsann): These are not atomic.
-#define InterlockedIncrement(x) ++*x
-#define InterlockedDecrement(x) --*x
-
 #define UNREFERENCED_PARAMETER(P) (P)
 
 #define RtlEqualMemory(Destination,Source,Length) (!memcmp((Destination),(Source),(Length)))

--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -229,7 +229,7 @@ public:
   DXC_MICROCOM_ADDREF_IMPL(m_dwRef)
   ULONG STDMETHODCALLTYPE Release() {
     // Because blobs are also used by tests and utilities, we avoid using TLS.
-    ULONG result = InterlockedDecrement(&m_dwRef);
+    ULONG result = (ULONG)llvm::sys::AtomicDecrement(&m_dwRef);
     if (result == 0) {
       CComPtr<IMalloc> pTmp(m_pMalloc);
       this->~InternalDxcBlobEncoding();
@@ -827,7 +827,7 @@ public:
   ULONG STDMETHODCALLTYPE Release() {
     // Because memory streams are also used by tests and utilities,
     // we avoid using TLS.
-    ULONG result = InterlockedDecrement(&m_dwRef);
+    ULONG result = (ULONG)llvm::sys::AtomicDecrement(&m_dwRef);
     if (result == 0) {
       CComPtr<IMalloc> pTmp(m_pMalloc);
       this->~MemoryStream();

--- a/tools/clang/tools/dxr/CMakeLists.txt
+++ b/tools/clang/tools/dxr/CMakeLists.txt
@@ -5,6 +5,7 @@
 set( LLVM_LINK_COMPONENTS
   ${LLVM_TARGETS_TO_BUILD}
   dxcsupport
+  Support    # For Atomic increment/decrement
   )
 
 add_clang_executable(dxr

--- a/tools/clang/unittests/HLSL/HlslTestUtils.h
+++ b/tools/clang/unittests/HLSL/HlslTestUtils.h
@@ -13,6 +13,7 @@
 #include <fstream>
 #include "dxc/Support/Unicode.h"
 #include "dxc/HLSL/DxilConstants.h" // DenormMode
+#include "llvm/Support/Atomic.h"
 #include <dxgiformat.h>
 
 // If TAEF verify macros are available, use them to alias other legacy
@@ -479,11 +480,11 @@ inline UINT GetByteSizeForFormat(DXGI_FORMAT value) {
 
 
 #define SIMPLE_IUNKNOWN_IMPL1(_IFACE_) \
-  private: volatile ULONG m_dwRef; \
+  private: volatile llvm::sys::cas_flag m_dwRef; \
   public:\
-  ULONG STDMETHODCALLTYPE AddRef() { return InterlockedIncrement(&m_dwRef); } \
+  ULONG STDMETHODCALLTYPE AddRef() { return (ULONG)llvm::sys::AtomicIncrement(&m_dwRef); } \
   ULONG STDMETHODCALLTYPE Release() { \
-    ULONG result = InterlockedDecrement(&m_dwRef); \
+    ULONG result = (ULONG)llvm::sys::AtomicDecrement(&m_dwRef); \
     if (result == 0) delete this; \
     return result; \
   } \

--- a/tools/clang/unittests/HLSLHost/CMakeLists.txt
+++ b/tools/clang/unittests/HLSLHost/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 set( LLVM_LINK_COMPONENTS
   ${LLVM_TARGETS_TO_BUILD}
+  Support    # For Atomic increment/decrement
   )
 
 add_clang_executable(HLSLHost


### PR DESCRIPTION
InterlockedIncrement and InterlockedDecrement are atomic operations to
increment or decrement the value pointed to by the pointer parameter and
return the same. Currently they are implemented as simple addition
operations in WinMacros.h for non-win32 platforms which works well
enough, but wasn't really the original intent.

There are already platform abstractions available to LLVM in Atomics.h.
This change leverages them to implement the same functionality in a
platform-agnostic way. Mostly it's just a matter of swapping
InterlockedIncrement for AtomicIncrement.

Fixes half of https://github.com/google/DirectXShaderCompiler/issues/198