### PR TITLE
[macos-port] Get dxc building on MacOS

### DIFF
--- a/include/dxc/Support/dxcapi.use.h
+++ b/include/dxc/Support/dxcapi.use.h
@@ -79,6 +79,8 @@ public:
   HRESULT Initialize() {
     #ifdef _WIN32
     return InitializeInternal(L"dxcompiler.dll", "DxcCreateInstance");
+    #elif __APPLE__
+    return InitializeInternal(L"libdxcompiler.dylib", "DxcCreateInstance");
     #else
     return InitializeInternal(L"libdxcompiler.so", "DxcCreateInstance");
     #endif

--- a/lib/Support/regerror.c
+++ b/lib/Support/regerror.c
@@ -108,12 +108,15 @@ llvm_regerror(int errcode, const llvm_regex_t *preg, _Out_writes_all_(errbuf_siz
 				assert(strlen(r->name) < sizeof(convbuf));
 				(void) llvm_strlcpy(convbuf, r->name, sizeof convbuf);
 			} else
+                          // Begin HLSL Change
 #ifndef _WIN32
 				(void)snprintf(convbuf, sizeof convbuf,
+				    "REG_0x%x", target);
 #else
 				(void)_snprintf_s(convbuf, _countof(convbuf), _countof(convbuf),
-#endif
 				    "REG_0x%x", target);
+#endif
+                          // End HLSL Change
 			s = convbuf;
 		} else
 			s = r->explain;

--- a/lib/Support/regex_impl.h
+++ b/lib/Support/regex_impl.h
@@ -35,8 +35,8 @@
  *	@(#)regex.h	8.1 (Berkeley) 6/2/93
  */
 
-#ifndef _REGEX_H_
-#define	_REGEX_H_
+#ifndef _REGEX_IMPL_H_ // HLSL Change
+#define	_REGEX_IMPL_H_ // HLSL Change
 
 #include <sys/types.h>
 #include "dxc/Support/WinAdapter.h"
@@ -119,4 +119,4 @@ size_t  llvm_strlcpy(
 }
 #endif
 
-#endif /* !_REGEX_H_ */
+#endif /* !_REGEX_IMPL_H_ */ // HLSL Change


### PR DESCRIPTION
The REGEX_H define prevented the inclusion of an Apple system header.
Not coincidentally, the same header regex_impl.h was derived from.

Prevent Apple warning by splitting macro args with an #else. Add HLSL
change comments too which were missing from the start.

Search for libdxcompiler.dylib instead of .so on Apple.

Enables https://github.com/google/DirectXShaderCompiler/issues/199