### PR TITLE
[linux-port] Fix gcc6.4 alpine(and others) compile

### DIFF
--- a/include/llvm/Analysis/TargetLibraryInfo.def
+++ b/include/llvm/Analysis/TargetLibraryInfo.def
@@ -431,9 +431,6 @@ TLI_DEFINE_STRING_INTERNAL("fmodl")
 /// FILE *fopen(const char *filename, const char *mode);
 TLI_DEFINE_ENUM_INTERNAL(fopen)
 TLI_DEFINE_STRING_INTERNAL("fopen")
-/// FILE *fopen64(const char *filename, const char *opentype)
-TLI_DEFINE_ENUM_INTERNAL(fopen64)
-TLI_DEFINE_STRING_INTERNAL("fopen64")
 /// int fprintf(FILE *stream, const char *format, ...);
 TLI_DEFINE_ENUM_INTERNAL(fprintf)
 TLI_DEFINE_STRING_INTERNAL("fprintf")
@@ -467,9 +464,6 @@ TLI_DEFINE_STRING_INTERNAL("fseek")
 /// int fseeko(FILE *stream, off_t offset, int whence);
 TLI_DEFINE_ENUM_INTERNAL(fseeko)
 TLI_DEFINE_STRING_INTERNAL("fseeko")
-/// int fseeko64(FILE *stream, off64_t offset, int whence)
-TLI_DEFINE_ENUM_INTERNAL(fseeko64)
-TLI_DEFINE_STRING_INTERNAL("fseeko64")
 /// int fsetpos(FILE *stream, const fpos_t *pos);
 TLI_DEFINE_ENUM_INTERNAL(fsetpos)
 TLI_DEFINE_STRING_INTERNAL("fsetpos")
@@ -491,9 +485,6 @@ TLI_DEFINE_STRING_INTERNAL("ftell")
 /// off_t ftello(FILE *stream);
 TLI_DEFINE_ENUM_INTERNAL(ftello)
 TLI_DEFINE_STRING_INTERNAL("ftello")
-/// off64_t ftello64(FILE *stream)
-TLI_DEFINE_ENUM_INTERNAL(ftello64)
-TLI_DEFINE_STRING_INTERNAL("ftello64")
 /// int ftrylockfile(FILE *file);
 TLI_DEFINE_ENUM_INTERNAL(ftrylockfile)
 TLI_DEFINE_STRING_INTERNAL("ftrylockfile")
@@ -955,9 +946,6 @@ TLI_DEFINE_STRING_INTERNAL("times")
 /// FILE *tmpfile(void);
 TLI_DEFINE_ENUM_INTERNAL(tmpfile)
 TLI_DEFINE_STRING_INTERNAL("tmpfile")
-/// FILE *tmpfile64(void)
-TLI_DEFINE_ENUM_INTERNAL(tmpfile64)
-TLI_DEFINE_STRING_INTERNAL("tmpfile64")
 /// int toascii(int c);
 TLI_DEFINE_ENUM_INTERNAL(toascii)
 TLI_DEFINE_STRING_INTERNAL("toascii")

--- a/lib/Analysis/TargetLibraryInfo.cpp
+++ b/lib/Analysis/TargetLibraryInfo.cpp
@@ -350,16 +350,12 @@ static void initialize(TargetLibraryInfoImpl &TLI, const Triple &T,
     TLI.setUnavailable(LibFunc::under_IO_getc);
     TLI.setUnavailable(LibFunc::under_IO_putc);
     TLI.setUnavailable(LibFunc::memalign);
-    TLI.setUnavailable(LibFunc::fopen64);
-    TLI.setUnavailable(LibFunc::fseeko64);
     TLI.setUnavailable(LibFunc::fstat64);
     TLI.setUnavailable(LibFunc::fstatvfs64);
-    TLI.setUnavailable(LibFunc::ftello64);
     TLI.setUnavailable(LibFunc::lstat64);
     TLI.setUnavailable(LibFunc::open64);
     TLI.setUnavailable(LibFunc::stat64);
     TLI.setUnavailable(LibFunc::statvfs64);
-    TLI.setUnavailable(LibFunc::tmpfile64);
   }
 
   TLI.addVectorizableFunctionsFromVecLib(ClVectorLibrary);

--- a/lib/Transforms/IPO/FunctionAttrs.cpp
+++ b/lib/Transforms/IPO/FunctionAttrs.cpp
@@ -1627,32 +1627,6 @@ bool FunctionAttrs::inferPrototypeAttributes(Function &F) {
     setOnlyReadsMemory(F, 1);
     setOnlyReadsMemory(F, 2);
     break;
-  case LibFunc::fopen64:
-    if (FTy->getNumParams() != 2 ||
-        !FTy->getReturnType()->isPointerTy() ||
-        !FTy->getParamType(0)->isPointerTy() ||
-        !FTy->getParamType(1)->isPointerTy())
-      return false;
-    setDoesNotThrow(F);
-    setDoesNotAlias(F, 0);
-    setDoesNotCapture(F, 1);
-    setDoesNotCapture(F, 2);
-    setOnlyReadsMemory(F, 1);
-    setOnlyReadsMemory(F, 2);
-    break;
-  case LibFunc::fseeko64:
-  case LibFunc::ftello64:
-    if (FTy->getNumParams() == 0 || !FTy->getParamType(0)->isPointerTy())
-      return false;
-    setDoesNotThrow(F);
-    setDoesNotCapture(F, 1);
-    break;
-  case LibFunc::tmpfile64:
-    if (!FTy->getReturnType()->isPointerTy())
-      return false;
-    setDoesNotThrow(F);
-    setDoesNotAlias(F, 0);
-    break;
   case LibFunc::fstat64:
   case LibFunc::fstatvfs64:
     if (FTy->getNumParams() != 2 || !FTy->getParamType(1)->isPointerTy())


### PR DESCRIPTION
Alpine Linux and probably several others, define fopen64, fseeko64,
ftello64, and tmpfile64 to their 32 bit equivalents in system
headers. This results in duplicates in areas of the code that
include 32 bit and 64 bit references to this. Since HLSL doesn't
have any of these functions anyway, we can safely remove them.

Fixes https://github.com/google/DirectXShaderCompiler/issues/253