### PR TITLE
[linux-port] Remove extra semicolons

### DIFF
--- a/include/dxc/HLSL/DxilMetadataHelper.h
+++ b/include/dxc/HLSL/DxilMetadataHelper.h
@@ -29,7 +29,7 @@ class MDTuple;
 class MDNode;
 class NamedMDNode;
 class GlobalVariable;
-};
+}
 
 namespace hlsl {
 

--- a/include/dxc/HLSL/DxilModule.h
+++ b/include/dxc/HLSL/DxilModule.h
@@ -35,7 +35,7 @@ class Instruction;
 class MDTuple;
 class MDOperand;
 class DebugInfoFinder;
-};
+}
 
 namespace hlsl {
 

--- a/include/dxc/HLSL/DxilOperations.h
+++ b/include/dxc/HLSL/DxilOperations.h
@@ -20,7 +20,7 @@ class Function;
 class Constant;
 class Value;
 class Instruction;
-};
+}
 #include "llvm/IR/Attributes.h"
 #include "llvm/ADT/StringRef.h"
 

--- a/include/dxc/HLSL/DxilResourceBase.h
+++ b/include/dxc/HLSL/DxilResourceBase.h
@@ -22,7 +22,7 @@
 namespace llvm {
 class Value;
 class Constant;
-};
+}
 
 
 namespace hlsl {

--- a/include/dxc/HLSL/DxilTypeSystem.h
+++ b/include/dxc/HLSL/DxilTypeSystem.h
@@ -27,7 +27,7 @@ class MDNode;
 class Type;
 class StructType;
 class StringRef;
-};
+}
 
 
 namespace hlsl {

--- a/include/dxc/HLSL/HLModule.h
+++ b/include/dxc/HLSL/HLModule.h
@@ -36,7 +36,7 @@ class MDNode;
 class GlobalVariable;
 class DIGlobalVariable;
 class DebugInfoFinder;
-};
+}
 
 
 namespace hlsl {

--- a/lib/HLSL/DxilShaderAccessTracking.cpp
+++ b/lib/HLSL/DxilShaderAccessTracking.cpp
@@ -184,7 +184,7 @@ static char EncodeRegisterType(RegisterType r) {
   case RegisterType::Invalid: return 'I';
   }
   return '.';
-};
+}
 
 static void ValidateDelimiter(std::deque<char> & q, char d) {
   ThrowIf(q.front() != d);

--- a/lib/HLSL/HLOperationLowerExtension.cpp
+++ b/lib/HLSL/HLOperationLowerExtension.cpp
@@ -188,7 +188,7 @@ llvm::Value *ExtensionLowering::NoTranslation(CallInst *CI) {
   IRBuilder<> builder(CI);
   SmallVector<Value *, 8> args(CI->arg_operands().begin(), CI->arg_operands().end());
   return builder.CreateCall(NoTranslationFunction, args);
-};
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Replicated Lowering.

--- a/tools/clang/lib/SPIRV/GlPerVertex.cpp
+++ b/tools/clang/lib/SPIRV/GlPerVertex.cpp
@@ -461,7 +461,7 @@ uint32_t GlPerVertex::readClipCullArrayAsType(bool isClip, uint32_t offset,
   }
 
   return theBuilder.createCompositeConstruct(arrayType, arrayElements);
-};
+}
 
 bool GlPerVertex::readField(hlsl::Semantic::Kind semanticKind,
                             uint32_t semanticIndex, uint32_t *value) {
@@ -579,7 +579,7 @@ void GlPerVertex::writeClipCullArrayFromType(
 
   llvm_unreachable("SV_ClipDistance/SV_CullDistance not float or vector of "
                    "float case sneaked in");
-};
+}
 
 bool GlPerVertex::writeField(hlsl::Semantic::Kind semanticKind,
                              uint32_t semanticIndex,

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -3746,7 +3746,7 @@ void SPIRVEmitter::handleOffsetInMethodCall(const CXXMemberCallExpr *expr,
     return; // Constant offset
   else
     *varOffset = doExpr(expr->getArg(index));
-};
+}
 
 SpirvEvalInfo
 SPIRVEmitter::processIntrinsicMemberCall(const CXXMemberCallExpr *expr,

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -9131,7 +9131,7 @@ void hlsl::DiagnoseRegisterType(
   case AR_OBJECT_LEGACY_EFFECT:   // Used for all unsupported but ignored legacy effect types
     isWarning = true;
     break;                        // So we don't care what you tried to bind it to
-  };
+  }
 
   // fxc is inconsistent as to when it reports an error and when it ignores invalid bind semantics, so emit
   // a warning instead.


### PR DESCRIPTION
Terminating classes may create a muscle memory for typing a
semicolon after a left-justified closed brace. Whatever the reason
to GCC's chagrine there were many functions ended with unnecessary
semicolons. Each one caused a warning. This removes them.

Fixes 285 GCC warnings

Contributes to https://github.com/google/DirectXShaderCompiler/issues/206