### PR TITLE
[linux-port] Remove unused from HLSL code

### DIFF
--- a/lib/HLSL/DxilDebugInstrumentation.cpp
+++ b/lib/HLSL/DxilDebugInstrumentation.cpp
@@ -583,14 +583,11 @@ void DxilDebugInstrumentation::addDebugEntryValue(BuilderContext &BC, Value * Th
     Function* StoreValue = BC.HlslOP->GetOpFunc(OP::OpCode::BufferStore, TheValue->getType()); // Type::getInt32Ty(BC.Ctx));
     Constant* StoreValueOpcode = BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::BufferStore);
     UndefValue* Undef32Arg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
-    Constant* ZeroArg;
     UndefValue* UndefArg;
     if (TheValueTypeID == Type::TypeID::IntegerTyID) {
-        ZeroArg = BC.HlslOP->GetU32Const(0);
         UndefArg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
     }
     else if (TheValueTypeID == Type::TypeID::FloatTyID) {
-        ZeroArg = BC.HlslOP->GetFloatConst(0.f);
         UndefArg = UndefValue::get(Type::getFloatTy(BC.Ctx));
     }
     else {

--- a/lib/HLSL/DxilRootSignature.cpp
+++ b/lib/HLSL/DxilRootSignature.cpp
@@ -1068,10 +1068,6 @@ static void SetFlags(DxilRootDescriptor1 &D, DxilRootDescriptorFlags Flags)
 {
   D.Flags = Flags;
 }
-static DxilRootDescriptorFlags GetFlags(const DxilContainerRootDescriptor1 &D)
-{
-  return (DxilRootDescriptorFlags)D.Flags;
-}
 static void SetFlags(DxilContainerRootDescriptor1 &D, DxilRootDescriptorFlags Flags)
 {
   D.Flags = (uint32_t)Flags;

--- a/lib/HLSL/HLMatrixLowerPass.cpp
+++ b/lib/HLSL/HLMatrixLowerPass.cpp
@@ -524,22 +524,6 @@ Instruction *HLMatrixLowerPass::MatIntrinsicToVec(CallInst *CI) {
   return Builder.CreateCall(vecF, argList);
 }
 
-static Value *VectorizeScalarOp(Value *op, Type *dstTy, IRBuilder<> &Builder) {
-  if (op->getType() == dstTy)
-    return op;
-  op = Builder.CreateInsertElement(
-      UndefValue::get(VectorType::get(op->getType(), 1)), op, (uint64_t)0);
-  Type *I32Ty = IntegerType::get(dstTy->getContext(), 32);
-  Constant *zero = ConstantInt::get(I32Ty, 0);
-
-  std::vector<Constant *> MaskVec(dstTy->getVectorNumElements(), zero);
-  Value *castMask = ConstantVector::get(MaskVec);
-
-  Value *vecOp = new ShuffleVectorInst(op, op, castMask);
-  Builder.Insert(cast<Instruction>(vecOp));
-  return vecOp;
-}
-
 Instruction *HLMatrixLowerPass::TrivialMatUnOpToVec(CallInst *CI) {
   Type *ResultTy = LowerMatrixType(CI->getType());
   UndefValue *tmp = UndefValue::get(ResultTy);
@@ -1579,7 +1563,6 @@ void HLMatrixLowerPass::TranslateMatLoadStoreOnGlobal(GlobalVariable *matGlobal,
                                                       GlobalVariable *scalarArrayGlobal,
                                                       CallInst *matLdStInst) {
   // vecGlobals already in correct major.
-  const bool bColMajor = true;
   HLMatLoadStoreOpcode opcode =
       static_cast<HLMatLoadStoreOpcode>(GetHLOpcode(matLdStInst));
   switch (opcode) {
@@ -1827,41 +1810,6 @@ static void IterateInitList(MutableArrayRef<Value *> elts, unsigned &idx,
     } else {
       DXASSERT(valTy->isSingleValueType(), "must be single value type here");
       elts[idx++] = val;
-    }
-  }
-}
-// Store flattened init list elements into matrix array.
-static void GenerateMatArrayInit(ArrayRef<Value *> elts, Value *ptr,
-                                 unsigned &offset, IRBuilder<> &Builder) {
-  Type *Ty = ptr->getType()->getPointerElementType();
-  if (Ty->isVectorTy()) {
-    unsigned vecSize = Ty->getVectorNumElements();
-    Type *eltTy = Ty->getVectorElementType();
-    Value *result = UndefValue::get(Ty);
-
-    for (unsigned i = 0; i < vecSize; i++) {
-      Value *elt = elts[offset + i];
-      if (elt->getType() != eltTy) {
-        // FIXME: get signed/unsigned info.
-        elt = CreateTypeCast(HLCastOpcode::DefaultCast, eltTy, elt, Builder);
-      }
-
-      result = Builder.CreateInsertElement(result, elt, i);
-    }
-    // Update offset.
-    offset += vecSize;
-    Builder.CreateStore(result, ptr);
-  } else {
-    DXASSERT(Ty->isArrayTy(), "must be array type");
-    Type *i32Ty = Type::getInt32Ty(Ty->getContext());
-    Constant *zero = ConstantInt::get(i32Ty, 0);
-
-    unsigned arraySize = Ty->getArrayNumElements();
-
-    for (unsigned i = 0; i < arraySize; i++) {
-      Value *GEP =
-          Builder.CreateInBoundsGEP(ptr, {zero, ConstantInt::get(i32Ty, i)});
-      GenerateMatArrayInit(elts, GEP, offset, Builder);
     }
   }
 }

--- a/lib/HLSL/HLModule.cpp
+++ b/lib/HLSL/HLModule.cpp
@@ -387,14 +387,6 @@ DXIL::ResourceKind HLModule::GetResourceKind(llvm::Type *Ty) {
   }
 }
 
-static unsigned GetIntAt(MDTuple *tuple, unsigned idx) {
-  return DxilMDHelper::ConstMDToUint32(tuple->getOperand(idx));
-}
-
-static unsigned GetFloatAt(MDTuple *tuple, unsigned idx) {
-  return DxilMDHelper::ConstMDToFloat(tuple->getOperand(idx));
-}
-
 DXIL::Float32DenormMode HLModule::GetFloat32DenormMode() const {
   return m_Float32DenormMode;
 }

--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -1102,7 +1102,6 @@ Value *TransalteAbs(CallInst *CI, IntrinsicOp IOP, OP::OpCode opcode,
     Value *src = CI->getArgOperand(HLOperandIndex::kUnaryOpSrc0Idx);
     IRBuilder<> Builder(CI);
     Value *neg = Builder.CreateNeg(src);
-    Value *refArgs[] = {nullptr, src, neg};
     return TrivialDxilBinaryOperation(DXIL::OpCode::IMax, src, neg, hlslOP,
                                       Builder);
   }
@@ -3081,26 +3080,6 @@ void Make64bitResultForLoad(Type *EltTy, ArrayRef<Value *> resultElts32,
       hi = Builder.CreateShl(hi, 32);
       resultElts[i] = Builder.CreateOr(lo, hi);
     }
-  }
-}
-
-static uint8_t GetRawBufferMaskFromIOP(IntrinsicOp IOP, hlsl::OP *OP) {
-  switch (IOP) {
-    // one component
-    case IntrinsicOp::MOP_Load:
-      return DXIL::kCompMask_X;
-    // two component
-    case IntrinsicOp::MOP_Load2:
-      return DXIL::kCompMask_X | DXIL::kCompMask_Y;
-    // three component
-    case IntrinsicOp::MOP_Load3:
-      return DXIL::kCompMask_X | DXIL::kCompMask_Y | DXIL::kCompMask_Z;
-    // four component
-    case IntrinsicOp::MOP_Load4:
-      return DXIL::kCompMask_All;
-    default:
-      DXASSERT(false, "Invalid Intrinsic for computing load mask.");
-      return 0;
   }
 }
 
@@ -6235,8 +6214,6 @@ Value *UpdateVectorElt(Value *VecVal, Value *EltVal, Value *EltIdx,
 }
 
 void TranslateDefaultSubscript(CallInst *CI, HLOperationLowerHelper &helper,  HLObjectOperationLowerHelper *pObjHelper, bool &Translated) {
-  auto U = CI->user_begin();
-
   Value *ptr = CI->getArgOperand(HLOperandIndex::kSubscriptObjectOpIdx);
 
   hlsl::OP *hlslOP = &helper.hlslOP;

--- a/lib/HLSL/HLSignatureLower.cpp
+++ b/lib/HLSL/HLSignatureLower.cpp
@@ -1432,14 +1432,6 @@ void HLSignatureLower::GenerateClipPlanesForVS(Value *outPosition) {
 }
 
 namespace {
-// Helper functions for Gs Streams.
-void GenerateStOutput(Function *stOutput, Value *eltVal, Value *outputID,
-                      Value *rowIdx, Value *colIdx, OP *hlslOP,
-                      IRBuilder<> Builder) {
-  Constant *OpArg = hlslOP->GetU32Const((unsigned)OP::OpCode::StoreOutput);
-  Builder.CreateCall(stOutput, {OpArg, outputID, rowIdx, colIdx, eltVal});
-}
-
 Value *TranslateStreamAppend(CallInst *CI, unsigned ID, hlsl::OP *OP) {
   Function *DxilFunc = OP->GetOpFunc(OP::OpCode::EmitStream, CI->getType());
   // TODO: generate a emit which has the data being emited as its argment.

--- a/lib/IR/LegacyPassManager.cpp
+++ b/lib/IR/LegacyPassManager.cpp
@@ -86,9 +86,6 @@ static cl::opt<bool>
 PrintAfterAll("print-after-all",
               llvm::cl::desc("Print IR after each pass"),
               cl::init(false));
-#else
-static const bool PrintBeforeAll = false;
-static const bool PrintAfterAll = false;
 #endif // HLSL Change Ends
 
 /// This is a helper to determine whether to print IR before or

--- a/lib/IR/Verifier.cpp
+++ b/lib/IR/Verifier.cpp
@@ -80,8 +80,6 @@ using namespace llvm;
 
 #if 0 // HLSL Change Starts - option pending
 static cl::opt<bool> VerifyDebugInfo("verify-debug-info", cl::init(true));
-#else
-static const bool VerifyDebugInfo = true;
 #endif // HLSL Change Ends
 
 namespace {

--- a/lib/Support/CommandLine.cpp
+++ b/lib/Support/CommandLine.cpp
@@ -1721,8 +1721,6 @@ void HelpPrinterWrapper::operator=(bool Value) {
 static const bool PrintOptions = false;
 static const bool PrintAllOptions = false;
 
-void HelpPrinterWrapper::operator=(bool Value) {
-}
 #endif // HLSL Change Ends
 
 // Print the value of each option.

--- a/lib/Support/Timer.cpp
+++ b/lib/Support/Timer.cpp
@@ -53,7 +53,6 @@ namespace {
                    cl::Hidden, cl::location(getLibSupportInfoOutputFilename()));
 #else
   static const bool TrackSpace = false;
-  static const char InfoOutputFilename[] = "";
 #endif // HLSL Change Ends
 }
 

--- a/lib/Transforms/IPO/MergeFunctions.cpp
+++ b/lib/Transforms/IPO/MergeFunctions.cpp
@@ -119,8 +119,6 @@ static cl::opt<unsigned> NumFunctionsForSanityCheck(
              "MergeFunctions pass sanity check. "
              "'0' disables this check. Works only with '-debug' key."),
     cl::init(0), cl::Hidden);
-#else
-static const unsigned NumFunctionsForSanityCheck = 0;
 #endif
 
 namespace {
@@ -1157,6 +1155,7 @@ ModulePass *llvm::createMergeFunctionsPass() {
 }
 
 bool MergeFunctions::doSanityCheck(std::vector<WeakVH> &Worklist) {
+#if 0 // Begin HLSL Change (NumFunctionsForSanityCheck is always zero)
   if (const unsigned Max = NumFunctionsForSanityCheck) {
     unsigned TripleNumber = 0;
     bool Valid = true;
@@ -1225,6 +1224,7 @@ bool MergeFunctions::doSanityCheck(std::vector<WeakVH> &Worklist) {
     dbgs() << "MERGEFUNC-SANITY: " << (Valid ? "Passed." : "Failed.") << "\n";
     return Valid;
   }
+#endif // End HLSL Change
   return true;
 }
 

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -68,7 +68,6 @@ using namespace hlsl;
 STATISTIC(NumReplaced, "Number of allocas broken up");
 STATISTIC(NumPromoted, "Number of allocas promoted");
 STATISTIC(NumAdjusted, "Number of scalar allocas adjusted to allow promotion");
-STATISTIC(NumConverted, "Number of aggregates converted to scalar");
 
 namespace {
 
@@ -5931,11 +5930,8 @@ static void LegalizeDxilInputOutputs(Function *F,
             EntryAnnotation->GetParameterAnnotation(output->getArgNo());
 
         auto Iter = Builder.GetInsertPoint();
-        bool onlyRetBlk = false;
         if (RI != BB.begin())
           Iter--;
-        else
-          onlyRetBlk = true;
         // split copy.
         SplitCpy(output->getType(), output, temp, idxList, Builder, DL, typeSys,
                  &paramAnnotation);

--- a/tools/clang/lib/AST/ASTContextHLSL.cpp
+++ b/tools/clang/lib/AST/ASTContextHLSL.cpp
@@ -33,20 +33,13 @@ static const int FirstTemplateDepth = 0;
 static const int FirstParamPosition = 0;
 static const bool ForConstFalse = false;          // a construct is targeting a const type
 static const bool ForConstTrue = true;            // a construct is targeting a non-const type
-static const bool ExplicitConversionFalse = false;// a conversion operation is not the result of an explicit cast
-static const bool InheritedFalse = false;         // template parameter default value is not inherited.
 static const bool ParameterPackFalse = false;     // template parameter is not an ellipsis.
 static const bool TypenameFalse = false;          // 'typename' specified rather than 'class' for a template argument.
 static const bool DelayTypeCreationTrue = true;   // delay type creation for a declaration
-static const bool DelayTypeCreationFalse = false; // immediately create a type when the declaration is created
-static const unsigned int NoQuals = 0;            // no qualifiers in effect
 static const SourceLocation NoLoc;                // no source location attribution available
-static const bool HasWrittenPrototypeTrue = true; // function had the prototype written
 static const bool InlineFalse = false;            // namespace is not an inline namespace
 static const bool InlineSpecifiedFalse = false;   // function was not specified as inline
 static const bool IsConstexprFalse = false;       // function is not constexpr
-static const bool ListInitializationFalse = false;// not performing a list initialization
-static const bool SuppressDiagTrue = true;        // suppress diagnostics
 static const bool VirtualFalse = false;           // whether the base class is declares 'virtual'
 static const bool BaseClassFalse = false;         // whether the base class is declared as 'class' (vs. 'struct')
 
@@ -293,7 +286,7 @@ void AddSubscriptOperator(
     vectorType = context.getConstType(vectorType);
 
   QualType indexType = intType;
-  CXXMethodDecl* functionDecl = CreateObjectFunctionDeclarationWithParams(
+  CreateObjectFunctionDeclarationWithParams(
     context, templateRecordDecl, vectorType,
     ArrayRef<QualType>(indexType), ArrayRef<StringRef>(StringRef("index")),
     context.DeclarationNames.getCXXOperatorName(OO_Subscript), forConst);
@@ -532,7 +525,6 @@ CXXRecordDecl* CreateStdStructWithStaticBool(clang::ASTContext& context, Namespa
   // struct true_type { static const bool value = true; }
   TypeSourceInfo* boolTypeSource = context.getTrivialTypeSourceInfo(context.BoolTy.withConst());
   CXXRecordDecl* trueTypeDecl = CXXRecordDecl::Create(context, TagTypeKind::TTK_Struct, stdNamespace, NoLoc, NoLoc, &trueTypeId, nullptr, DelayTypeCreationTrue);
-  QualType trueTypeQT = context.getTagDeclType(trueTypeDecl); // Fault this in now.
 
   // static fields are variables in the AST
   VarDecl* trueValueDecl = VarDecl::Create(context, trueTypeDecl, NoLoc, NoLoc, &valueId,

--- a/tools/clang/lib/AST/ExprConstant.cpp
+++ b/tools/clang/lib/AST/ExprConstant.cpp
@@ -5725,7 +5725,6 @@ bool VectorExprEvaluator::VisitCastExpr(const CastExpr* E) {
           hlsl::GetHLSLVecElementType(E->getType()), Elem.getFloat());
       Elts.push_back(Elem);
     }
-    const auto EltsSize = Elts.size();
     return Success(Elts, E);
   }
   case CK_HLSLCC_IntegralToFloating: {
@@ -5740,7 +5739,6 @@ bool VectorExprEvaluator::VisitCastExpr(const CastExpr* E) {
                            ElemFloat);
       Elts.push_back(APValue(ElemFloat));
     }
-    const auto EltsSize = Elts.size();
     return Success(Elts, E);
   }
   case CK_HLSLCC_FloatingToIntegral: {

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -150,9 +150,7 @@ uint32_t GetHLSLVecSize(clang::QualType type) {
          "otherwise caller shouldn't be invoking this");
 
   const TemplateArgumentList &argList = templateDecl->getTemplateArgs();
-  const TemplateArgument &arg0 = argList[0];
   const TemplateArgument &arg1 = argList[1];
-  QualType elemTy = arg0.getAsType();
   llvm::APSInt vecSize = arg1.getAsIntegral();
   return vecSize.getLimitedValue();
 }
@@ -172,10 +170,8 @@ void GetRowsAndCols(clang::QualType type, uint32_t &rowCount,
          "otherwise caller shouldn't be invoking this");
 
   const TemplateArgumentList &argList = templateDecl->getTemplateArgs();
-  const TemplateArgument &arg0 = argList[0];
   const TemplateArgument &arg1 = argList[1];
   const TemplateArgument &arg2 = argList[2];
-  QualType elemTy = arg0.getAsType();
   llvm::APSInt rowSize = arg1.getAsIntegral();
   llvm::APSInt colSize = arg2.getAsIntegral();
   rowCount = rowSize.getLimitedValue();

--- a/tools/clang/lib/CodeGen/CGExprAgg.cpp
+++ b/tools/clang/lib/CodeGen/CGExprAgg.cpp
@@ -710,7 +710,6 @@ void AggExprEmitter::VisitCastExpr(CastExpr *E) {
   // HLSL Change Begins.
   case CK_FlatConversion: {
     QualType Ty = E->getSubExpr()->getType();
-    QualType PtrTy = CGF.getContext().getPointerType(Ty);
     llvm::Value *DestPtr = Dest.getAddr();
 
     if (IntegerLiteral *IL = dyn_cast<IntegerLiteral>(E->getSubExpr())) {

--- a/tools/clang/lib/CodeGen/CGExprCXX.cpp
+++ b/tools/clang/lib/CodeGen/CGExprCXX.cpp
@@ -85,8 +85,6 @@ RValue CodeGenFunction::EmitCXXMemberOrOperatorCall(
   llvm::SmallVector<LValue, 8> castArgList;
   // The argList of the CallExpr, may be update for out parameter
   llvm::SmallVector<const Stmt *, 8> argList(CE->arg_begin(), CE->arg_end());
-  ConstExprIterator argBegin = argList.data();
-  ConstExprIterator argEnd = argList.data() + CE->getNumArgs();
   // out param conversion
   CodeGenFunction::HLSLOutParamScope OutParamScope(*this);
   auto MapTemp = [&](const VarDecl *LocalVD, llvm::Value *TmpArg) {
@@ -122,8 +120,6 @@ RValue CodeGenFunction::EmitCXXStructorCall(
   llvm::SmallVector<LValue, 8> castArgList;
   // The argList of the CallExpr, may be update for out parameter
   llvm::SmallVector<const Stmt *, 8> argList(CE->arg_begin(), CE->arg_end());
-  ConstExprIterator argBegin = argList.data();
-  ConstExprIterator argEnd = argList.data() + CE->getNumArgs();
   // out param conversion
   CodeGenFunction::HLSLOutParamScope OutParamScope(*this);
   auto MapTemp = [&](const VarDecl *LocalVD, llvm::Value *TmpArg) {

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -912,7 +912,6 @@ unsigned CGMSHLSLRuntime::ConstructStructAnnotation(DxilStructAnnotation *annota
 
     unsigned CBufferOffset = offset;
 
-    bool userOffset = false;
     // Try to get info from fieldDecl.
     for (const hlsl::UnusualAnnotation *it :
          fieldDecl->getUnusualAnnotations()) {
@@ -927,7 +926,6 @@ unsigned CGMSHLSLRuntime::ConstructStructAnnotation(DxilStructAnnotation *annota
         CBufferOffset += cp->ComponentOffset;
         // Change to byte.
         CBufferOffset <<= 2;
-        userOffset = true;
       } break;
       case hlsl::UnusualAnnotation::UA_RegisterAssignment: {
         // register assignment only works on global constant.
@@ -2041,18 +2039,6 @@ hlsl::GetResourceClassForType(const clang::ASTContext &context,
   return hlsl::DxilResourceBase::Class::Invalid;
 }
 
-static DxilSampler::SamplerKind KeywordToSamplerKind(const std::string &keyword) {
-  // TODO: refactor for faster search (switch by 1/2/3 first letters, then
-  // compare)
-  if (keyword == "SamplerState")
-    return DxilSampler::SamplerKind::Default;
-
-  if (keyword == "SamplerComparisonState")
-    return DxilSampler::SamplerKind::Comparison;
-
-  return DxilSampler::SamplerKind::Invalid;
-}
-
 hlsl::DxilResourceBase::Class CGMSHLSLRuntime::TypeToClass(clang::QualType Ty) {
   return hlsl::GetResourceClassForType(CGM.getContext(), Ty);
 }
@@ -2122,27 +2108,6 @@ uint32_t CGMSHLSLRuntime::AddSampler(VarDecl *samplerDecl) {
   hlslRes->SetID(m_pHLModule->GetSamplers().size());
   return m_pHLModule->AddSampler(std::move(hlslRes));
 }
-
-static void CollectScalarTypes(std::vector<llvm::Type *> &scalarTys, llvm::Type *Ty) {
-  if (llvm::StructType *ST = dyn_cast<llvm::StructType>(Ty)) {
-    for (llvm::Type *EltTy : ST->elements()) {
-      CollectScalarTypes(scalarTys, EltTy);
-    }
-  } else if (llvm::ArrayType *AT = dyn_cast<llvm::ArrayType>(Ty)) {
-    llvm::Type *EltTy = AT->getElementType();
-    for (unsigned i=0;i<AT->getNumElements();i++) {
-      CollectScalarTypes(scalarTys, EltTy);
-    }
-  } else if (llvm::VectorType *VT = dyn_cast<llvm::VectorType>(Ty)) {
-    llvm::Type *EltTy = VT->getElementType();
-    for (unsigned i=0;i<VT->getNumElements();i++) {
-      CollectScalarTypes(scalarTys, EltTy);
-    }
-  } else {
-    scalarTys.emplace_back(Ty);
-  }
-}
-
 
 static void CollectScalarTypes(std::vector<QualType> &ScalarTys, QualType Ty) {
   if (Ty->isRecordType()) {
@@ -4379,8 +4344,6 @@ RValue CGMSHLSLRuntime::EmitHLSLBuiltinCallExpr(CodeGenFunction &CGF,
                                                 const FunctionDecl *FD,
                                                 const CallExpr *E,
                                                 ReturnValueSlot ReturnValue) {
-  StringRef name = FD->getName();
-
   const Decl *TargetDecl = E->getCalleeDecl();
   llvm::Value *Callee = CGF.EmitScalarExpr(E->getCallee());
   RValue RV = CGF.EmitCall(E->getCallee()->getType(), Callee, E, ReturnValue,
@@ -4928,8 +4891,6 @@ static bool ExpTypeMatch(Expr *E, QualType Ty, ASTContext &Ctx, CodeGenTypes &Ty
     if (Ty->isStructureOrClassType()) {
       RecordDecl *record = Ty->castAs<RecordType>()->getDecl();
       bool bMatch = true;
-      auto It = record->field_begin();
-      auto ItEnd = record->field_end();
       unsigned i = 0;
       for (auto it = record->field_begin(), end = record->field_end();
            it != end; it++) {
@@ -5838,8 +5799,6 @@ void CGMSHLSLRuntime::FlattenAggregatePtrToGepList(
     const clang::RecordType *RT = Type->getAsStructureType();
     RecordDecl *RD = RT->getDecl();
 
-    auto fieldIter = RD->field_begin();
-
     const CGRecordLayout &RL = CGF.getTypes().getCGRecordLayout(RD);
 
     if (const CXXRecordDecl *CXXRD = dyn_cast<CXXRecordDecl>(RD)) {
@@ -5924,7 +5883,6 @@ void CGMSHLSLRuntime::LoadFlattenedGepList(CodeGenFunction &CGF,
   unsigned eltSize = GepList.size();
   for (unsigned i = 0; i < eltSize; i++) {
     Value *Ptr = GepList[i];
-    QualType Type = EltTyList[i];
     // Everying is element type.
     EltList.push_back(CGF.Builder.CreateLoad(Ptr));
   }
@@ -6185,7 +6143,6 @@ void CGMSHLSLRuntime::EmitHLSLFlatConversionToAggregate(
 
     const clang::RecordType *RT = Type->getAsStructureType();
     RecordDecl *RD = RT->getDecl();
-    auto fieldIter = RD->field_begin();
 
     const CGRecordLayout &RL = CGF.getTypes().getCGRecordLayout(RD);
     // Take care base.

--- a/tools/clang/lib/Parse/HLSLRootSignature.cpp
+++ b/tools/clang/lib/Parse/HLSLRootSignature.cpp
@@ -516,9 +516,8 @@ HRESULT RootSignatureParser::Error(uint32_t uErrorNum, LPCSTR pError, ...)
 {
     va_list Args;
     char msg[512];
-    int len;
     va_start(Args, pError);
-    len = vsprintf_s(msg, pError, Args);
+    vsprintf_s(msg, pError, Args);
     va_end(Args);
     try {
       m_OS << msg;

--- a/tools/clang/lib/Parse/ParseDecl.cpp
+++ b/tools/clang/lib/Parse/ParseDecl.cpp
@@ -408,7 +408,6 @@ bool Parser::MaybeParseHLSLAttributes(std::vector<hlsl::UnusualAnnotation *> &ta
 
         ExprResult result;
         if (Tok.isNot(tok::r_square)) {
-          SourceLocation expressionLoc = Tok.getLocation();
           subcomponentResult = ParseConstantExpression();
           r.IsValid = r.IsValid && !subcomponentResult.isInvalid();
           Expr::EvalResult evalResult;

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -708,8 +708,8 @@ uint32_t DeclResultIdMapper::getOrRegisterFnResultId(const FunctionDecl *fn) {
   auto &info = astDecls[fn].info;
 
   bool isAlias = false;
-  const uint32_t type =
-      getTypeAndCreateCounterForPotentialAliasVar(fn, &isAlias, &info);
+
+  (void)getTypeAndCreateCounterForPotentialAliasVar(fn, &isAlias, &info);
 
   const uint32_t id = theBuilder.getSPIRVContext()->takeNextId();
   info.setResultId(id);
@@ -1707,8 +1707,6 @@ bool DeclResultIdMapper::writeBackOutputStream(const NamedDecl *decl,
   if (semanticInfo.isValid()) {
     // Found semantic attached directly to this Decl. Write the value for this
     // Decl to the corresponding stage output variable.
-
-    const uint32_t srcTypeId = typeTranslator.translateType(type);
 
     // Handle SV_Position, SV_ClipDistance, and SV_CullDistance
     if (glPerVertex.tryToAccess(

--- a/tools/clang/lib/SPIRV/TypeTranslator.cpp
+++ b/tools/clang/lib/SPIRV/TypeTranslator.cpp
@@ -24,9 +24,6 @@ namespace {
 /// The alignment for 4-component float vectors.
 constexpr uint32_t kStd140Vec4Alignment = 16u;
 
-/// Returns true if the given value is a power of 2.
-inline bool isPow2(int val) { return (val & (val - 1)) == 0; }
-
 /// Rounds the given value up to the given power of 2.
 inline uint32_t roundToPow2(uint32_t val, uint32_t pow2) {
   assert(pow2 != 0);

--- a/tools/clang/lib/Sema/SemaExprObjC.cpp
+++ b/tools/clang/lib/Sema/SemaExprObjC.cpp
@@ -283,18 +283,6 @@ bool Sema::isKnownName(StringRef name) {
   return LookupName(R, TUScope, false);
 }
 
-static void addFixitForObjCARCConversion(Sema &S,
-  DiagnosticBuilder &DiagB,
-  Sema::CheckedConversionKind CCK,
-  SourceLocation afterLParen,
-  QualType castType,
-  Expr *castExpr,
-  Expr *realCast,
-  const char *bridgeKeyword,
-  const char *CFBridgeName) {
-  llvm_unreachable("HLSL does not support ObjC constructs");
-}
-
 void Sema::CheckTollFreeBridgeCast(QualType castType, Expr *castExpr) {
   llvm_unreachable("HLSL does not support ObjC constructs");
 }

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -641,15 +641,9 @@ using namespace hlsl;
 
 extern const char *HLSLScalarTypeNames[];
 
-static const int FirstTemplateDepth = 0;
-static const int FirstParamPosition = 0;
 static const bool ExplicitConversionFalse = false;// a conversion operation is not the result of an explicit cast
-static const bool InheritedFalse = false;         // template parameter default value is not inherited.
 static const bool ParameterPackFalse = false;     // template parameter is not an ellipsis.
 static const bool TypenameTrue = false;           // 'typename' specified rather than 'class' for a template argument.
-static const bool DelayTypeCreationTrue = true;   // delay type creation for a declaration
-static const bool DelayTypeCreationFalse = false; // immediately create a type when the declaration is created
-static const unsigned int NoQuals = 0;            // no qualifiers in effect
 static const SourceLocation NoLoc;                // no source location attribution available
 static const SourceRange NoRange;                 // no source range attribution available
 static const bool HasWrittenPrototypeTrue = true; // function had the prototype written
@@ -657,8 +651,6 @@ static const bool InlineSpecifiedFalse = false;   // function was not specified 
 static const bool IsConstexprFalse = false;       // function is not constexpr
 static const bool ListInitializationFalse = false;// not performing a list initialization
 static const bool SuppressWarningsFalse = false;  // do not suppress warning diagnostics
-static const bool SuppressWarningsTrue = true;    // suppress warning diagnostics
-static const bool SuppressErrorsFalse = false;    // do not suppress error diagnostics
 static const bool SuppressErrorsTrue = true;      // suppress error diagnostics
 static const int OneRow = 1;                      // a single row for a type
 static const bool MipsFalse = false;              // a type does not support the .mips member
@@ -1509,24 +1501,6 @@ const char* g_DeprecatedEffectObjectNames[] =
   "RenderTargetView", // 16
 };
 
-// The CompareStringsWithLen function lexicographically compares LHS and RHS and
-// returns a value indicating the relationship between the strings - < 0 if LHS is
-// less than RHS, 0 if they are equal, > 0 if LHS is greater than RHS.
-static
-int CompareStringsWithLen(
-  _In_count_(LHSlen) const char* LHS, size_t LHSlen,
-  _In_count_(RHSlen) const char* RHS, size_t RHSlen
-)
-{
-  // Check whether the name is greater or smaller (without walking past end).
-  size_t maxNameComparable = std::min(LHSlen, RHSlen);
-  int comparison = strncmp(LHS, RHS, maxNameComparable);
-  if (comparison != 0) return comparison;
-
-  // Check whether the name is greater or smaller based on extra characters.
-  return LHSlen - RHSlen;
-}
-
 static hlsl::ParameterModifier
 ParamModsFromIntrinsicArg(const HLSL_INTRINSIC_ARGUMENT *pArg) {
   if (pArg->qwUsage == AR_QUAL_IN_OUT) {
@@ -1583,7 +1557,6 @@ static void AddHLSLIntrinsicAttr(FunctionDecl *FD, ASTContext &context,
   unsigned opcode = (unsigned)pIntrinsic->Op;
   if (HasUnsignedOpcode(opcode) && IsBuiltinTable(tableName)) {
     QualType Ty = FD->getReturnType();
-    IntrinsicOp intrinOp = static_cast<IntrinsicOp>(pIntrinsic->Op);
     if (pIntrinsic->iOverloadParamIndex != -1) {
       const FunctionProtoType *FT =
           FD->getFunctionType()->getAs<FunctionProtoType>();
@@ -1639,7 +1612,6 @@ FunctionDecl *AddHLSLIntrinsicFunction(
   IdentifierInfo &functionId = context.Idents.get(
       StringRef(pIntrinsic->pArgs[0].pName), tok::TokenKind::identifier);
   DeclarationName functionName(&functionId);
-  QualType returnQualType = functionArgQualTypes[0];
   QualType functionType = context.getFunctionType(
       functionArgQualTypes[0],
       ArrayRef<QualType>(functionArgQualTypes + 1,
@@ -2119,32 +2091,6 @@ static
 bool DoesLegalTemplateAcceptMultipleTypes(BYTE value)
 {
   return DoesLegalTemplateAcceptMultipleTypes(static_cast<LEGAL_INTRINSIC_TEMPLATES>(value));
-}
-
-
-static
-bool DoesIntrinsicRequireTemplate(const HLSL_INTRINSIC* intrinsic)
-{
-  const HLSL_INTRINSIC_ARGUMENT* argument = intrinsic->pArgs;
-  for (size_t i = 0; i < intrinsic->uNumArgs; i++)
-  {
-    // The intrinsic will require a template for any of these reasons:
-    // - A type template (layout) or component needs to match something else.
-    // - A parameter can take multiple types.
-    // - Row or columns numbers may vary.
-    if (
-      argument->uTemplateId != i ||
-      DoesLegalTemplateAcceptMultipleTypes(argument->uLegalTemplates) ||
-      DoesComponentTypeAcceptMultipleTypes(argument->uLegalComponentTypes) ||
-      IsRowOrColumnVariable(argument->uCols) ||
-      IsRowOrColumnVariable(argument->uRows))
-    {
-      return true;
-    }
-    argument++;
-  }
-
-  return false;
 }
 
 static
@@ -3236,12 +3182,10 @@ public:
         R.addDecl(typeDecl);
       }
       else if (rowCount == 0) { // vector
-        QualType qt = LookupVectorType(parsedType, colCount);
         TypedefDecl *qts = LookupVectorShorthandType(parsedType, colCount);
         R.addDecl(qts);
       }
       else { // matrix
-        QualType qt = LookupMatrixType(parsedType, rowCount, colCount);
         TypedefDecl* qts = LookupMatrixShorthandType(parsedType, rowCount, colCount);
         R.addDecl(qts);
       }
@@ -4553,19 +4497,6 @@ QualType GetFirstElementTypeFromDecl(const Decl* decl)
     const TemplateArgumentList& list = specialization->getTemplateArgs();
     if (list.size()) {
       return list[0].getAsType();
-    }
-  }
-
-  return QualType();
-}
-
-static
-QualType GetFirstElementType(QualType type)
-{
-  if (!type.isNull()) {
-    const RecordType* record = type->getAs<RecordType>();
-    if (record) {
-      return GetFirstElementTypeFromDecl(record->getDecl());
     }
   }
 
@@ -8631,7 +8562,6 @@ bool HLSLExternalSource::TryStaticCastForHLSL(ExprResult &SrcExpr,
   DXASSERT(!SrcExpr.isInvalid(), "caller should check for invalid expressions and placeholder types");
   bool explicitConversion
     = (CCK == Sema::CCK_CStyleCast || CCK == Sema::CCK_FunctionalCast);
-  QualType sourceType = SrcExpr.get()->getType();
   bool suppressWarnings = explicitConversion || SuppressWarnings;
   SourceLocation loc = OpRange.getBegin();
   if (ValidateCast(loc, SrcExpr.get(), DestType, explicitConversion, suppressWarnings, SuppressErrors, standard)) {
@@ -9179,7 +9109,6 @@ void hlsl::DiagnoseTranslationUnit(clang::Sema *self) {
 
   // TODO: make these error 'real' errors rather than on-the-fly things
   // Validate that the entry point is available.
-  ASTContext &Ctx = self->getASTContext();
   DiagnosticsEngine &Diags = self->getDiagnostics();
   FunctionDecl *pEntryPointDecl = nullptr;
   FunctionDecl *pPatchFnDecl = nullptr;
@@ -10608,7 +10537,6 @@ Decl* Sema::ActOnStartHLSLBuffer(
   SourceLocation LBrace)
 {
   // For anonymous namespace, take the location of the left brace.
-  SourceLocation Loc = Ident ? IdentLoc : LBrace;
   DeclContext* lexicalParent = getCurLexicalContext();
   clang::HLSLBufferDecl *result = HLSLBufferDecl::Create(
       Context, lexicalParent, cbuffer, /*isConstantBufferView*/ false, KwLoc,
@@ -10966,9 +10894,6 @@ bool Sema::DiagnoseHLSLDecl(Declarator &D, DeclContext *DC,
 
   // Validate attributes
   clang::AttributeList
-    *pPrecise = nullptr,
-    *pShared = nullptr,
-    *pGroupShared = nullptr,
     *pUniform = nullptr,
     *pUsage = nullptr,
     *pNoInterpolation = nullptr,
@@ -10988,7 +10913,6 @@ bool Sema::DiagnoseHLSLDecl(Declarator &D, DeclContext *DC,
 
     switch (pAttr->getKind()) {
     case AttributeList::AT_HLSLPrecise: // precise is applicable everywhere.
-      pPrecise = pAttr;
       break;
     case AttributeList::AT_HLSLShared:
       if (!isGlobal) {
@@ -11002,7 +10926,6 @@ bool Sema::DiagnoseHLSLDecl(Declarator &D, DeclContext *DC,
             << pAttr->getRange();
         result = false;
       }
-      pShared = pAttr;
       break;
     case AttributeList::AT_HLSLGroupShared:
       if (!isGlobal) {
@@ -11016,7 +10939,6 @@ bool Sema::DiagnoseHLSLDecl(Declarator &D, DeclContext *DC,
             << pAttr->getRange();
         result = false;
       }
-      pGroupShared = pAttr;
       break;
     case AttributeList::AT_HLSLGloballyCoherent:
       if (!bIsObject) {

--- a/tools/clang/lib/Sema/SemaOpenMP.cpp
+++ b/tools/clang/lib/Sema/SemaOpenMP.cpp
@@ -455,12 +455,6 @@ OMPClause *Sema::ActOnOpenMPLinearClause(ArrayRef<Expr *> VarList, Expr *Step,
   llvm_unreachable("HLSL does not support OpenMP constructs");
 }
 
-static bool FinishOpenMPLinearClause(OMPLinearClause &Clause, DeclRefExpr *IV,
-  Expr *NumIterations, Sema &SemaRef,
-  Scope *S) {
-  llvm_unreachable("HLSL does not support OpenMP constructs");
-}
-
 OMPClause *Sema::ActOnOpenMPAlignedClause(
   ArrayRef<Expr *> VarList, Expr *Alignment, SourceLocation StartLoc,
   SourceLocation LParenLoc, SourceLocation ColonLoc, SourceLocation EndLoc) {

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -41,11 +41,6 @@ using namespace hlsl;
 namespace {
 // Disassemble helper functions.
 
-void PrintDiagnosticHandler(const DiagnosticInfo &DI, void *Context) {
-  DiagnosticPrinter *printer = reinterpret_cast<DiagnosticPrinter *>(Context);
-  DI.print(*printer);
-}
-
 template <typename T>
 const T *ByteOffset(LPCVOID p, uint32_t byteOffset) {
   return reinterpret_cast<const T *>((const uint8_t *)p + byteOffset);


### PR DESCRIPTION
Removes unused variables and functions from code between HLSL
change comments in LLVM code or else in HLSL or SPIRV original
source files along with any code correspondingly rendered unused
or originally in service of these ultimately unused elements.
Each of these produces a warning in clang, gcc, or both.
Fixes around 458 clang warnings and 461 gcc warnings.

Contributes to https://github.com/google/DirectXShaderCompiler/issues/206