### PR TITLE
[linux-port] Use cross-platform dynamic lib load

### DIFF
--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -105,6 +105,9 @@
 #define ERROR_IO_DEVICE EIO
 #define ERROR_INVALID_HANDLE EBADF
 
+// Error returned explicitly. Windows value used.
+#define ERROR_DLL_INIT_FAILED 0x45A
+
 // Used by HRESULT <--> WIN32 error code conversion
 #define SEVERITY_ERROR 1
 #define FACILITY_WIN32 7

--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -105,9 +105,6 @@
 #define ERROR_IO_DEVICE EIO
 #define ERROR_INVALID_HANDLE EBADF
 
-// Error returned explicitly. Windows value used.
-#define ERROR_DLL_NOT_FOUND ELIBACC
-
 // Used by HRESULT <--> WIN32 error code conversion
 #define SEVERITY_ERROR 1
 #define FACILITY_WIN32 7

--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -106,7 +106,7 @@
 #define ERROR_INVALID_HANDLE EBADF
 
 // Error returned explicitly. Windows value used.
-#define ERROR_DLL_INIT_FAILED 0x45A
+#define ERROR_DLL_NOT_FOUND ELIBACC
 
 // Used by HRESULT <--> WIN32 error code conversion
 #define SEVERITY_ERROR 1

--- a/include/dxc/Support/dxcapi.use.h
+++ b/include/dxc/Support/dxcapi.use.h
@@ -28,7 +28,7 @@ protected:
   HRESULT InitializeInternal(LPCWSTR dllName, LPCSTR fnName) {
     if (m_dll.isValid()) return S_OK;
     m_dll = DynamicLibrary::getPermanentLibrary(CW2A(dllName));
-    if (!m_dll.isValid()) return HRESULT_FROM_WIN32(ERROR_DLL_INIT_FAILED);
+    if (!m_dll.isValid()) return HRESULT_FROM_WIN32(ERROR_DLL_NOT_FOUND);
     m_createFn = (DxcCreateInstanceProc)m_dll.getAddressOfSymbol(fnName);
 
     if (m_createFn == nullptr) {

--- a/include/dxc/Support/dxcapi.use.h
+++ b/include/dxc/Support/dxcapi.use.h
@@ -13,38 +13,27 @@
 #define __DXCAPI_USE_H__
 
 #include "dxc/dxcapi.h"
+#include "llvm/Support/DynamicLibrary.h"
 
 namespace dxc {
 
 // Helper class to dynamically load the dxcompiler or a compatible libraries.
 class DxcDllSupport {
 protected:
-  HMODULE m_dll;
+  using DynamicLibrary = llvm::sys::DynamicLibrary;
+  DynamicLibrary m_dll;
   DxcCreateInstanceProc m_createFn;
   DxcCreateInstance2Proc m_createFn2;
 
-  #ifndef _WIN32
-  void FreeLibrary(void* handle) {
-    ::dlclose(handle);
-  }
-  HMODULE LoadLibraryW(LPCWSTR name) {
-    return ::dlopen(CW2A(name).m_psz, RTLD_LAZY);
-  }
-  HMODULE GetProcAddress(HMODULE dll, LPCSTR fnName) {
-    return ::dlsym(dll, fnName);
-  }
-  #endif
-
   HRESULT InitializeInternal(LPCWSTR dllName, LPCSTR fnName) {
-    if (m_dll != nullptr) return S_OK;
-    m_dll = LoadLibraryW(dllName);
-    if (m_dll == nullptr) return HRESULT_FROM_WIN32(GetLastError());
-    m_createFn = (DxcCreateInstanceProc)GetProcAddress(m_dll, fnName);
+    if (m_dll.isValid()) return S_OK;
+    m_dll = DynamicLibrary::getPermanentLibrary(CW2A(dllName));
+    if (!m_dll.isValid()) return HRESULT_FROM_WIN32(ERROR_DLL_INIT_FAILED);
+    m_createFn = (DxcCreateInstanceProc)m_dll.getAddressOfSymbol(fnName);
 
     if (m_createFn == nullptr) {
       HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
-      FreeLibrary(m_dll);
-      m_dll = nullptr;
+      m_dll = DynamicLibrary();
       return hr;
     }
 
@@ -56,18 +45,18 @@ protected:
       memcpy(fnName2, fnName, s);
       fnName2[s] = '2';
       fnName2[s + 1] = '\0';
-      m_createFn2 = (DxcCreateInstance2Proc)GetProcAddress(m_dll, fnName2);
+      m_createFn2 = (DxcCreateInstance2Proc)m_dll.getAddressOfSymbol(fnName2);
     }
 
     return S_OK;
   }
 
 public:
-  DxcDllSupport() : m_dll(nullptr), m_createFn(nullptr), m_createFn2(nullptr) {
+  DxcDllSupport() : m_dll(), m_createFn(nullptr), m_createFn2(nullptr) {
   }
 
   DxcDllSupport(DxcDllSupport&& other) {
-    m_dll = other.m_dll; other.m_dll = nullptr;
+    m_dll = other.m_dll; other.m_dll = DynamicLibrary();
     m_createFn = other.m_createFn; other.m_createFn = nullptr;
     m_createFn2 = other.m_createFn2; other.m_createFn2 = nullptr;
   }
@@ -95,7 +84,7 @@ public:
 
   HRESULT CreateInstance(REFCLSID clsid, REFIID riid, _Outptr_ IUnknown **pResult) {
     if (pResult == nullptr) return E_POINTER;
-    if (m_dll == nullptr) return E_FAIL;
+    if (!m_dll.isValid()) return E_FAIL;
     HRESULT hr = m_createFn(clsid, riid, (LPVOID*)pResult);
     return hr;
   }
@@ -107,7 +96,7 @@ public:
 
   HRESULT CreateInstance2(IMalloc *pMalloc, REFCLSID clsid, REFIID riid, _Outptr_ IUnknown **pResult) {
     if (pResult == nullptr) return E_POINTER;
-    if (m_dll == nullptr) return E_FAIL;
+    if (!m_dll.isValid()) return E_FAIL;
     if (m_createFn2 == nullptr) return E_FAIL;
     HRESULT hr = m_createFn2(pMalloc, clsid, riid, (LPVOID*)pResult);
     return hr;
@@ -118,21 +107,20 @@ public:
   }
 
   bool IsEnabled() const {
-    return m_dll != nullptr;
+    return m_dll.isValid();
   }
 
   void Cleanup() {
-    if (m_dll != nullptr) {
+    if (m_dll.isValid()) {
       m_createFn = nullptr;
       m_createFn2 = nullptr;
-      FreeLibrary(m_dll);
-      m_dll = nullptr;
+      m_dll = DynamicLibrary();
     }
   }
 
-  HMODULE Detach() {
-    HMODULE module = m_dll;
-    m_dll = nullptr;
+  DynamicLibrary Detach() {
+    DynamicLibrary module = m_dll;
+    m_dll = DynamicLibrary();
     return module;
   }
 };

--- a/include/dxc/Support/dxcapi.use.h
+++ b/include/dxc/Support/dxcapi.use.h
@@ -28,7 +28,7 @@ protected:
   HRESULT InitializeInternal(LPCWSTR dllName, LPCSTR fnName) {
     if (m_dll.isValid()) return S_OK;
     m_dll = DynamicLibrary::getPermanentLibrary(CW2A(dllName));
-    if (!m_dll.isValid()) return HRESULT_FROM_WIN32(ERROR_DLL_NOT_FOUND);
+    if (!m_dll.isValid()) return HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
     m_createFn = (DxcCreateInstanceProc)m_dll.getAddressOfSymbol(fnName);
 
     if (m_createFn == nullptr) {

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -28,7 +28,7 @@ if( NOT MSVC )
 endif( NOT MSVC )
 
 # HLSL Change - add ignored sources
-set(HLSL_IGNORE_SOURCES DynamicLibrary.cpp PluginLoader.cpp)
+set(HLSL_IGNORE_SOURCES PluginLoader.cpp)
 
 add_llvm_library(LLVMSupport
   APFloat.cpp
@@ -52,6 +52,7 @@ add_llvm_library(LLVMSupport
   DeltaAlgorithm.cpp
   DAGDeltaAlgorithm.cpp
   Dwarf.cpp
+  DynamicLibrary.cpp
   ErrorHandling.cpp
   FileUtilities.cpp
   FileOutputBuffer.cpp

--- a/tools/clang/tools/dxcompiler/dxillib.cpp
+++ b/tools/clang/tools/dxcompiler/dxillib.cpp
@@ -25,6 +25,11 @@ static llvm::sys::Mutex *cs = nullptr;
 // This function is to prevent multiple attempts to load dxil.dll 
 HRESULT DxilLibInitialize() {
   cs = new llvm::sys::Mutex;
+#if LLVM_ON_WIN32
+  cs->lock();
+  g_DllLibResult = g_DllSupport.InitializeForDll(L"dxil.dll", "DxcCreateInstance");
+  cs->unlock();
+#endif
   return S_OK;
 }
 


### PR DESCRIPTION
LLVM includes a DynamicLibrary class that works on multiple platforms
Rather than ifdefing between dlopen for non-Windows and LoadLibraryW
on Windows, using this class allows us to abstract platform differences
while using the same code.

Changed DxilLibInitialize to attempt to initialize dxil.dll so the
smart mutex inside the dynamic library object uses the same IMalloc
as the other ManagedStatic objects so they can all be freed in order.