### PR TITLE
[linux-port] Replace tests of never null addresses

### DIFF
--- a/lib/HLSL/ComputeViewIdState.cpp
+++ b/lib/HLSL/ComputeViewIdState.cpp
@@ -226,7 +226,6 @@ void DxilViewIdState::FuncInfo::Clear() {
 void DxilViewIdState::DetermineMaxPackedLocation(DxilSignature &DxilSig,
                                                  unsigned *pMaxSigLoc,
                                                  unsigned NumStreams) {
-  if (&DxilSig == nullptr) return;
   DXASSERT_NOMSG(NumStreams == 1 || NumStreams == kNumStreams);
 
   for (unsigned i = 0; i < NumStreams; i++) {

--- a/lib/HLSL/DxilOperations.cpp
+++ b/lib/HLSL/DxilOperations.cpp
@@ -828,11 +828,11 @@ bool OP::GetOpCodeClass(const Function *F, OP::OpCodeClass &opClass) {
 
 bool OP::UseMinPrecision() {
   if (m_LowPrecisionMode == DXIL::LowPrecisionMode::Undefined) {
-    if (&m_pModule->GetDxilModule()) {
+    if (m_pModule->HasDxilModule()) {
       m_LowPrecisionMode = m_pModule->GetDxilModule().m_ShaderFlags.GetUseNativeLowPrecision() ?
         DXIL::LowPrecisionMode::UseNativeLowPrecision : DXIL::LowPrecisionMode::UseMinPrecision;
     }
-    else if (&m_pModule->GetHLModule()) {
+    else if (m_pModule->HasHLModule()) {
       m_LowPrecisionMode = m_pModule->GetHLModule().GetHLOptions().bUseMinPrecision ?
         DXIL::LowPrecisionMode::UseMinPrecision : DXIL::LowPrecisionMode::UseNativeLowPrecision;
     }

--- a/lib/HLSL/DxilTypeSystem.cpp
+++ b/lib/HLSL/DxilTypeSystem.cpp
@@ -414,11 +414,11 @@ DXIL::SigPointKind SigPointFromInputQual(DxilParamInputQual Q, DXIL::ShaderKind 
 
 bool DxilTypeSystem::UseMinPrecision() {
   if (m_LowPrecisionMode == DXIL::LowPrecisionMode::Undefined) {
-    if (&m_pModule->GetDxilModule()) {
+    if (m_pModule->HasDxilModule()) {
       m_LowPrecisionMode = m_pModule->GetDxilModule().m_ShaderFlags.GetUseNativeLowPrecision() ?
         DXIL::LowPrecisionMode::UseNativeLowPrecision : DXIL::LowPrecisionMode::UseMinPrecision;
     }
-    else if (&m_pModule->GetHLModule()) {
+    else if (m_pModule->HasHLModule()) {
       m_LowPrecisionMode = m_pModule->GetHLModule().GetHLOptions().bUseMinPrecision ?
         DXIL::LowPrecisionMode::UseMinPrecision : DXIL::LowPrecisionMode::UseNativeLowPrecision;
     }


### PR DESCRIPTION
Found as part of a project to eliminate warnings, but this is an
actual bug. An HLSL change adds the possibility of a Dxil and an
HLSL module to the base LLVM Module as well as the ability to
retrieve a reference to them when the are present. This reference
retrieval was mistakenly used to determine if the module was
present in spite of the fact that references are never null. Worse
the reference is from a dereferenced pointer, so if it wasn't there,
it would cause a null dereference. The module interface had methods
to query the presence of these submodules, but they weren't used.
fixes 4 clang warnings and possibly some mysterious crashes

The same warning for a different cause is encountered where an
address is taken of a value passed by reference and compared to
null, which can never be true.
Fixes 1 clang warning.

Contributes to https://github.com/google/DirectXShaderCompiler/issues/206