### PR TITLE
[linux-port] Scalar initialization warnings

### DIFF
--- a/include/dxc/HLSL/DxilSignatureAllocator.h
+++ b/include/dxc/HLSL/DxilSignatureAllocator.h
@@ -110,7 +110,7 @@ public:
     // - for occupied components, they signify element flags
     // - for unoccupied components, they signify conflict flags
     uint8_t Flags[4];
-    DXIL::InterpolationMode Interp : 4;
+    DXIL::InterpolationMode Interp : 8;
     uint8_t IndexFlags : 2;
     uint8_t IndexingFixed : 1;
     DXIL::SignatureDataWidth DataWidth; // length of each scalar type in bytes. (2 or 4 for now)

--- a/lib/HLSL/DxilContainerAssembler.cpp
+++ b/lib/HLSL/DxilContainerAssembler.cpp
@@ -469,7 +469,7 @@ public:
       for (unsigned streamIndex = 0; streamIndex < 4; streamIndex++) {
         m_PSVInitInfo.SigOutputVectors[streamIndex] = m_Module.GetOutputSignature().NumVectorsUsed(streamIndex);
       }
-      m_PSVInitInfo.SigPatchConstantVectors = m_PSVInitInfo.SigPatchConstantVectors = 0;
+      m_PSVInitInfo.SigPatchConstantVectors = 0;
       if (SM->IsHS()) {
         m_PSVInitInfo.SigPatchConstantVectors = m_Module.GetPatchConstantSignature().NumVectorsUsed(0);
       }

--- a/lib/HLSL/HLMatrixLowerPass.cpp
+++ b/lib/HLSL/HLMatrixLowerPass.cpp
@@ -759,7 +759,7 @@ Instruction *HLMatrixLowerPass::TrivialMatBinOpToVec(CallInst *CI) {
 }
 
 void HLMatrixLowerPass::lowerToVec(Instruction *matInst) {
-  Instruction *vecInst;
+  Instruction *vecInst = nullptr;
 
   if (CallInst *CI = dyn_cast<CallInst>(matInst)) {
     hlsl::HLOpcodeGroup group =

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -5167,7 +5167,7 @@ bool HLSLExternalSource::MatchArguments(
       // Use the templated input type, but resize it if the
       // intrinsic's rows/cols isn't 0
       if (pArgument->uRows && pArgument->uCols) {
-        UINT uRows, uCols;
+        UINT uRows, uCols = 0;
 
         // if type is overriden, use new type size, for
         // now it only supports scalars


### PR DESCRIPTION
There is the possibility of a few variables being used without
initialization, which causes some warnings.
Fixes 2 clang warnings

GCC worries that assigning a variable to the result of an
assignment of that same variable may be undefined. It's a silly
thing to do anyway. So it's removed.
Fixes 1 gcc warning.

GCC is quite sure that Interp is too small to hold values of up
to 9 with only 4 bits. Perhaps because the RHS is a variable of
8 bits.
Fixes 47 gcc warnings

Contributes to https://github.com/google/DirectXShaderCompiler/issues/206