### PR TITLE
[linux-port] Fix anonymous struct warnings

### DIFF
--- a/include/dxc/Support/WinIncludes.h
+++ b/include/dxc/Support/WinIncludes.h
@@ -28,6 +28,7 @@
 #define NOMCX 1
 #define WIN32_LEAN_AND_MEAN 1
 #define VC_EXTRALEAN 1
+#define NONAMELESSSTRUCT 1
 
 #include <windows.h>
 #include <unknwn.h>

--- a/include/llvm/Support/WinTypes.h
+++ b/include/llvm/Support/WinTypes.h
@@ -181,8 +181,8 @@ typedef struct _WIN32_FIND_DATAW {
 typedef union _LARGE_INTEGER {
   struct {
     DWORD LowPart;
-    LONG HighPart;
-  };
+    DWORD HighPart;
+  } u;
   LONGLONG QuadPart;
 } LARGE_INTEGER;
 
@@ -192,7 +192,7 @@ typedef union _ULARGE_INTEGER {
   struct {
     DWORD LowPart;
     DWORD HighPart;
-  };
+  } u;
   ULONGLONG QuadPart;
 } ULARGE_INTEGER;
 

--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -112,25 +112,25 @@ void ReadBinaryFile(IMalloc *pMalloc, LPCWSTR pFileName, void **ppData,
   if (!GetFileSizeEx(hFile, &FileSize)) {
     IFT(HRESULT_FROM_WIN32(GetLastError()));
   }
-  if (FileSize.HighPart != 0) {
+  if (FileSize.u.HighPart != 0) {
     throw(hlsl::Exception(DXC_E_INPUT_FILE_TOO_LARGE, "input file is too large"));
   }
 
-  char *pData = (char *)pMalloc->Alloc(FileSize.LowPart);
+  char *pData = (char *)pMalloc->Alloc(FileSize.u.LowPart);
   if (!pData) {
     throw std::bad_alloc();
   }
 
   DWORD BytesRead;
-  if (!ReadFile(hFile, pData, FileSize.LowPart, &BytesRead, nullptr)) {
+  if (!ReadFile(hFile, pData, FileSize.u.LowPart, &BytesRead, nullptr)) {
     HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
     pMalloc->Free(pData);
     throw ::hlsl::Exception(hr);
   }
-  DXASSERT(FileSize.LowPart == BytesRead, "ReadFile operation failed");
+  DXASSERT(FileSize.u.LowPart == BytesRead, "ReadFile operation failed");
 
   *ppData = pData;
-  *pDataSize = FileSize.LowPart;
+  *pDataSize = FileSize.u.LowPart;
 
   #else
   // Open file
@@ -950,19 +950,19 @@ public:
 
   // IStream implementation.
   HRESULT STDMETHODCALLTYPE SetSize(ULARGE_INTEGER val) override {
-    if (val.HighPart != 0) {
+    if (val.u.HighPart != 0) {
       return E_OUTOFMEMORY;
     }
-    if (val.LowPart > m_allocSize) {
+    if (val.u.LowPart > m_allocSize) {
       return Grow(m_allocSize);
     }
-    if (val.LowPart < m_size) {
-      m_size = val.LowPart;
+    if (val.u.LowPart < m_size) {
+      m_size = val.u.LowPart;
       m_offset = std::min(m_offset, m_size);
     }
-    else if (val.LowPart > m_size) {
-      memset(m_pMemory + m_size, 0, val.LowPart - m_size);
-      m_size = val.LowPart;
+    else if (val.u.LowPart > m_size) {
+      memset(m_pMemory + m_size, 0, val.u.LowPart - m_size);
+      m_size = val.u.LowPart;
     }
     return S_OK;
   }
@@ -996,7 +996,7 @@ public:
       lpNewFilePointer->QuadPart = 0;
     }
 
-    if (liDistanceToMove.HighPart != 0) {
+    if (liDistanceToMove.u.HighPart != 0) {
       return E_FAIL;
     }
 
@@ -1004,13 +1004,13 @@ public:
 
     switch (dwOrigin) {
     case STREAM_SEEK_SET:
-      targetOffset = liDistanceToMove.LowPart;
+      targetOffset = liDistanceToMove.u.LowPart;
       break;
     case STREAM_SEEK_CUR:
-      targetOffset = liDistanceToMove.LowPart + m_offset;
+      targetOffset = liDistanceToMove.u.LowPart + m_offset;
       break;
     case STREAM_SEEK_END:
-      targetOffset = liDistanceToMove.LowPart + m_size;
+      targetOffset = liDistanceToMove.u.LowPart + m_size;
       break;
     default:
       return STG_E_INVALIDFUNCTION;
@@ -1018,7 +1018,7 @@ public:
 
     m_offset = targetOffset;
     if (lpNewFilePointer != nullptr) {
-      lpNewFilePointer->LowPart = targetOffset;
+      lpNewFilePointer->u.LowPart = targetOffset;
     }
     return S_OK;
   }
@@ -1030,7 +1030,7 @@ public:
     }
     ZeroMemory(pStatstg, sizeof(*pStatstg));
     pStatstg->type = STGTY_STREAM;
-    pStatstg->cbSize.LowPart = m_size;
+    pStatstg->cbSize.u.LowPart = m_size;
     return S_OK;
   }
 };
@@ -1107,7 +1107,7 @@ public:
       lpNewFilePointer->QuadPart = 0;
     }
 
-    if (liDistanceToMove.HighPart != 0) {
+    if (liDistanceToMove.u.HighPart != 0) {
       return E_FAIL;
     }
 
@@ -1115,13 +1115,13 @@ public:
 
     switch (dwOrigin) {
     case STREAM_SEEK_SET:
-      targetOffset = liDistanceToMove.LowPart;
+      targetOffset = liDistanceToMove.u.LowPart;
       break;
     case STREAM_SEEK_CUR:
-      targetOffset = liDistanceToMove.LowPart + m_offset;
+      targetOffset = liDistanceToMove.u.LowPart + m_offset;
       break;
     case STREAM_SEEK_END:
-      targetOffset = liDistanceToMove.LowPart + m_size;
+      targetOffset = liDistanceToMove.u.LowPart + m_size;
       break;
     default:
       return STG_E_INVALIDFUNCTION;
@@ -1134,7 +1134,7 @@ public:
 
     m_offset = targetOffset;
     if (lpNewFilePointer != nullptr) {
-      lpNewFilePointer->LowPart = targetOffset;
+      lpNewFilePointer->u.LowPart = targetOffset;
     }
     return S_OK;
   }
@@ -1146,7 +1146,7 @@ public:
     }
     ZeroMemory(pStatstg, sizeof(*pStatstg));
     pStatstg->type = STGTY_STREAM;
-    pStatstg->cbSize.LowPart = m_size;
+    pStatstg->cbSize.u.LowPart = m_size;
     return S_OK;
   }
 };

--- a/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
+++ b/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
@@ -477,7 +477,7 @@ public:
         SetLastError(ERROR_IO_DEVICE);
         return FALSE;
       }
-      lpFileInformation->nFileSizeLow = stat.cbSize.LowPart;
+      lpFileInformation->nFileSizeLow = stat.cbSize.u.LowPart;
       return TRUE;
     }
     else if (argsHandle.IsDirHandle()) {
@@ -661,8 +661,8 @@ public:
     }
 
     LARGE_INTEGER li;
-    li.LowPart = offset;
-    li.HighPart = 0;
+    li.u.LowPart = offset;
+    li.u.HighPart = 0;
     ULARGE_INTEGER newOffset;
     HRESULT hr = stream->Seek(li, origin, &newOffset);
     if (FAILED(hr)) {
@@ -670,7 +670,7 @@ public:
       return -1;
     }
 
-    return newOffset.LowPart;
+    return newOffset.u.LowPart;
   }
   int setmode(int fd, int mode) throw() override {
     return 0;

--- a/tools/clang/tools/dxr/dxr.cpp
+++ b/tools/clang/tools/dxr/dxr.cpp
@@ -143,10 +143,10 @@ public:
     if (!GetFileSizeEx(fileHandle, &FileSize)) {
       return HRESULT_FROM_WIN32(GetLastError());
     }
-    if (FileSize.HighPart != 0 || FileSize.LowPart == UINT_MAX) {
+    if (FileSize.u.HighPart != 0 || FileSize.u.LowPart == UINT_MAX) {
       return DXC_E_INPUT_FILE_TOO_LARGE;
     }
-    m_FileSize = FileSize.LowPart;
+    m_FileSize = FileSize.u.LowPart;
 
     return S_OK;
   }


### PR DESCRIPTION
A most pervasive warning from a minimal amount of code. The Wintypes
header included an anonymous struct in the form of LARGE_INTEGER
which is specified by Microsoft, but the actual MS header includes
another struct in the union for environments that don't want
anonymous structs. Given the minimal usage, I think this can
qualify. Microsoft's own headers will exclude the anonymous struct
in favor of the named one if NONAMELESSSTRUCT is defined before
windows.h. To prevent future uses of the anonymous part of LARGE_
INTEGER, this defines that in WinIncludes.h.
Fixes 148 clang and 148 gcc warnings.

Contributes to https://github.com/google/DirectXShaderCompiler/issues/206