### PR TITLE
[linux-port] Correct const casts

### DIFF
--- a/include/dxc/HLSL/DxilPipelineStateValidation.h
+++ b/include/dxc/HLSL/DxilPipelineStateValidation.h
@@ -390,7 +390,7 @@ public:
   // returns true if no errors occurred.
   bool InitFromPSV0(const void* pBits, uint32_t size) {
     if(!(pBits != nullptr)) return false;
-    const uint8_t* pCurBits = (uint8_t*)pBits;
+    uint8_t* pCurBits = (uint8_t*)pBits;
     uint32_t minsize = sizeof(PSVRuntimeInfo0) + sizeof(uint32_t) * 2;
     if(!(size >= minsize)) return false;
     m_uPSVRuntimeInfoSize = *((const uint32_t*)pCurBits);

--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -348,7 +348,7 @@ static HRESULT CodePageBufferToUtf16(UINT32 codePage, LPCVOID bufferPointer,
 
   // Calculate the length of the buffer in wchar_t elements.
   int numToConvertUTF16 =
-      MultiByteToWideChar(codePage, MB_ERR_INVALID_CHARS, (char *)bufferPointer,
+      MultiByteToWideChar(codePage, MB_ERR_INVALID_CHARS, (LPCSTR)bufferPointer,
                           bufferSize, nullptr, 0);
   if (numToConvertUTF16 == 0)
     return HRESULT_FROM_WIN32(GetLastError());
@@ -362,7 +362,7 @@ static HRESULT CodePageBufferToUtf16(UINT32 codePage, LPCVOID bufferPointer,
   IFROOM(utf16NewCopy.m_pData);
 
   int numActuallyConvertedUTF16 =
-      MultiByteToWideChar(codePage, MB_ERR_INVALID_CHARS, (char *)bufferPointer,
+      MultiByteToWideChar(codePage, MB_ERR_INVALID_CHARS, (LPCSTR)bufferPointer,
                           bufferSize, utf16NewCopy, buffSizeUTF16);
 
   if (numActuallyConvertedUTF16 == 0)
@@ -641,7 +641,7 @@ HRESULT DxcGetBlobAsUtf8(IDxcBlob *pBlob, IDxcBlobEncoding **pBlobEncoding) thro
 
   SIZE_T blobLen = pBlob->GetBufferSize();
   if (!known && blobLen > 0) {
-    codePage = DxcCodePageFromBytes((char *)pBlob->GetBufferPointer(), blobLen);
+    codePage = DxcCodePageFromBytes((const char *)pBlob->GetBufferPointer(), blobLen);
   }
 
   if (codePage == CP_UTF8) {
@@ -659,10 +659,10 @@ HRESULT DxcGetBlobAsUtf8(IDxcBlob *pBlob, IDxcBlobEncoding **pBlobEncoding) thro
   // Any UTF-16 output must be converted to UTF-16 first, then
   // back to the target code page.
   CDxcMallocHeapPtr<WCHAR> utf16NewCopy(DxcGetThreadMallocNoRef());
-  wchar_t* utf16Chars = nullptr;
+  const wchar_t* utf16Chars = nullptr;
   UINT32 utf16CharCount;
   if (codePage == CP_UTF16) {
-    utf16Chars = (wchar_t*)pBlob->GetBufferPointer();
+    utf16Chars = (const wchar_t*)pBlob->GetBufferPointer();
     utf16CharCount = blobLen / sizeof(wchar_t);
   }
   else {

--- a/lib/HLSL/DxilMetadataHelper.cpp
+++ b/lib/HLSL/DxilMetadataHelper.cpp
@@ -377,7 +377,7 @@ void DxilMDHelper::LoadRootSignature(RootSignatureHandle &Sig) {
           DXC_E_INCORRECT_DXIL_METADATA);
 
   Sig.Clear();
-  Sig.LoadSerialized((uint8_t *)pData->getRawDataValues().begin(),
+  Sig.LoadSerialized((const uint8_t *)pData->getRawDataValues().begin(),
                      pData->getRawDataValues().size());
 }
 
@@ -1108,7 +1108,7 @@ void DxilMDHelper::LoadDxilViewIdState(DxilViewIdState &ViewIdState) {
   IFTBOOL(pData->getRawDataValues().size() < UINT_MAX && 
           (pData->getRawDataValues().size() & 3) == 0, DXC_E_INCORRECT_DXIL_METADATA);
 
-  ViewIdState.Deserialize((unsigned *)pData->getRawDataValues().begin(), 
+  ViewIdState.Deserialize((const unsigned *)pData->getRawDataValues().begin(),
                           (unsigned)pData->getRawDataValues().size() / 4);
 }
 

--- a/lib/HLSL/DxilRootSignature.cpp
+++ b/lib/HLSL/DxilRootSignature.cpp
@@ -1525,11 +1525,11 @@ void DeserializeRootSignatureTemplate(_In_reads_bytes_(SrcDataSizeInBytes) const
   const char *pData = (const char *)pSrcData;
   const char *pMaxPtr = pData + SrcDataSizeInBytes;
   UNREFERENCED_PARAMETER(DescVersion);
-  DXASSERT_NOMSG(((uint32_t*)pData)[0] == (uint32_t)DescVersion);
+  DXASSERT_NOMSG(((const uint32_t*)pData)[0] == (uint32_t)DescVersion);
 
   // Root signature.
   IFTBOOL(pData + sizeof(DxilContainerRootSignatureDesc) <= pMaxPtr, E_FAIL);
-  DxilContainerRootSignatureDesc *pRS = (DxilContainerRootSignatureDesc *)pData;
+  const DxilContainerRootSignatureDesc *pRS = (const DxilContainerRootSignatureDesc *)pData;
   pRootSignature->Flags = (DxilRootSignatureFlags)pRS->Flags;
   pRootSignature->NumParameters = pRS->NumParameters;
   pRootSignature->NumStaticSamplers = pRS->NumStaticSamplers;
@@ -1538,8 +1538,8 @@ void DeserializeRootSignatureTemplate(_In_reads_bytes_(SrcDataSizeInBytes) const
   pRootSignature->pStaticSamplers = nullptr;
 
   size_t s = sizeof(DxilContainerRootParameter)*pRS->NumParameters;
-  DxilContainerRootParameter *pInRTS = (DxilContainerRootParameter *)(pData + pRS->RootParametersOffset);
-  IFTBOOL(((char*)pInRTS) + s <= pMaxPtr, E_FAIL);
+  const DxilContainerRootParameter *pInRTS = (const DxilContainerRootParameter *)(pData + pRS->RootParametersOffset);
+  IFTBOOL(((const char*)pInRTS) + s <= pMaxPtr, E_FAIL);
   if (pRootSignature->NumParameters) {
     pRootSignature->pParameters = new T_ROOT_PARAMETER[pRootSignature->NumParameters];
   }
@@ -1552,12 +1552,12 @@ void DeserializeRootSignatureTemplate(_In_reads_bytes_(SrcDataSizeInBytes) const
     pOutRTS->ShaderVisibility = (DxilShaderVisibility)pInRTS[iRP].ShaderVisibility;
     switch(ParameterType) {
     case DxilRootParameterType::DescriptorTable: {
-      DxilContainerRootDescriptorTable *p1 = (DxilContainerRootDescriptorTable*)(pData + pInRTS[iRP].PayloadOffset);
-      IFTBOOL((char*)p1 + sizeof(DxilContainerRootDescriptorTable) <= pMaxPtr, E_FAIL);
+      const DxilContainerRootDescriptorTable *p1 = (const DxilContainerRootDescriptorTable*)(pData + pInRTS[iRP].PayloadOffset);
+      IFTBOOL((const char*)p1 + sizeof(DxilContainerRootDescriptorTable) <= pMaxPtr, E_FAIL);
       pOutRTS->DescriptorTable.NumDescriptorRanges = p1->NumDescriptorRanges;
       pOutRTS->DescriptorTable.pDescriptorRanges = nullptr;
-      T_DESCRIPTOR_RANGE_INTERNAL *p2 = (T_DESCRIPTOR_RANGE_INTERNAL*)(pData + p1->DescriptorRangesOffset);
-      IFTBOOL((char*)p2 + sizeof(T_DESCRIPTOR_RANGE_INTERNAL) <= pMaxPtr, E_FAIL);
+      const T_DESCRIPTOR_RANGE_INTERNAL *p2 = (const T_DESCRIPTOR_RANGE_INTERNAL*)(pData + p1->DescriptorRangesOffset);
+      IFTBOOL((const char*)p2 + sizeof(T_DESCRIPTOR_RANGE_INTERNAL) <= pMaxPtr, E_FAIL);
       if (p1->NumDescriptorRanges) {
         pOutRTS->DescriptorTable.pDescriptorRanges = new T_DESCRIPTOR_RANGE[p1->NumDescriptorRanges];
       }
@@ -1574,8 +1574,8 @@ void DeserializeRootSignatureTemplate(_In_reads_bytes_(SrcDataSizeInBytes) const
       break;
     }
     case DxilRootParameterType::Constants32Bit: {
-      DxilRootConstants *p = (DxilRootConstants*)(pData + pInRTS[iRP].PayloadOffset);
-      IFTBOOL((char*)p + sizeof(DxilRootConstants) <= pMaxPtr, E_FAIL);
+      const DxilRootConstants *p = (const DxilRootConstants*)(pData + pInRTS[iRP].PayloadOffset);
+      IFTBOOL((const char*)p + sizeof(DxilRootConstants) <= pMaxPtr, E_FAIL);
       pOutRTS->Constants.Num32BitValues = p->Num32BitValues;
       pOutRTS->Constants.ShaderRegister = p->ShaderRegister;
       pOutRTS->Constants.RegisterSpace  = p->RegisterSpace;
@@ -1584,8 +1584,8 @@ void DeserializeRootSignatureTemplate(_In_reads_bytes_(SrcDataSizeInBytes) const
     case DxilRootParameterType::CBV:
     case DxilRootParameterType::SRV:
     case DxilRootParameterType::UAV: {
-      T_ROOT_DESCRIPTOR *p = (T_ROOT_DESCRIPTOR *)(pData + pInRTS[iRP].PayloadOffset);
-      IFTBOOL((char*)p + sizeof(T_ROOT_DESCRIPTOR) <= pMaxPtr, E_FAIL);
+      const T_ROOT_DESCRIPTOR *p = (const T_ROOT_DESCRIPTOR *)(pData + pInRTS[iRP].PayloadOffset);
+      IFTBOOL((const char*)p + sizeof(T_ROOT_DESCRIPTOR) <= pMaxPtr, E_FAIL);
       pOutRTS->Descriptor.ShaderRegister = p->ShaderRegister;
       pOutRTS->Descriptor.RegisterSpace  = p->RegisterSpace;
       DxilRootDescriptorFlags Flags = GetFlags(*p);
@@ -1598,8 +1598,8 @@ void DeserializeRootSignatureTemplate(_In_reads_bytes_(SrcDataSizeInBytes) const
   }
 
   s = sizeof(DxilStaticSamplerDesc)*pRS->NumStaticSamplers;
-  DxilStaticSamplerDesc *pInSS = (DxilStaticSamplerDesc *)(pData + pRS->StaticSamplersOffset);
-  IFTBOOL(((char*)pInSS) + s <= pMaxPtr, E_FAIL);
+  const DxilStaticSamplerDesc *pInSS = (const DxilStaticSamplerDesc *)(pData + pRS->StaticSamplersOffset);
+  IFTBOOL(((const char*)pInSS) + s <= pMaxPtr, E_FAIL);
   if (pRootSignature->NumStaticSamplers) {
     pRootSignature->pStaticSamplers = new DxilStaticSamplerDesc[pRootSignature->NumStaticSamplers];
   }
@@ -1616,7 +1616,7 @@ void DeserializeRootSignature(const void *pSrcData,
   const char *pData = (const char *)pSrcData;
   IFTBOOL(pData + sizeof(uint32_t) < pData + SrcDataSizeInBytes, E_FAIL);
 
-  DxilRootSignatureVersion Version = (DxilRootSignatureVersion)((uint32_t*)pData)[0];
+  DxilRootSignatureVersion Version = (const DxilRootSignatureVersion)((const uint32_t*)pData)[0];
 
   pRootSignature = new DxilVersionedRootSignatureDesc();
 

--- a/tools/clang/tools/dxc/dxc.cpp
+++ b/tools/clang/tools/dxc/dxc.cpp
@@ -1005,7 +1005,7 @@ HRESULT DxcContext::FindModuleBlob(hlsl::DxilFourCC fourCC, IDxcBlob *pSource, I
   }
   if (fourCC == pDxilPartHeader->PartFourCC) {
     UINT32 pBlobSize;
-    hlsl::DxilProgramHeader *pDxilProgramHeader = (hlsl::DxilProgramHeader*)(pDxilPartHeader + 1);
+    const hlsl::DxilProgramHeader *pDxilProgramHeader = (const hlsl::DxilProgramHeader*)(pDxilPartHeader + 1);
     hlsl::GetDxilProgramBitcode(pDxilProgramHeader, &pBitcode, &pBlobSize);
     UINT32 offset = (UINT32)(pBitcode - (const char *)pSource->GetBufferPointer());
     pLibrary->CreateBlobFromBlob(pSource, offset, pBlobSize, ppTargetBlob);

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -1023,7 +1023,7 @@ void PrintPipelineStateValidationRuntimeInfo(const char *pBuffer,
      << comment << "\n";
 
   const unsigned offset = sizeof(unsigned);
-  const PSVRuntimeInfo0 *pInfo = (PSVRuntimeInfo0 *)(pBuffer + offset);
+  const PSVRuntimeInfo0 *pInfo = (const PSVRuntimeInfo0 *)(pBuffer + offset);
 
   switch (shaderKind) {
   case DXIL::ShaderKind::Hull: {

--- a/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
+++ b/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
@@ -706,7 +706,7 @@ public:
 #ifdef _DEBUG
     if (fd == STDERR_FILENO) {
         char* copyWithNull = new char[count+1];
-        strncpy(copyWithNull, (char*)buffer, count);
+        strncpy(copyWithNull, (const char*)buffer, count);
         copyWithNull[count] = '\0';
         OutputDebugStringA(copyWithNull);
         delete[] copyWithNull;


### PR DESCRIPTION
There are a lot of cases where const is carelessly cast off. Some
of them lead to really dramatic changes in multiple interfaces to
fix properly. This is instead a subset of cases where const was
disrespected, often for no apparent reason at all. likely just a
mistake in type casting.
Fixes 88 gcc and 88 clang warnings.

Contributes to https://github.com/google/DirectXShaderCompiler/issues/206