### PR TITLE
[linux-port] Disable win-only targets on other platforms.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
       -DSPIRV_BUILD_TESTS=ON
       -DCMAKE_BUILD_TYPE=${DXC_BUILD_TYPE}
       -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX}
-  - ninja dxc && ninja clang-spirv-tests
+  - ninja
   - ./bin/dxc --help
   - ./bin/dxc -T ps_6_0 ../tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv
   - ./bin/clang-spirv-tests --spirv-test-root ../tools/clang/test/CodeGenSPIRV/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ before_build:
 
 build_script:
 - cmd: call utils\hct\hctbuild -%PLATFORM% -%CONFIGURATION% -spirvtest
-- sh: cd build && ninja dxc && ninja clang-spirv-tests
+- sh: cd build && ninja
 
 test_script:
 - ps:  utils\appveyor\appveyor_test.ps1

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -17,7 +17,13 @@ endif()
 # add_llvm_tool_subdirectory(llvm-as) # HLSL Change
 # add_llvm_tool_subdirectory(llvm-dis) # HLSL Change
 # add_llvm_tool_subdirectory(llvm-mc) # HLSL Change
-add_llvm_tool_subdirectory(dxexp) # HLSL Change
+
+# HLSL Change Begins
+if (WIN32)
+# This target can currently only be built on Windows.
+add_llvm_tool_subdirectory(dxexp)
+endif (WIN32)
+# HLSL Change ends
 
 # add_llvm_tool_subdirectory(llc) # HLSL Change
 # add_llvm_tool_subdirectory(llvm-ar) # HLSL Change

--- a/tools/clang/tools/CMakeLists.txt
+++ b/tools/clang/tools/CMakeLists.txt
@@ -35,11 +35,7 @@ add_subdirectory(dxl)
 add_subdirectory(dxr)
 add_subdirectory(dxv)
 add_subdirectory(dxlib-sample)
+# UI powered by .NET.
+add_subdirectory(dotnetc)
 endif (WIN32)
-
-# UI powered by .NET. Can only be built on Windows.
-if (WIN32)
-  add_subdirectory(dotnetc)
-endif (WIN32)
-
 # HLSL Change Ends

--- a/tools/clang/tools/CMakeLists.txt
+++ b/tools/clang/tools/CMakeLists.txt
@@ -23,16 +23,23 @@ endif()
 add_llvm_external_project(clang-tools-extra extra)
 
 # HLSL Change Starts
-add_subdirectory(d3dcomp)
 add_subdirectory(dxcompiler)
-add_subdirectory(dxa)
 add_subdirectory(dxc)
+
+# These targets can currently only be built on Windows.
+if (WIN32)
+add_subdirectory(d3dcomp)
+add_subdirectory(dxa)
 add_subdirectory(dxopt)
 add_subdirectory(dxl)
 add_subdirectory(dxr)
 add_subdirectory(dxv)
-if (WIN32) # UI powered by .NET
+add_subdirectory(dxlib-sample)
+endif (WIN32)
+
+# UI powered by .NET. Can only be built on Windows.
+if (WIN32)
   add_subdirectory(dotnetc)
 endif (WIN32)
-add_subdirectory(dxlib-sample)
+
 # HLSL Change Ends

--- a/tools/clang/unittests/CMakeLists.txt
+++ b/tools/clang/unittests/CMakeLists.txt
@@ -39,8 +39,8 @@ if (HLSL_INCLUDE_TESTS)
   if (WIN32) # These tests require MS specific TAEF and DIA SDK
     add_subdirectory(HLSL)
     add_subdirectory(HLSLHost)
+    add_subdirectory(dxc_batch)
   endif (WIN32)
-  add_subdirectory(dxc_batch)
 endif (HLSL_INCLUDE_TESTS)
 
 # HLSL Change Ends


### PR DESCRIPTION
After this change, you can simply run 'ninja', and you'll get the 'dxc'
target and 'clang-spirv-tests' target built.