### PR TITLE
[linux-port] fix simple ErrorCodes.h warning

### DIFF
--- a/include/dxc/Support/ErrorCodes.h
+++ b/include/dxc/Support/ErrorCodes.h
@@ -17,7 +17,7 @@
 #define DXC_MAKE_HRESULT(sev,fac,code) \
     ((HRESULT) (((unsigned long)(sev)<<31) | ((unsigned long)(fac)<<16) | ((unsigned long)(code))) )
 
-#define HRESULT_IS_WIN32ERR(hr) ((hr & 0xFFFF0000) == MAKE_HRESULT(SEVERITY_ERROR, FACILITY_WIN32, 0))
+#define HRESULT_IS_WIN32ERR(hr) ((HRESULT)(hr & 0xFFFF0000) == MAKE_HRESULT(SEVERITY_ERROR, FACILITY_WIN32, 0))
 #define HRESULT_AS_WIN32ERR(hr) (HRESULT_CODE(hr))
 
 // Error codes from C libraries (0n150) - 0x8096xxxx


### PR DESCRIPTION
The errno as GetLastError change exposed previously excluded
but existing code to *nix compilers that contains a unsigned/
signed comparison that produces a warning. Simple fix for a
simple warning.