### PR TITLE
[linux-port] Evade unused in LLVM code

### DIFF
--- a/lib/Analysis/ConstantFolding.cpp
+++ b/lib/Analysis/ConstantFolding.cpp
@@ -1367,6 +1367,7 @@ static Constant *ConstantFoldBinaryFP(double (__cdecl *NativeFP)(double, double)
   return GetConstantFoldFPValue(V, Ty);
 }
 
+#if 0 // HLSL Change - remove platform intrinsics
 /// Attempt to fold an SSE floating point to integer conversion of a constant
 /// floating point. If roundTowardZero is false, the default IEEE rounding is
 /// used (toward nearest, ties to even). This matches the behavior of the
@@ -1392,6 +1393,7 @@ static Constant *ConstantFoldConvertToInt(const APFloat &Val,
     return nullptr;
   return ConstantInt::get(Ty, UIntVal, /*isSigned=*/true);
 }
+#endif // HLSL Change Ends
 
 // HLSL Change - make non-static.
 double llvm::getValueAsDouble(ConstantFP *Op) {

--- a/lib/DxcSupport/dxcapi.use.cpp
+++ b/lib/DxcSupport/dxcapi.use.cpp
@@ -16,6 +16,7 @@
 
 namespace dxc {
 
+#ifdef _WIN32
 static void TrimEOL(_Inout_z_ char *pMsg) {
   char *pEnd = pMsg + strlen(pMsg);
   --pEnd;
@@ -25,7 +26,6 @@ static void TrimEOL(_Inout_z_ char *pMsg) {
   pEnd[1] = '\0';
 }
 
-#ifdef _WIN32
 static std::string GetWin32ErrorMessage(DWORD err) {
   char formattedMsg[200];
   DWORD formattedMsgLen =

--- a/lib/IR/AsmWriter.cpp
+++ b/lib/IR/AsmWriter.cpp
@@ -691,9 +691,11 @@ void ModuleSlotTracker::incorporateFunction(const Function &F) {
   this->F = &F;
 }
 
+#if 0 // HLSL Change - Unused
 static SlotTracker *createSlotTracker(const Module *M) {
   return new SlotTracker(M);
 }
+#endif
 
 static SlotTracker *createSlotTracker(const Value *V) {
   if (const Argument *FA = dyn_cast<Argument>(V))
@@ -2078,6 +2080,7 @@ AssemblyWriter::AssemblyWriter(formatted_raw_ostream &o, SlotTracker &Mac,
   init();
 }
 
+#if 0 // HLSL Change - Unused
 AssemblyWriter::AssemblyWriter(formatted_raw_ostream &o, const Module *M,
                                AssemblyAnnotationWriter *AAW,
                                bool ShouldPreserveUseListOrder)
@@ -2086,6 +2089,7 @@ AssemblyWriter::AssemblyWriter(formatted_raw_ostream &o, const Module *M,
       ShouldPreserveUseListOrder(ShouldPreserveUseListOrder) {
   init();
 }
+#endif
 
 void AssemblyWriter::writeOperand(const Value *Operand, bool PrintType) {
   if (!Operand) {

--- a/lib/IR/AutoUpgrade.cpp
+++ b/lib/IR/AutoUpgrade.cpp
@@ -30,6 +30,7 @@
 #include <cstring>
 using namespace llvm;
 
+#if 0 // HLSL Change - remove platform intrinsics
 // Upgrade the declarations of the SSE4.1 functions whose arguments have
 // changed their type from v4f32 to v2i64.
 static bool UpgradeSSE41Function(Function* F, Intrinsic::ID IID,
@@ -61,6 +62,7 @@ static bool UpgradeX86IntrinsicsWith8BitMask(Function *F, Intrinsic::ID IID,
   NewFn = Intrinsic::getDeclaration(F->getParent(), IID);
   return true;
 }
+#endif // HLSL Change - remove platform intrinsics
 
 static bool UpgradeIntrinsicFunction1(Function *F, Function *&NewFn) {
   assert(F && "Illegal to upgrade a non-existent Function.");
@@ -246,6 +248,7 @@ bool llvm::UpgradeGlobalVariable(GlobalVariable *GV) {
   return false;
 }
 
+#if 0 // HLSL Change - remove platform intrinsics
 // Handles upgrading SSE2 and AVX2 PSLLDQ intrinsics by converting them
 // to byte shuffles.
 static Value *UpgradeX86PSLLDQIntrinsics(IRBuilder<> &Builder, LLVMContext &C,
@@ -319,6 +322,7 @@ static Value *UpgradeX86PSRLDQIntrinsics(IRBuilder<> &Builder, LLVMContext &C,
                                VectorType::get(Type::getInt64Ty(C), 2*NumLanes),
                                "cast");
 }
+#endif // HLSL Change - remove platform intrinsics
 
 // UpgradeIntrinsicCall - Upgrade a call to an old intrinsic to be a call the
 // upgraded intrinsic. All argument and return casting must be provided in

--- a/lib/IR/DiagnosticInfo.cpp
+++ b/lib/IR/DiagnosticInfo.cpp
@@ -97,9 +97,9 @@ static PassRemarksOptNull PassRemarksOptLoc;
 static PassRemarksOptNull PassRemarksMissedOptLoc;
 static PassRemarksOptNull PassRemarksAnalysisOptLoc;
 
-static PassRemarksOptNull PassRemarks;
-static PassRemarksOptNull PassRemarksMissed;
-static PassRemarksOptNull PassRemarksAnalysis;
+// static PassRemarksOptNull PassRemarks; // HLSL Change
+// static PassRemarksOptNull PassRemarksMissed; // HLSL Change
+// static PassRemarksOptNull PassRemarksAnalysis; // HLSL Change
 }
 #endif
 

--- a/lib/IR/Function.cpp
+++ b/lib/IR/Function.cpp
@@ -379,9 +379,11 @@ void Function::addDereferenceableOrNullAttr(unsigned i, uint64_t Bytes) {
 // allocating an additional word in Function for programs which do not use GC
 // (i.e., most programs) at the cost of increased overhead for clients which do
 // use GC.
+#if 0 // HLSL Change
 static DenseMap<const Function*,PooledStringPtr> *GCNames;
 static StringPool *GCNamePool;
 static ManagedStatic<sys::SmartRWMutex<true> > GCLock;
+#endif // HLSL Change
 
 bool Function::hasGC() const {
 #if 0 // HLSL Change

--- a/lib/IR/LegacyPassManager.cpp
+++ b/lib/IR/LegacyPassManager.cpp
@@ -91,6 +91,7 @@ PrintAfterAll("print-after-all",
 /// This is a helper to determine whether to print IR before or
 /// after a pass.
 
+#if 0 // HLSL Change
 static bool ShouldPrintBeforeOrAfterPass(const PassInfo *PI,
                                          PassOptionList &PassesToPrint) {
   for (auto *PassInf : PassesToPrint) {
@@ -101,6 +102,7 @@ static bool ShouldPrintBeforeOrAfterPass(const PassInfo *PI,
   }
   return false;
 }
+#endif
 
 /// This is a utility to check whether a pass should have IR dumped
 /// before it.

--- a/lib/ProfileData/CoverageMappingReader.cpp
+++ b/lib/ProfileData/CoverageMappingReader.cpp
@@ -432,6 +432,7 @@ static std::error_code loadTestingFormat(StringRef Data,
   return std::error_code();
 }
 
+#if 0 // HLSL Change Starts - remove support for object files
 static ErrorOr<SectionRef> lookupSection(ObjectFile &OF, StringRef Name) {
   StringRef FoundName;
   for (const auto &Section : OF.sections()) {
@@ -442,6 +443,7 @@ static ErrorOr<SectionRef> lookupSection(ObjectFile &OF, StringRef Name) {
   }
   return coveragemap_error::no_data_found;
 }
+#endif // HLSL Change Ends - remove support for object files
 
 static std::error_code loadBinaryFormat(MemoryBufferRef ObjectBuffer,
                                         SectionData &ProfileNames,

--- a/lib/Support/APFloat.cpp
+++ b/lib/Support/APFloat.cpp
@@ -515,6 +515,7 @@ powerOf5(integerPart *dst, unsigned int power)
   return result;
 }
 
+#if 0 // HLSL Change
 /* Zero at the end to avoid modular arithmetic when adding one; used
    when rounding up during hexadecimal output.  */
 static const char hexDigitsLower[] = "0123456789abcdef0";
@@ -574,6 +575,7 @@ writeSignedDecimal(_Out_writes_(11) char *dst, int value) // HLSL Change: '-2147
 
   return dst;
 }
+#endif // HLSL Change
 
 /* Constructors.  */
 void

--- a/lib/Support/CommandLine.cpp
+++ b/lib/Support/CommandLine.cpp
@@ -1630,14 +1630,18 @@ protected:
 // at run time which should be invoked.
 class HelpPrinterWrapper {
 private:
+#if 0 // HLSL Change Starts
   HelpPrinter &UncategorizedPrinter;
   CategorizedHelpPrinter &CategorizedPrinter;
-
+#endif // HLSL Change Ends
 public:
   explicit HelpPrinterWrapper(HelpPrinter &UncategorizedPrinter,
                               CategorizedHelpPrinter &CategorizedPrinter)
+#if 0 // HLSL Change Starts
       : UncategorizedPrinter(UncategorizedPrinter),
-        CategorizedPrinter(CategorizedPrinter) {}
+        CategorizedPrinter(CategorizedPrinter)
+#endif // HLSL Change Starts
+  {}
 
   // Invoke the printer.
   void operator=(bool Value);
@@ -1717,6 +1721,7 @@ void HelpPrinterWrapper::operator=(bool Value) {
   } else
     UncategorizedPrinter = true; // Invoke uncategorized printer
 }
+
 #else
 static const bool PrintOptions = false;
 static const bool PrintAllOptions = false;

--- a/lib/Support/GraphWriter.cpp
+++ b/lib/Support/GraphWriter.cpp
@@ -21,7 +21,7 @@ using namespace llvm;
 #if 0 // HLSL Change Starts - option pending
 static cl::opt<bool> ViewBackground("view-background", cl::Hidden,
   cl::desc("Execute graph viewer in the background. Creates tmp file litter."));
-#else
+#elif defined (__APPLE__)
 static const bool ViewBackground = false;
 #endif // HLSL Change Ends
 

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -101,7 +101,9 @@ static const bool UseNewSROA = true;
 static const bool RunLoopRerolling = false;
 static const bool RunFloat2Int = true;
 static const bool RunLoadCombine = false;
+#if HLSL_VECTORIZATION_ENABLED // HLSL Change - don't build vectorization passes
 static const bool RunSLPAfterLoopVectorization = true;
+#endif // HLSL Change
 static const bool UseCFLAA = false;
 static const bool EnableMLSM = true;
 static const bool EnableLoopInterchange = false;

--- a/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -198,6 +198,7 @@ Instruction *InstCombiner::SimplifyMemSet(MemSetInst *MI) {
   return nullptr;
 }
 
+#if 0 // HLSL Change - remove platform intrinsics
 static Value *SimplifyX86insertps(const IntrinsicInst &II,
                                   InstCombiner::BuilderTy &Builder) {
   if (auto *CInt = dyn_cast<ConstantInt>(II.getArgOperand(2))) {
@@ -318,6 +319,8 @@ static Value *SimplifyX86vperm2(const IntrinsicInst &II,
   }
   return nullptr;
 }
+#endif // HLSL Change - remove platform intrinsics
+
 
 /// visitCallInst - CallInst simplification.  This mostly only handles folding
 /// of intrinsic instructions.  For normal calls, it allows visitCallSite to do

--- a/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -2830,6 +2830,7 @@ static bool TryToSimplifyUncondBranchWithICmpInIt(
   return true;
 }
 
+#if 0  // HLSL Change Begins. This will not help for hlsl.
 /// The specified branch is a conditional branch.
 /// Check to see if it is branching on an or/and chain of icmp instructions, and
 /// fold it into a switch instruction if so.
@@ -2937,6 +2938,8 @@ static bool SimplifyBranchOnICmpChain(BranchInst *BI, IRBuilder<> &Builder,
   DEBUG(dbgs() << "  ** 'icmp' chain result is:\n" << *BB << '\n');
   return true;
 }
+#endif // HLSL Change Ends
+
 
 bool SimplifyCFGOpt::SimplifyResume(ResumeInst *RI, IRBuilder<> &Builder) {
   // If this is a trivial landing pad that just continues unwinding the caught

--- a/tools/clang/lib/Basic/Targets.cpp
+++ b/tools/clang/lib/Basic/Targets.cpp
@@ -36,6 +36,7 @@ using namespace clang;
 //  Common code shared among targets.
 //===----------------------------------------------------------------------===//
 
+#if 0 // HLSL Change Starts - remove unsupported targets
 /// DefineStd - Define a macro name and standard variants.  For example if
 /// MacroName is "unix", then this will define "__unix", "__unix__", and "unix"
 /// when in GNU mode.
@@ -62,6 +63,7 @@ static void defineCPUMacros(MacroBuilder &Builder, StringRef CPUName,
   if (Tuning)
     Builder.defineMacro("__tune_" + CPUName + "__");
 }
+#endif // HLSL Change Ends - remove unsupported targets
 
 //===----------------------------------------------------------------------===//
 // Defines specific to certain operating systems.

--- a/tools/clang/lib/CodeGen/CGCall.cpp
+++ b/tools/clang/lib/CodeGen/CGCall.cpp
@@ -2149,6 +2149,7 @@ void CodeGenFunction::EmitFunctionProlog(const CGFunctionInfo &FI,
   // HLSL Change Ends.
 }
 
+#if 0 // HLSL Change Start - no ObjC support
 static void eraseUnusedBitCasts(llvm::Instruction *insn) {
   while (insn->use_empty()) {
     llvm::BitCastInst *bitcast = dyn_cast<llvm::BitCastInst>(insn);
@@ -2305,6 +2306,7 @@ static llvm::Value *emitAutoreleaseOfResult(CodeGenFunction &CGF,
 
   return CGF.EmitARCAutoreleaseReturnValue(result);
 }
+#endif // HLSL Change Ends - no ObjC support
 
 /// Heuristically search for a dominating store to the return-value slot.
 static llvm::StoreInst *findDominatingStoreToReturnValue(CodeGenFunction &CGF) {
@@ -2582,6 +2584,7 @@ void CodeGenFunction::EmitDelegateCallArg(CallArgList &args,
   args.add(convertTempToRValue(local, type, loc), type);
 }
 
+#if 0 // HLSL Change - no ObjC support
 static bool isProvablyNull(llvm::Value *addr) {
   return isa<llvm::ConstantPointerNull>(addr);
 }
@@ -2590,7 +2593,6 @@ static bool isProvablyNonNull(llvm::Value *addr) {
   return isa<llvm::AllocaInst>(addr);
 }
 
-#if 0 // HLSL Change - no ObjC support
 /// Emit the actual writing-back of a writeback.
 static void emitWriteback(CodeGenFunction &CGF,
                           const CallArgList::Writeback &writeback) {
@@ -2677,6 +2679,7 @@ static void deactivateArgCleanupsBeforeCall(CodeGenFunction &CGF,
   }
 }
 
+#if 0 // HLSL Change - no ObjC support
 static const Expr *maybeGetUnaryAddrOfOperand(const Expr *E) {
   if (const UnaryOperator *uop = dyn_cast<UnaryOperator>(E->IgnoreParens()))
     if (uop->getOpcode() == UO_AddrOf)
@@ -2684,7 +2687,6 @@ static const Expr *maybeGetUnaryAddrOfOperand(const Expr *E) {
   return nullptr;
 }
 
-#if 0 // HLSL Change - no ObjC support
 
 /// Emit an argument that's being passed call-by-writeback.  That is,
 /// we are passing the address of 

--- a/tools/clang/lib/CodeGen/CGCleanup.cpp
+++ b/tools/clang/lib/CodeGen/CGCleanup.cpp
@@ -599,7 +599,7 @@ void CodeGenFunction::PopCleanupBlock(bool FallthroughIsBranchThrough) {
   llvm::BasicBlock *EHEntry = Scope.getCachedEHDispatchBlock();
   assert(Scope.hasEHBranches() == (EHEntry != nullptr));
   bool RequiresEHCleanup = (EHEntry != nullptr);
-  EHScopeStack::stable_iterator EHParent = Scope.getEnclosingEHScope();
+  //EHScopeStack::stable_iterator EHParent = Scope.getEnclosingEHScope(); // HLSL Change - no support for exception handling
 
   // Check the three conditions which might require a normal cleanup:
 

--- a/tools/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/tools/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -1571,7 +1571,6 @@ llvm::DIType *CGDebugInfo::CreateType(const ObjCObjectType *Ty,
   // Ignore protocols.
   return getOrCreateType(Ty->getBaseType(), Unit);
 }
-#endif // HLSL Change - no ObjC support
 
 /// \return true if Getter has the default name for the property PD.
 static bool hasDefaultGetterName(const ObjCPropertyDecl *PD,
@@ -1597,7 +1596,6 @@ static bool hasDefaultSetterName(const ObjCPropertyDecl *PD,
          Setter->getDeclName().getObjCSelector().getNameForSlot(0);
 }
 
-#if 0 // HLSL Change - no ObjC support
 llvm::DIType *CGDebugInfo::CreateType(const ObjCInterfaceType *Ty,
                                       llvm::DIFile *Unit) {
   ObjCInterfaceDecl *ID = Ty->getDecl();
@@ -2977,6 +2975,7 @@ void CGDebugInfo::EmitDeclareOfArgVariable(const VarDecl *VD, llvm::Value *AI,
   EmitDeclare(VD, llvm::dwarf::DW_TAG_arg_variable, AI, ArgNo, Builder);
 }
 
+#if 0 // HLSL Change - no block support
 namespace {
 struct BlockLayoutChunk {
   uint64_t OffsetInBits;
@@ -2987,7 +2986,6 @@ bool operator<(const BlockLayoutChunk &l, const BlockLayoutChunk &r) {
 }
 }
 
-#if 0 // HLSL Change - no block support
 void CGDebugInfo::EmitDeclareOfBlockLiteralArgVariable(const CGBlockInfo &block,
                                                        llvm::Value *Arg,
                                                        unsigned ArgNo,

--- a/tools/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/tools/clang/lib/CodeGen/CGExprScalar.cpp
@@ -3085,13 +3085,13 @@ Value *ScalarExprEmitter::EmitShr(const BinOpInfo &Ops) {
 }
 
 enum IntrinsicType { VCMPEQ, VCMPGT };
+#if 0 // HLSL Change - remove platform intrinsics
 // return corresponding comparison intrinsic for given vector type
 static llvm::Intrinsic::ID GetIntrinsic(IntrinsicType IT,
                                         BuiltinType::Kind ElemKind) {
   llvm_unreachable("HLSL Does not support altivec vectors");
   return llvm::Intrinsic::not_intrinsic;  // HLSL Change - remove platform intrinsics
 
-#if 0 // HLSL Change - remove platform intrinsics
   switch (ElemKind) {
   default: llvm_unreachable("unexpected element type");
   case BuiltinType::Char_U:
@@ -3120,8 +3120,8 @@ static llvm::Intrinsic::ID GetIntrinsic(IntrinsicType IT,
     return (IT == VCMPEQ) ? llvm::Intrinsic::ppc_altivec_vcmpeqfp_p :
                             llvm::Intrinsic::ppc_altivec_vcmpgtfp_p;
   }
-#endif // HLSL Change - remove platform intrinsics
 }
+#endif // HLSL Change - remove platform intrinsics
 
 Value *ScalarExprEmitter::EmitCompare(const BinaryOperator *E,unsigned UICmpOpc,
                                       unsigned SICmpOpc, unsigned FCmpOpc) {

--- a/tools/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3257,6 +3257,7 @@ void CodeGenModule::EmitObjCPropertyImplementations(const
 #endif // HLSL Change - no ObjC support
 }
 
+#if 0 // HLSL Change - no ObjC support
 static bool needsDestructMethod(ObjCImplementationDecl *impl) {
   const ObjCInterfaceDecl *iface = impl->getClassInterface();
   for (const ObjCIvarDecl *ivar = iface->all_declared_ivar_begin();
@@ -3279,6 +3280,7 @@ static bool AllTrivialInitializers(CodeGenModule &CGM,
   }
   return true;
 }
+#endif
 
 /// EmitObjCIvarInitializations - Emit information for ivar initialization
 /// for an implementation.

--- a/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -924,6 +924,7 @@ void ItaniumCXXABI::emitRethrow(CodeGenFunction &CGF, bool isNoReturn) {
     CGF.EmitRuntimeCallOrInvoke(Fn);
 }
 
+#if 0 // HLSL Change Starts
 static llvm::Constant *getAllocateExceptionFn(CodeGenModule &CGM) {
   // void *__cxa_allocate_exception(size_t thrown_size);
 
@@ -943,6 +944,7 @@ static llvm::Constant *getThrowFn(CodeGenModule &CGM) {
 
   return CGM.CreateRuntimeFunction(FTy, "__cxa_throw");
 }
+#endif
 
 void ItaniumCXXABI::emitThrow(CodeGenFunction &CGF, const CXXThrowExpr *E) {
 #if 1 // HLSL Change Starts
@@ -3594,6 +3596,7 @@ void ItaniumCXXABI::emitBeginCatch(CodeGenFunction &CGF,
   CGF.EmitAutoVarCleanups(var);
 }
 
+#if 0 // HLSL Change Start
 /// Get or define the following function:
 ///   void @__clang_call_terminate(i8* %exn) nounwind noreturn
 /// This code is used only in C++.
@@ -3645,6 +3648,7 @@ static llvm::Constant *getClangCallTerminateFn(CodeGenModule &CGM) {
 
   return fnRef;
 }
+#endif // HLSL Change End
 
 llvm::CallInst *
 ItaniumCXXABI::emitTerminateForUnexpectedException(CodeGenFunction &CGF,

--- a/tools/clang/lib/Frontend/ASTUnit.cpp
+++ b/tools/clang/lib/Frontend/ASTUnit.cpp
@@ -140,6 +140,7 @@ static OnDiskData &getOnDiskData(const ASTUnit *AU) {
   return *D;
 }
 
+#if 0 // HLSL Change Starts - no support for PCH
 static void erasePreambleFile(const ASTUnit *AU) {
   getOnDiskData(AU).CleanPreambleFile();
 }
@@ -159,6 +160,7 @@ static void removeOnDiskEntry(const ASTUnit *AU) {
 static void setPreambleFile(const ASTUnit *AU, StringRef preambleFile) {
   getOnDiskData(AU).PreambleFile = preambleFile;
 }
+#endif // HLSL Change Ends - no support for PCH
 
 static const std::string &getPreambleFile(const ASTUnit *AU) {
   return getOnDiskData(AU).PreambleFile;  
@@ -209,7 +211,8 @@ void ASTUnit::addTemporaryFile(StringRef TempFile) {
 /// errors in the source that occurs in the preamble), the number of
 /// reparses during which we'll skip even trying to precompile the
 /// preamble.
-const unsigned DefaultPreambleRebuildInterval = 5;
+//const unsigned DefaultPreambleRebuildInterval = 5; // HLSL Change Starts - no support for PCH
+
 
 /// \brief Tracks the number of ASTUnit objects that are currently active.
 ///
@@ -1206,6 +1209,7 @@ error:
   return true;
 }
 
+#if 0 // HLSL Change Ends - no support for PCH
 /// \brief Simple function to retrieve a path for a preamble precompiled header.
 static std::string GetPreamblePCHPath() {
   // FIXME: This is a hack so that we can override the preamble file during
@@ -1220,6 +1224,7 @@ static std::string GetPreamblePCHPath() {
 
   return Path.str();
 }
+#endif // HLSL Change Ends - no support for PCH
 
 /// \brief Compute the preamble for the main file, providing the source buffer
 /// that corresponds to the main file along with a pair (bytes, start-of-line)
@@ -1311,6 +1316,7 @@ bool operator==(const ASTUnit::PreambleFileHash &LHS,
 }
 } // namespace clang
 
+#if 0 // HLSL Change Starts - no support for PCH
 static std::pair<unsigned, unsigned>
 makeStandaloneRange(CharSourceRange Range, const SourceManager &SM,
                     const LangOptions &LangOpts) {
@@ -1355,6 +1361,7 @@ makeStandaloneDiagnostic(const LangOptions &LangOpts,
 
   return OutDiag;
 }
+#endif // HLSL Change Ends - no support for PCH
 
 /// \brief Attempt to build or re-use a precompiled preamble when (re-)parsing
 /// the source file.
@@ -2885,6 +2892,7 @@ struct PCHLocatorInfo {
 };
 }
 
+#if 0 // HLSL Change Starts - no support for PCH
 static bool PCHLocator(serialization::ModuleFile &M, void *UserData) {
   PCHLocatorInfo &Info = *static_cast<PCHLocatorInfo*>(UserData);
   switch (M.Kind) {
@@ -2902,6 +2910,7 @@ static bool PCHLocator(serialization::ModuleFile &M, void *UserData) {
 
   return true;
 }
+#endif // HLSL Change Ends - no support for PCH
 
 const FileEntry *ASTUnit::getPCHFile() {
 #if 1 // HLSL Change Starts - no support for modules or PCH

--- a/tools/clang/lib/Frontend/CompilerInstance.cpp
+++ b/tools/clang/lib/Frontend/CompilerInstance.cpp
@@ -889,6 +889,16 @@ bool CompilerInstance::ExecuteAction(FrontendAction &Act) {
   return !getDiagnostics().getClient()->getNumErrors();
 }
 
+#if 1 // HLSL Change Starts - no support for modules
+
+bool CompilerInstance::lookupMissingImports(StringRef, SourceLocation) { return false; }
+GlobalModuleIndex *CompilerInstance::loadGlobalModuleIndex(SourceLocation) { return nullptr; }
+void CompilerInstance::makeModuleVisible(Module *, Module::NameVisibilityKind, SourceLocation) { }
+ModuleLoadResult CompilerInstance::loadModule(SourceLocation, ModuleIdPath, Module::NameVisibilityKind, bool) { return ModuleLoadResult(); }
+bool CompilerInstance::loadModuleFile(StringRef) { return false; }
+void CompilerInstance::createModuleManager() { }
+
+#else
 /// \brief Determine the appropriate source input kind based on language
 /// options.
 static InputKind getSourceInputKindFromOptions(const LangOptions &LangOpts) {
@@ -902,17 +912,6 @@ static InputKind getSourceInputKindFromOptions(const LangOptions &LangOpts) {
     return LangOpts.CPlusPlus? IK_ObjCXX : IK_ObjC;
   return LangOpts.CPlusPlus? IK_CXX : IK_C;
 }
-
-#if 1 // HLSL Change Starts - no support for modules
-
-bool CompilerInstance::lookupMissingImports(StringRef, SourceLocation) { return false; }
-GlobalModuleIndex *CompilerInstance::loadGlobalModuleIndex(SourceLocation) { return nullptr; }
-void CompilerInstance::makeModuleVisible(Module *, Module::NameVisibilityKind, SourceLocation) { }
-ModuleLoadResult CompilerInstance::loadModule(SourceLocation, ModuleIdPath, Module::NameVisibilityKind, bool) { return ModuleLoadResult(); }
-bool CompilerInstance::loadModuleFile(StringRef) { return false; }
-void CompilerInstance::createModuleManager() { }
-
-#else
 
 /// \brief Compile a module file for the given module, using the options 
 /// provided by the importing compiler instance. Returns true if the module

--- a/tools/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/tools/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1299,6 +1299,7 @@ void CompilerInvocation::setLangDefaults(LangOptions &Opts, InputKind IK,
 
 }
 
+#ifdef MS_SUPPORT_VARIABLE_LANGOPTS
 /// Attempt to parse a visibility value out of the given argument.
 static Visibility parseVisibility(Arg *arg, ArgList &args,
                                   DiagnosticsEngine &diags) {
@@ -1316,6 +1317,7 @@ static Visibility parseVisibility(Arg *arg, ArgList &args,
     << arg->getAsString(args) << value;
   return DefaultVisibility;
 }
+#endif // MS_SUPPORT_VARIABLE_LANGOPTS
 
 static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
                           DiagnosticsEngine &Diags) {

--- a/tools/clang/lib/Parse/ParseStmtAsm.cpp
+++ b/tools/clang/lib/Parse/ParseStmtAsm.cpp
@@ -262,6 +262,7 @@ ExprResult Parser::ParseMSAsmIdentifier(llvm::SmallVectorImpl<Token> &LineToks,
                                            IsUnevaluatedContext);
 }
 
+#if 0 // HLSL Change Start - disable this block to avoid having to build/link llvmMC
 /// Turn a sequence of our tokens back into a string that we can hand
 /// to the MC asm parser.
 static bool buildMSAsmString(Preprocessor &PP, SourceLocation AsmLoc,
@@ -318,6 +319,7 @@ static bool buildMSAsmString(Preprocessor &PP, SourceLocation AsmLoc,
   assert(TokOffsets.size() == AsmToks.size());
   return false;
 }
+#endif // HLSL Change End - disable this block to avoid having to build/link llvmMC
 
 /// ParseMicrosoftAsmStatement. When -fms-extensions/-fasm-blocks is enabled,
 /// this routine is called to collect the tokens for an MS asm statement.

--- a/tools/clang/lib/Sema/SemaChecking.cpp
+++ b/tools/clang/lib/Sema/SemaChecking.cpp
@@ -8564,6 +8564,7 @@ namespace {
   };
 }
 
+#if 0 // HLSL Change Starts
 /// Consider whether capturing the given variable can possibly lead to
 /// a retain cycle.
 static bool considerVariable(VarDecl *var, Expr *ref, RetainCycleOwner &owner) {
@@ -8657,7 +8658,7 @@ static bool findRetainCycleOwner(Sema &S, Expr *e, RetainCycleOwner &owner) {
     return false;
   }
 }
-
+#endif // HLSL Change Ends
 namespace {
   struct FindCaptureVisitor : EvaluatedExprVisitor<FindCaptureVisitor> {
     FindCaptureVisitor(ASTContext &Context, VarDecl *variable)
@@ -8710,6 +8711,7 @@ namespace {
   };
 }
 
+#if 0 // HLSL Change Starts
 /// Check whether the given argument is a block which captures a
 /// variable.
 static Expr *findCapturingExpr(Sema &S, Expr *e, RetainCycleOwner &owner) {
@@ -8780,8 +8782,6 @@ static bool isSetterLikeSelector(Selector sel) {
   return !isLowercase(str.front());
 }
 
-#if 1 // HLSL Change Starts
-#else // HLSL Change Ends
 static Optional<int> GetNSMutableArrayArgumentIndex(Sema &S,
                                                     ObjCMessageExpr *Message) {
   bool IsMutableArray = S.NSAPIObj->isSubclassOfNSClass(

--- a/tools/clang/lib/Sema/SemaDeclObjC.cpp
+++ b/tools/clang/lib/Sema/SemaDeclObjC.cpp
@@ -3709,6 +3709,7 @@ Decl *Sema::ActOnAtEnd(Scope *S, SourceRange AtEnd, ArrayRef<Decl *> allMethods,
 }
 
 
+#if 0 // HLSL Change Starts
 /// CvtQTToAstBitMask - utility routine to produce an AST bitmask for
 /// objective-c's type qualifier from the parser version of the same info.
 static Decl::ObjCDeclQualifier
@@ -3754,6 +3755,7 @@ CheckRelatedResultTypeCompatibility(Sema &S, ObjCMethodDecl *Method,
   
   return Sema::RTC_Incompatible;
 }
+#endif // HLSL Change Ends
 
 namespace {
 /// A helper class for searching for methods which a particular method
@@ -4004,6 +4006,7 @@ void Sema::CheckObjCMethodOverrides(ObjCMethodDecl *ObjCMethod,
   ObjCMethod->setOverriding(hasOverriddenMethodsInBaseOrProtocol);
 }
 
+#if 0 // HLSL Change Starts - HLSL does not support ObjC constructs
 /// Merge type nullability from for a redeclaration of the same entity,
 /// producing the updated type of the redeclared entity.
 static QualType mergeTypeNullabilityForRedecl(Sema &S, SourceLocation loc,
@@ -4086,6 +4089,7 @@ static void mergeInterfaceMethodToImpl(Sema &S,
     param->setType(newParamType);
   }
 }
+#endif // HLSL Change Ends - HLSL does not support ObjC constructs
 
 Decl *Sema::ActOnMethodDeclaration(
     Scope *S,

--- a/tools/clang/lib/Sema/SemaExceptionSpec.cpp
+++ b/tools/clang/lib/Sema/SemaExceptionSpec.cpp
@@ -182,6 +182,7 @@ Sema::UpdateExceptionSpec(FunctionDecl *FD,
     Context.adjustExceptionSpec(cast<FunctionDecl>(Redecl), ESI);
 }
 
+#if 0 // HLSL Change Starts
 /// Determine whether a function has an implicitly-generated exception
 /// specification.
 static bool hasImplicitExceptionSpec(FunctionDecl *Decl) {
@@ -202,6 +203,8 @@ static bool hasImplicitExceptionSpec(FunctionDecl *Decl) {
     Decl->getTypeSourceInfo()->getType()->getAs<FunctionProtoType>();
   return !Ty->hasExceptionSpec();
 }
+#endif // HLSL Change Ends
+
 
 bool Sema::CheckEquivalentExceptionSpec(FunctionDecl *Old, FunctionDecl *New) {
   // HLSL Change Starts

--- a/tools/clang/lib/Sema/SemaExpr.cpp
+++ b/tools/clang/lib/Sema/SemaExpr.cpp
@@ -8355,6 +8355,11 @@ static void diagnoseFunctionPointerToVoidComparison(Sema &S, SourceLocation Loc,
     << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
 }
 
+#if 1 // HLSL Change Starts
+Sema::ObjCLiteralKind Sema::CheckLiteralKind(Expr *FromE) {
+  return LK_None;
+}
+#else
 static bool isObjCObjectLiteral(ExprResult &E) {
   switch (E.get()->IgnoreParenImpCasts()->getStmtClass()) {
   case Stmt::ObjCArrayLiteralClass:
@@ -8368,11 +8373,6 @@ static bool isObjCObjectLiteral(ExprResult &E) {
   }
 }
 
-#if 1 // HLSL Change Starts
-Sema::ObjCLiteralKind Sema::CheckLiteralKind(Expr *FromE) {
-  return LK_None;
-}
-#else
 static bool hasIsEqualMethod(Sema &S, const Expr *LHS, const Expr *RHS) {
   const ObjCObjectPointerType *Type =
     LHS->getType()->getAs<ObjCObjectPointerType>();

--- a/tools/clang/lib/Sema/SemaExprObjC.cpp
+++ b/tools/clang/lib/Sema/SemaExprObjC.cpp
@@ -3666,6 +3666,7 @@ bool Sema::isKnownName(StringRef name) {
   return LookupName(R, TUScope, false);
 }
 
+#if 0 // HLSL Change Start - No ObjC support
 static void addFixitForObjCARCConversion(Sema &S,
                                          DiagnosticBuilder &DiagB,
                                          Sema::CheckedConversionKind CCK,
@@ -3763,6 +3764,7 @@ static void addFixitForObjCARCConversion(Sema &S,
     }
   }
 }
+#endif // HLSL change End - No ObjC support
 
 template <typename T>
 static inline T *getObjCBridgeAttr(const TypedefType *TD) {

--- a/tools/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/tools/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -3612,6 +3612,7 @@ Sema::DeduceTemplateArguments(FunctionTemplateDecl *FunctionTemplate,
   return TDK_Success;
 }
 
+#if 0 // HLSL Change Starts
 /// \brief Given a function declaration (e.g. a generic lambda conversion 
 ///  function) that contains an 'auto' in its result type, substitute it 
 ///  with TypeToReplaceAutoWith.  Be careful to pass in the type you want
@@ -3627,6 +3628,7 @@ SubstAutoWithinFunctionReturnType(FunctionDecl *F,
                                                TypeToReplaceAutoWith);
   S.Context.adjustDeducedFunctionResultType(F, DeducedResultType);
 }
+#endif // HLSL Change Ends
 
 /// \brief Given a specialized conversion operator of a generic lambda 
 /// create the corresponding specializations of the call operator and 

--- a/tools/clang/tools/libclang/CIndex.cpp
+++ b/tools/clang/tools/libclang/CIndex.cpp
@@ -2872,7 +2872,7 @@ struct RegisterFatalErrorHandler {
 };
 }
 
-static llvm::ManagedStatic<RegisterFatalErrorHandler> RegisterFatalErrorHandlerOnce;
+//static llvm::ManagedStatic<RegisterFatalErrorHandler> RegisterFatalErrorHandlerOnce; // HLSL Change - properly scoped mechanisms should be used
 
 // extern "C" {    // HLSL Change -Don't use c linkage.
 CXIndex clang_createIndex(int excludeDeclarationsFromPCH,

--- a/utils/TableGen/FixedLenDecoderEmitter.cpp
+++ b/utils/TableGen/FixedLenDecoderEmitter.cpp
@@ -411,7 +411,7 @@ protected:
   }
 
   // Called from Filter::recurse() when singleton exists.  For debug purpose.
-  void SingletonExists(unsigned Opc) const;
+  //void SingletonExists(unsigned Opc) const; // HLSL Change - Unused
 
   bool PositionFiltered(unsigned i) const {
     return ValueSet(FilterBitValues[i]);
@@ -947,6 +947,7 @@ void FilterChooser::dumpStack(raw_ostream &o, const char *prefix) const {
   }
 }
 
+#if 0 // HLSL Change Unused
 // Called from Filter::recurse() when singleton exists.  For debug purpose.
 void FilterChooser::SingletonExists(unsigned Opc) const {
   insn_t Insn0;
@@ -970,6 +971,7 @@ void FilterChooser::SingletonExists(unsigned Opc) const {
     errs() << '\n';
   }
 }
+#endif // HLSL Change Ends - Unused
 
 // Calculates the island(s) needed to decode the instruction.
 // This returns a list of undecoded bits of an instructions, for example,


### PR DESCRIPTION
Primarily if not exclusively due to the massive carveouts of the
original LLVM source base as part of the HLSL adaptation, many
variables and functions are left unused. In keeping with the
practice of commenting or ifdef-ing out unused portions of this
code and marking every such exclusion as an HLSL change, this adds
few comments and moves a lot of preprocessor conditionals around to
encompass the portions left unused as a consequence of the earlier
exclusions.
Fixes 450 clang and 442 gcc warnings.

Contributes to https://github.com/google/DirectXShaderCompiler/issues/206