### PR TITLE
[linux-port] Implement Win file IO funcs for *nix

### DIFF
--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -141,6 +141,21 @@
 
 #define MB_ERR_INVALID_CHARS 0x00000008 // error for invalid chars
 
+// File IO
+
+#define CREATE_ALWAYS 2
+#define CREATE_NEW 1
+#define OPEN_ALWAYS 4
+#define OPEN_EXISTING 3
+#define TRUNCATE_EXISTING 5
+
+#define FILE_SHARE_DELETE 0x00000004
+#define FILE_SHARE_READ 0x00000001
+#define FILE_SHARE_WRITE 0x00000002
+
+#define GENERIC_READ 0x80000000
+#define GENERIC_WRITE 0x40000000
+
 #define _atoi64 atoll
 #define sprintf_s snprintf
 #define _strdup strdup
@@ -859,7 +874,19 @@ public:
 
 typedef CA2WEX<> CA2W;
 
-#endif  // __cplusplus
+//===--------- File IO Related Types ----------------===//
+
+class CHandle {
+public:
+  CHandle(HANDLE h);
+  ~CHandle();
+  operator HANDLE() const throw();
+
+private:
+  HANDLE m_h;
+};
+
+#endif // __cplusplus
 
 #endif // _WIN32
 

--- a/include/llvm/Support/WinFunctions.h
+++ b/include/llvm/Support/WinFunctions.h
@@ -26,6 +26,29 @@ HRESULT UInt32Mult(UINT a, UINT b, UINT *out);
 int _stricmp(const char *str1, const char *str2);
 HRESULT CoGetMalloc(DWORD dwMemContext, IMalloc **ppMalloc);
 
+HANDLE CreateFile2(_In_ LPCWSTR lpFileName, _In_ DWORD dwDesiredAccess,
+                   _In_ DWORD dwShareMode, _In_ DWORD dwCreationDisposition,
+                   _In_opt_ void *pCreateExParams);
+
+HANDLE CreateFileW(_In_ LPCWSTR lpFileName, _In_ DWORD dwDesiredAccess,
+                   _In_ DWORD dwShareMode, _In_opt_ void *lpSecurityAttributes,
+                   _In_ DWORD dwCreationDisposition,
+                   _In_ DWORD dwFlagsAndAttributes,
+                   _In_opt_ HANDLE hTemplateFile);
+
+BOOL GetFileSizeEx(_In_ HANDLE hFile, _Out_ PLARGE_INTEGER lpFileSize);
+
+BOOL ReadFile(_In_ HANDLE hFile, _Out_ LPVOID lpBuffer,
+              _In_ DWORD nNumberOfBytesToRead,
+              _Out_opt_ LPDWORD lpNumberOfBytesRead,
+              _Inout_opt_ void *lpOverlapped);
+BOOL WriteFile(_In_ HANDLE hFile, _In_ LPCVOID lpBuffer,
+               _In_ DWORD nNumberOfBytesToWrite,
+               _Out_opt_ LPDWORD lpNumberOfBytesWritten,
+               _Inout_opt_ void *lpOverlapped);
+
+BOOL CloseHandle(_In_ HANDLE hObject);
+
 #endif // _WIN32
 
 #endif // LLVM_SUPPORT_WINFUNCTIONS_H

--- a/lib/DxcSupport/WinAdapter.cpp
+++ b/lib/DxcSupport/WinAdapter.cpp
@@ -10,6 +10,7 @@
 #ifndef _WIN32
 
 #include "dxc/Support/WinAdapter.h"
+#include "llvm/Support/WinFunctions.h"
 
 DEFINE_CROSS_PLATFORM_UUIDOF(IUnknown)
 DEFINE_CROSS_PLATFORM_UUIDOF(INoMarshal)
@@ -48,5 +49,11 @@ void *CAllocator::Reallocate(void *p, size_t nBytes) throw() {
 }
 void *CAllocator::Allocate(size_t nBytes) throw() { return malloc(nBytes); }
 void CAllocator::Free(void *p) throw() { free(p); }
+
+//===--------------------------- CHandle -------------------------------===//
+
+CHandle::CHandle(HANDLE h) { m_h = h; }
+CHandle::~CHandle() { CloseHandle(m_h); }
+CHandle::operator HANDLE() const throw() { return m_h; }
 
 #endif

--- a/lib/Support/WinFunctions.cpp
+++ b/lib/Support/WinFunctions.cpp
@@ -12,17 +12,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #ifndef _WIN32
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include "llvm/Support/WinFunctions.h"
 
-HRESULT StringCchPrintfA(char *dst, size_t dstSize, const char* format, ...) {
+HRESULT StringCchPrintfA(char *dst, size_t dstSize, const char *format, ...) {
   va_list args;
   va_start(args, format);
-  // C++11 snprintf can return the size of the resulting string if it was to be constructed.
+  // C++11 snprintf can return the size of the resulting string if it was to be
+  // constructed.
   size_t size = snprintf(nullptr, 0, format, args) + 1; // Extra space for '\0'
-  if(size > dstSize) {
+  if (size > dstSize) {
     *dst = '\0';
   } else {
     snprintf(dst, size, format, args);
@@ -30,7 +33,7 @@ HRESULT StringCchPrintfA(char *dst, size_t dstSize, const char* format, ...) {
   va_end(args);
   return S_OK;
 }
-HRESULT UIntAdd(UINT uAugend, UINT uAddend, UINT* puResult) {
+HRESULT UIntAdd(UINT uAugend, UINT uAddend, UINT *puResult) {
   HRESULT hr;
   if ((uAugend + uAddend) >= uAugend) {
     *puResult = (uAugend + uAddend);
@@ -41,7 +44,7 @@ HRESULT UIntAdd(UINT uAugend, UINT uAddend, UINT* puResult) {
   }
   return hr;
 }
-HRESULT IntToUInt(int in, UINT* out) {
+HRESULT IntToUInt(int in, UINT *out) {
   HRESULT hr;
   if (in >= 0) {
     *out = (UINT)in;
@@ -52,9 +55,9 @@ HRESULT IntToUInt(int in, UINT* out) {
   }
   return hr;
 }
-HRESULT UInt32Mult(UINT a, UINT b, UINT* out) {
+HRESULT UInt32Mult(UINT a, UINT b, UINT *out) {
   uint64_t result = (uint64_t)a * (uint64_t)b;
-  if(result > uint64_t(UINT_MAX))
+  if (result > uint64_t(UINT_MAX))
     return (HRESULT)1L;
 
   *out = (uint32_t)result;
@@ -77,6 +80,99 @@ HRESULT CoGetMalloc(DWORD dwMemContext, IMalloc **ppMalloc) {
   return S_OK;
 }
 
+HANDLE CreateFile2(_In_ LPCWSTR lpFileName, _In_ DWORD dwDesiredAccess,
+                   _In_ DWORD dwShareMode, _In_ DWORD dwCreationDisposition,
+                   _In_opt_ void *pCreateExParams) {
+  return CreateFileW(lpFileName, dwDesiredAccess, dwShareMode, pCreateExParams,
+                     dwCreationDisposition, FILE_ATTRIBUTE_NORMAL, nullptr);
+}
+
+HANDLE CreateFileW(_In_ LPCWSTR lpFileName, _In_ DWORD dwDesiredAccess,
+                   _In_ DWORD dwShareMode, _In_opt_ void *lpSecurityAttributes,
+                   _In_ DWORD dwCreationDisposition,
+                   _In_ DWORD dwFlagsAndAttributes,
+                   _In_opt_ HANDLE hTemplateFile) {
+  CW2A pUtf8FileName(lpFileName);
+  size_t fd = -1;
+  int flags = 0;
+
+  if (dwDesiredAccess & GENERIC_WRITE)
+    if (dwDesiredAccess & GENERIC_READ)
+      flags |= O_RDWR;
+    else
+      flags |= O_WRONLY;
+  else // dwDesiredAccess may be 0, but open() demands something here. This is mostly harmless
+    flags |= O_RDONLY;
+
+  if (dwCreationDisposition == CREATE_ALWAYS)
+    flags |= (O_CREAT | O_TRUNC);
+  if (dwCreationDisposition == OPEN_ALWAYS)
+    flags |= O_CREAT;
+  else if (dwCreationDisposition == CREATE_NEW)
+    flags |= (O_CREAT | O_EXCL);
+  else if (dwCreationDisposition == TRUNCATE_EXISTING)
+    flags |= O_TRUNC;
+  // OPEN_EXISTING represents default open() behavior
+
+  // Catch Implementation limitations.
+  assert(!lpSecurityAttributes && "security attributes not supported in CreateFileW yet");
+  assert(!hTemplateFile && "template file not supported in CreateFileW yet");
+  assert(dwFlagsAndAttributes == FILE_ATTRIBUTE_NORMAL &&
+         "Attributes other than NORMAL not supported in CreateFileW yet");
+
+  fd = open(pUtf8FileName, flags);
+
+  return (HANDLE)fd;
+}
+
+BOOL GetFileSizeEx(_In_ HANDLE hFile, _Out_ PLARGE_INTEGER lpFileSize) {
+  int fd = (size_t)hFile;
+  struct stat fdstat;
+  int rv = fstat(fd, &fdstat);
+  if (!rv) {
+    lpFileSize->QuadPart = (LONGLONG)fdstat.st_size;
+    return true;
+  }
+  return false;
+}
+
+BOOL ReadFile(_In_ HANDLE hFile, _Out_ LPVOID lpBuffer,
+              _In_ DWORD nNumberOfBytesToRead,
+              _Out_opt_ LPDWORD lpNumberOfBytesRead,
+              _Inout_opt_ void *lpOverlapped) {
+  size_t fd = (size_t)hFile;
+  ssize_t rv = -1;
+
+  // Implementation limitation
+  assert(!lpOverlapped && "Overlapping not supported in ReadFile yet.");
+
+  rv = read(fd, lpBuffer, nNumberOfBytesToRead);
+  if (rv < 0)
+    return false;
+  *lpNumberOfBytesRead = rv;
+  return true;
+}
+
+BOOL WriteFile(_In_ HANDLE hFile, _In_ LPCVOID lpBuffer,
+               _In_ DWORD nNumberOfBytesToWrite,
+               _Out_opt_ LPDWORD lpNumberOfBytesWritten,
+               _Inout_opt_ void *lpOverlapped) {
+  size_t fd = (size_t)hFile;
+  ssize_t rv = -1;
+
+  // Implementation limitation
+  assert(!lpOverlapped && "Overlapping not supported in WriteFile yet.");
+
+  rv = write(fd, lpBuffer, nNumberOfBytesToWrite);
+  if (rv < 0)
+    return false;
+  *lpNumberOfBytesWritten = rv;
+  return true;
+}
+
+BOOL CloseHandle(_In_ HANDLE hObject) {
+  int fd = (size_t)hObject;
+  return !close(fd);
+}
 
 #endif // _WIN32
-


### PR DESCRIPTION
Add CreateFile*, Read/WriteFile, and other Windows interfaces for
file management. Also add CHandle for scope-based file closure.
This allows more shared code, implicitly implements some
features missing from the Unix implementation, and prevents
inconsistencies in when files are closed. i.e. WriteHeader in dxc.cpp
called WriteString twice on the same file, though WriteString closed
that file.