### PR TITLE
[linux-port] Mark all overridden methods

### DIFF
--- a/include/dxc/Support/dxcapi.impl.h
+++ b/include/dxc/Support/dxcapi.impl.h
@@ -24,7 +24,7 @@ private:
     ULONG cbWritten;
     IFT(m_pStream->Write(Ptr, Size, &cbWritten));
   }
-  uint64_t current_pos() const { return m_pStream->GetPosition(); }
+  uint64_t current_pos() const override { return m_pStream->GetPosition(); }
 public:
   raw_stream_ostream(hlsl::AbstractMemoryStream* pStream) : m_pStream(pStream) { }
   ~raw_stream_ostream() override {
@@ -51,7 +51,7 @@ public:
   CComPtr<IDxcBlob> m_result;
   CComPtr<IDxcBlobEncoding> m_errors;
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDxcOperationResult>(this, iid, ppvObject);
   }
 

--- a/include/dxc/Support/microcom.h
+++ b/include/dxc/Support/microcom.h
@@ -85,12 +85,12 @@ public:
 
 #define DXC_MICROCOM_REF_FIELD(m_dwRef) volatile llvm::sys::cas_flag m_dwRef = 0;
 #define DXC_MICROCOM_ADDREF_IMPL(m_dwRef) \
-    ULONG STDMETHODCALLTYPE AddRef() {\
+    ULONG STDMETHODCALLTYPE AddRef() override {\
         return (ULONG)llvm::sys::AtomicIncrement(&m_dwRef); \
     }
 #define DXC_MICROCOM_ADDREF_RELEASE_IMPL(m_dwRef) \
     DXC_MICROCOM_ADDREF_IMPL(m_dwRef) \
-    ULONG STDMETHODCALLTYPE Release() { \
+    ULONG STDMETHODCALLTYPE Release() override { \
         ULONG result = (ULONG)llvm::sys::AtomicDecrement(&m_dwRef); \
         if (result == 0) delete this; \
         return result; \
@@ -117,7 +117,7 @@ void DxcCallDestructor(T *obj) {
 
 #define DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()                                  \
   DXC_MICROCOM_ADDREF_IMPL(m_dwRef)                                            \
-  ULONG STDMETHODCALLTYPE Release() {                                          \
+  ULONG STDMETHODCALLTYPE Release() override {                                 \
     ULONG result = (ULONG)llvm::sys::AtomicDecrement(&m_dwRef);                \
     if (result == 0) {                                                         \
       CComPtr<IMalloc> pTmp(m_pMalloc);                                        \

--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -39,7 +39,7 @@ public:
   ULONG STDMETHODCALLTYPE Release() {
     return 1;
   }
-  STDMETHODIMP QueryInterface(REFIID iid, void** ppvObject) {
+  STDMETHODIMP QueryInterface(REFIID iid, void** ppvObject) override {
     return DoBasicQueryInterface<IMalloc>(this, iid, ppvObject);
   }
   virtual void *STDMETHODCALLTYPE Alloc(
@@ -231,7 +231,7 @@ private:
   UINT32 m_CodePage;
 public:
   DXC_MICROCOM_ADDREF_IMPL(m_dwRef)
-  ULONG STDMETHODCALLTYPE Release() {
+  ULONG STDMETHODCALLTYPE Release() override {
     // Because blobs are also used by tests and utilities, we avoid using TLS.
     ULONG result = (ULONG)llvm::sys::AtomicDecrement(&m_dwRef);
     if (result == 0) {
@@ -242,7 +242,7 @@ public:
     return result;
   }
   DXC_MICROCOM_TM_CTOR(InternalDxcBlobEncoding)
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDxcBlob, IDxcBlobEncoding>(this, iid, ppvObject);
   }
 
@@ -313,7 +313,7 @@ public:
   virtual SIZE_T STDMETHODCALLTYPE GetBufferSize(void) override {
     return m_BufferSize;
   }
-  virtual HRESULT STDMETHODCALLTYPE GetEncoding(_Out_ BOOL *pKnown, _Out_ UINT32 *pCodePage) {
+  virtual HRESULT STDMETHODCALLTYPE GetEncoding(_Out_ BOOL *pKnown, _Out_ UINT32 *pCodePage) override {
     #ifdef _WIN32
     *pKnown = m_EncodingKnown ? TRUE : FALSE;
     *pCodePage = m_CodePage;
@@ -828,7 +828,7 @@ private:
   ULONG m_allocSize = 0;
 public:
   DXC_MICROCOM_ADDREF_IMPL(m_dwRef)
-  ULONG STDMETHODCALLTYPE Release() {
+  ULONG STDMETHODCALLTYPE Release() override {
     // Because memory streams are also used by tests and utilities,
     // we avoid using TLS.
     ULONG result = (ULONG)llvm::sys::AtomicDecrement(&m_dwRef);
@@ -842,7 +842,7 @@ public:
 
   DXC_MICROCOM_TM_CTOR(MemoryStream)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IStream, ISequentialStream, IDxcBlob>(this, iid, ppvObject);
   }
 
@@ -1046,7 +1046,7 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_CTOR(ReadOnlyBlobStream)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IStream, ISequentialStream>(this, iid, ppvObject);
   }
 

--- a/lib/HLSL/DxcOptimizer.cpp
+++ b/lib/HLSL/DxcOptimizer.cpp
@@ -437,7 +437,7 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_CTOR(DxcOptimizerPass)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDxcOptimizerPass>(this, iid, ppvObject);
   }
 
@@ -493,7 +493,7 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_CTOR(DxcOptimizer)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDxcOptimizer>(this, iid, ppvObject);
   }
 

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -212,7 +212,7 @@ private:
                                          llvm::Type *Ty);
 
   void EmitHLSLRootSignature(CodeGenFunction &CGF, HLSLRootSignatureAttr *RSA,
-                             llvm::Function *Fn);
+                             llvm::Function *Fn) override;
 
   void CheckParameterAnnotation(SourceLocation SLoc,
                                 const DxilParameterAnnotation &paramInfo,

--- a/tools/clang/tools/dxc/dxc.cpp
+++ b/tools/clang/tools/dxc/dxc.cpp
@@ -606,7 +606,7 @@ public:
   DxcIncludeHandlerForInjectedSources() : m_dwRef(0) {};
   std::unordered_map<std::wstring, CComPtr<IDxcBlob>> includeFiles;
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDxcIncludeHandler>(this, iid, ppvObject);
   }
 

--- a/tools/clang/tools/dxcompiler/dxcassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcassembler.cpp
@@ -39,7 +39,7 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_CTOR(DxcAssembler)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDxcAssembler>(this, iid, ppvObject);
   }
 

--- a/tools/clang/tools/dxcompiler/dxclibrary.cpp
+++ b/tools/clang/tools/dxcompiler/dxclibrary.cpp
@@ -30,7 +30,7 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_CTOR(DxcIncludeHandlerForFS)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDxcIncludeHandler>(this, iid, ppvObject);
   }
 
@@ -54,7 +54,7 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_CTOR(DxcLibrary)
   
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDxcLibrary>(this, iid, ppvObject);
   }
 

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -177,7 +177,7 @@ public:
     return false;
   }
 
-  virtual HLSLExtensionsCodegenHelper::CustomRootSignature::Status GetCustomRootSignature(CustomRootSignature *out) {
+  virtual HLSLExtensionsCodegenHelper::CustomRootSignature::Status GetCustomRootSignature(CustomRootSignature *out) override {
     // Find macro definition in preprocessor.
     Preprocessor &pp = m_CI.getPreprocessor();
     MacroInfo *macro = MacroExpander::FindMacroInfo(pp, m_rootSigDefine);
@@ -255,7 +255,7 @@ public:
     return S_OK;
   }
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDxcCompiler,
                                  IDxcCompiler2,
                                  IDxcLangExtensions,

--- a/tools/clang/tools/dxcompiler/dxcontainerbuilder.cpp
+++ b/tools/clang/tools/dxcompiler/dxcontainerbuilder.cpp
@@ -36,7 +36,7 @@ public:
 
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_CTOR(DxcContainerBuilder)
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppvObject) override {
     return DoBasicQueryInterface<IDxcContainerBuilder>(this, riid, ppvObject);
   }
 

--- a/tools/clang/tools/dxcompiler/dxcvalidator.cpp
+++ b/tools/clang/tools/dxcompiler/dxcvalidator.cpp
@@ -68,7 +68,7 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_CTOR(DxcValidator)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDxcValidator, IDxcVersionInfo>(this, iid, ppvObject);
   }
 

--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -551,7 +551,7 @@ public:
   DXC_MICROCOM_TM_CTOR(DxcRewriter)
   DXC_LANGEXTENSIONS_HELPER_IMPL(m_langExtensionsHelper)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDxcRewriter, IDxcLangExtensions>(this, iid, ppvObject);
   }
 


### PR DESCRIPTION
Clang produces a warning when a method that overrides another is
not marked with the override keyword. Adding the keyword has no
effect on overridden functions, but it is good practice to mark
all methods intended to override as such because if they fail to
do so, the keyword will produce an error.

Fixes 78 Clang warnings.

Contributes to https://github.com/google/DirectXShaderCompiler/issues/206