### PR TITLE
[linux-port] avoid unnecessary gcc5 installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,23 @@ env:
 
 compiler:
   - clang
-  - gcc
+
+matrix:
+  include:
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources: ubuntu-toolchain-r-test
+          packages: ninja-build g++-5
+      env: DXC_BUILD_TYPE=Debug
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources: ubuntu-toolchain-r-test
+          packages: ninja-build g++-5
+      env: DXC_BUILD_TYPE=Release
 
 cache:
   apt: true
@@ -30,11 +46,8 @@ branches:
 
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
       - ninja-build
-      - g++-5
 
 before_script:
   - git submodule update --init


### PR DESCRIPTION
When the clang compiler is used, there is no need to install gcc5.
By adding gcc as special case, addons and environment variables can
be set custom just for these exceptional cases while expediting the
clang builds by skipping this unnecessary installation.