### PR TITLE
[linux-port] Fix static function header warnings

### DIFF
--- a/include/llvm/Support/WinFunctions.h
+++ b/include/llvm/Support/WinFunctions.h
@@ -17,64 +17,14 @@
 
 #ifndef _WIN32
 
-static HRESULT StringCchPrintfA(char *dst, size_t dstSize, const char *format,
-                                ...) {
-  va_list args;
-  va_start(args, format);
-  // C++11 snprintf can return the size of the resulting string if it was to be
-  // constructed.
-  size_t size = snprintf(nullptr, 0, format, args) + 1; // Extra space for '\0'
-  if (size > dstSize) {
-    *dst = '\0';
-  } else {
-    snprintf(dst, size, format, args);
-  }
-  va_end(args);
-  return S_OK;
-}
+#include "llvm/Support/WinTypes.h"
 
-static HRESULT UIntAdd(UINT uAugend, UINT uAddend, UINT *puResult) {
-  HRESULT hr;
-  if ((uAugend + uAddend) >= uAugend) {
-    *puResult = (uAugend + uAddend);
-    hr = S_OK;
-  } else {
-    *puResult = 0xffffffff;
-    hr = (HRESULT)1L;
-  }
-  return hr;
-}
-
-static HRESULT IntToUInt(int in, UINT *out) {
-  HRESULT hr;
-  if (in >= 0) {
-    *out = (UINT)in;
-    hr = S_OK;
-  } else {
-    *out = 0xffffffff;
-    hr = (HRESULT)1L;
-  }
-  return hr;
-}
-
-static HRESULT UInt32Mult(UINT a, UINT b, UINT *out) {
-  uint64_t result = (uint64_t)a * (uint64_t)b;
-  if (result > uint64_t(UINT_MAX))
-    return (HRESULT)1L;
-
-  *out = (uint32_t)result;
-  return S_OK;
-}
-
-static int _stricmp(const char *str1, const char *str2) {
-  size_t i = 0;
-  for (; str1[i] && str2[i]; ++i) {
-    int d = std::tolower(str1[i]) - std::tolower(str2[i]);
-    if (d != 0)
-      return d;
-  }
-  return str1[i] - str2[i];
-}
+HRESULT StringCchPrintfA(char *dst, size_t dstSize, const char *format, ...);
+HRESULT UIntAdd(UINT uAugend, UINT uAddend, UINT *puResult);
+HRESULT IntToUInt(int in, UINT *out);
+HRESULT UInt32Mult(UINT a, UINT b, UINT *out);
+int _stricmp(const char *str1, const char *str2);
+HRESULT CoGetMalloc(DWORD dwMemContext, IMalloc **ppMalloc);
 
 #endif // _WIN32
 

--- a/include/llvm/Support/WinTypes.h
+++ b/include/llvm/Support/WinTypes.h
@@ -457,8 +457,6 @@ public:
   }
 };
 
-HRESULT CoGetMalloc(DWORD dwMemContext, IMalloc **ppMalloc);
-
 template <class T> class CSimpleArray : public std::vector<T> {
 public:
   bool Add(const T &t) {

--- a/lib/DxcSupport/dxcmem.cpp
+++ b/lib/DxcSupport/dxcmem.cpp
@@ -135,11 +135,3 @@ IMalloc *DxcSwapThreadMalloc(IMalloc *pMalloc, IMalloc **ppPrior) throw() {
 IMalloc *DxcSwapThreadMallocOrDefault(IMalloc *pMallocOrNull, IMalloc **ppPrior) throw() {
   return DxcSwapThreadMalloc(pMallocOrNull ? pMallocOrNull : g_pDefaultMalloc, ppPrior);
 }
-
-#ifndef _WIN32
-HRESULT CoGetMalloc(DWORD dwMemContext, IMalloc **ppMalloc) {
-  *ppMalloc = new IMalloc;
-  (*ppMalloc)->AddRef();
-  return S_OK;
-}
-#endif

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -126,6 +126,7 @@ add_llvm_library(LLVMSupport
   TimeValue.cpp
   Valgrind.cpp
   Watchdog.cpp
+  WinFunctions.cpp
 
   ADDITIONAL_HEADER_DIRS
   Unix

--- a/lib/Support/WinFunctions.cpp
+++ b/lib/Support/WinFunctions.cpp
@@ -1,0 +1,82 @@
+//===-- WinFunctions.cpp - Windows Functions for other platforms --*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines Windows-specific functions used in the codebase for
+// non-Windows platforms.
+//
+//===----------------------------------------------------------------------===//
+
+
+#ifndef _WIN32
+
+#include "llvm/Support/WinFunctions.h"
+
+HRESULT StringCchPrintfA(char *dst, size_t dstSize, const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+  // C++11 snprintf can return the size of the resulting string if it was to be constructed.
+  size_t size = snprintf(nullptr, 0, format, args) + 1; // Extra space for '\0'
+  if(size > dstSize) {
+    *dst = '\0';
+  } else {
+    snprintf(dst, size, format, args);
+  }
+  va_end(args);
+  return S_OK;
+}
+HRESULT UIntAdd(UINT uAugend, UINT uAddend, UINT* puResult) {
+  HRESULT hr;
+  if ((uAugend + uAddend) >= uAugend) {
+    *puResult = (uAugend + uAddend);
+    hr = S_OK;
+  } else {
+    *puResult = 0xffffffff;
+    hr = (HRESULT)1L;
+  }
+  return hr;
+}
+HRESULT IntToUInt(int in, UINT* out) {
+  HRESULT hr;
+  if (in >= 0) {
+    *out = (UINT)in;
+    hr = S_OK;
+  } else {
+    *out = 0xffffffff;
+    hr = (HRESULT)1L;
+  }
+  return hr;
+}
+HRESULT UInt32Mult(UINT a, UINT b, UINT* out) {
+  uint64_t result = (uint64_t)a * (uint64_t)b;
+  if(result > uint64_t(UINT_MAX))
+    return (HRESULT)1L;
+
+  *out = (uint32_t)result;
+  return S_OK;
+}
+
+int _stricmp(const char *str1, const char *str2) {
+  size_t i = 0;
+  for (; str1[i] && str2[i]; ++i) {
+    int d = std::tolower(str1[i]) - std::tolower(str2[i]);
+    if (d != 0)
+      return d;
+  }
+  return str1[i] - str2[i];
+}
+
+HRESULT CoGetMalloc(DWORD dwMemContext, IMalloc **ppMalloc) {
+  *ppMalloc = new IMalloc;
+  (*ppMalloc)->AddRef();
+  return S_OK;
+}
+
+
+#endif // _WIN32
+

--- a/tools/clang/tools/dxc/dxc.cpp
+++ b/tools/clang/tools/dxc/dxc.cpp
@@ -60,6 +60,8 @@
 #ifdef LLVM_ON_WIN32
 #include <dia2.h>
 #include <comdef.h>
+#else
+#include "llvm/Support/WinFunctions.h"
 #endif
 #include <algorithm>
 #include <unordered_map>


### PR DESCRIPTION
Having fully implemented functions in a header file means that
every source file that includes it will get its own set of these
functions whether it uses them or not. If they are unused, they
are reported in an error as a defined but unused function. In a
common header, this happens a lot. By leaving only prototypes in
the header and putting the bodies in a source file, they are all
silenced.
Fixes 363 clang and 363 gcc warnings

Contributes to https://github.com/google/DirectXShaderCompiler/issues/206