### PR TITLE
[linux-port] Fix a couple of adapter issues.

### DIFF
--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -743,7 +743,7 @@ public:
   // Allocate a buffer with the given number of bytes
   bool AllocateBytes(size_t nBytes) throw() {
     assert(m_pData == NULL);
-    m_pData = static_cast<T *>(malloc(nBytes * sizeof(char)));
+    m_pData = static_cast<T *>(Allocator::Allocate(nBytes * sizeof(char)));
     if (m_pData == NULL)
       return false;
 
@@ -752,7 +752,7 @@ public:
 
   // Attach to an existing pointer (takes ownership)
   void Attach(T *pData) throw() {
-    free(m_pData);
+    Allocator::Free(m_pData);
     m_pData = pData;
   }
 
@@ -765,14 +765,15 @@ public:
 
   // Free the memory pointed to, and set the pointer to NULL
   void Free() throw() {
-    free(m_pData);
+    Allocator::Free(m_pData);
     m_pData = NULL;
   }
 
   // Reallocate the buffer to hold a given number of bytes
   bool ReallocateBytes(size_t nBytes) throw() {
     T *pNew;
-    pNew = static_cast<T *>(realloc(m_pData, nBytes * sizeof(char)));
+    pNew =
+        static_cast<T *>(Allocator::Reallocate(m_pData, nBytes * sizeof(char)));
     if (pNew == NULL)
       return false;
     m_pData = pNew;

--- a/lib/DxcSupport/WinAdapter.cpp
+++ b/lib/DxcSupport/WinAdapter.cpp
@@ -24,11 +24,11 @@ ULONG IUnknown::AddRef() {
   return m_count;
 }
 ULONG IUnknown::Release() {
-  --m_count;
+  ULONG result = --m_count;
   if (m_count == 0) {
     delete this;
   }
-  return m_count;
+  return result;
 }
 IUnknown::~IUnknown() {}
 


### PR DESCRIPTION
We should use the Allocator's methods rather than directly using
malloc/free/etc.

Also fixed a bug: shouldn't access m_count after it has been potentially
deleted.