### PR TITLE
[spirv] LowerTypeVisitor: AST type into SPIR-V type

### DIFF
--- a/tools/clang/include/clang/SPIRV/SPIRVContext.h
+++ b/tools/clang/include/clang/SPIRV/SPIRVContext.h
@@ -214,10 +214,6 @@ private:
   const VoidType *voidType;
   const BoolType *boolType;
 
-  // TODO: the following scalar/vector/matrix type fields are not factoring in
-  // relaxed precision when doing unification. It should be fixed when adding
-  // support for relaxed precision.
-
   // The type at index i is for bitwidth 2^i. So max bitwidth supported
   // is 2^6 = 64. Index 0/1/2/3 is not used right now.
   std::array<const IntegerType *, 7> sintTypes;

--- a/tools/clang/include/clang/SPIRV/SpirvType.h
+++ b/tools/clang/include/clang/SPIRV/SpirvType.h
@@ -129,6 +129,11 @@ public:
 private:
   const VectorType *vectorType;
   uint32_t vectorCount;
+  // It's debatable whether we should put majorness as a field in the type
+  // itself. Majorness only matters at the time of emitting SPIR-V words since
+  // we need the layout decoration then. However, if we don't put it here,
+  // we will need to rediscover the majorness information from QualType at
+  // the time of emitting SPIR-V words.
   bool isRowMajor;
 };
 
@@ -214,6 +219,10 @@ public:
   bool operator==(const StructType &that) const;
 
 private:
+  // Reflection is heavily used in graphics pipelines. Reflection relies on
+  // struct names and field names. That basically means we cannot ignore these
+  // names when considering unification. Otherwise, reflection will be confused.
+
   std::string structName;
   llvm::SmallVector<const SpirvType *, 8> fieldTypes;
   llvm::SmallVector<std::string, 8> fieldNames;

--- a/tools/clang/include/clang/SPIRV/SpirvType.h
+++ b/tools/clang/include/clang/SPIRV/SpirvType.h
@@ -120,14 +120,16 @@ private:
 
 class MatrixType : public SpirvType {
 public:
-  MatrixType(const VectorType *vecType, uint32_t vecCount)
-      : SpirvType(TK_Matrix), vectorType(vecType), vectorCount(vecCount) {}
+  MatrixType(const VectorType *vecType, uint32_t vecCount, bool rowMajor);
 
   static bool classof(const SpirvType *t) { return t->getKind() == TK_Matrix; }
+
+  bool operator==(const MatrixType &that) const;
 
 private:
   const VectorType *vectorType;
   uint32_t vectorCount;
+  bool isRowMajor;
 };
 
 class ImageType : public SpirvType {
@@ -202,9 +204,12 @@ private:
 class StructType : public SpirvType {
 public:
   StructType(llvm::ArrayRef<const SpirvType *> memberTypes,
-             llvm::StringRef name, llvm::ArrayRef<llvm::StringRef> memberNames);
+             llvm::StringRef name, llvm::ArrayRef<llvm::StringRef> memberNames,
+             bool isReadOnly);
 
   static bool classof(const SpirvType *t) { return t->getKind() == TK_Struct; }
+
+  bool isReadOnly() const { return readOnly; }
 
   bool operator==(const StructType &that) const;
 
@@ -212,6 +217,7 @@ private:
   std::string structName;
   llvm::SmallVector<const SpirvType *, 8> fieldTypes;
   llvm::SmallVector<std::string, 8> fieldNames;
+  bool readOnly;
 };
 
 class SpirvPointerType : public SpirvType {

--- a/tools/clang/include/clang/SPIRV/SpirvVisitor.h
+++ b/tools/clang/include/clang/SPIRV/SpirvVisitor.h
@@ -8,6 +8,7 @@
 #ifndef LLVM_CLANG_SPIRV_SPIRVVISITOR_H
 #define LLVM_CLANG_SPIRV_SPIRVVISITOR_H
 
+#include "dxc/Support/SPIRVOptions.h"
 #include "clang/SPIRV/SpirvInstruction.h"
 
 namespace clang {
@@ -105,7 +106,12 @@ public:
 #undef DEFINE_VISIT_METHOD
 
 protected:
-  Visitor() = default;
+  explicit Visitor(const SpirvCodeGenOptions &opts) : spvOptions(opts) {}
+
+  const SpirvCodeGenOptions &getCodeGenOptions() const { return spvOptions; }
+
+private:
+  const SpirvCodeGenOptions &spvOptions;
 };
 
 } // namespace spirv

--- a/tools/clang/lib/SPIRV/CMakeLists.txt
+++ b/tools/clang/lib/SPIRV/CMakeLists.txt
@@ -15,6 +15,7 @@ add_clang_library(clangSPIRV
   InitListHandler.cpp
   InstBuilderAuto.cpp
   InstBuilderManual.cpp
+  LowerTypeVisitor.cpp
   ModuleBuilder.cpp
   SPIRVContext.cpp
   SPIRVEmitter.cpp

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -1,0 +1,549 @@
+//===--- LowerTypeVisitor.cpp - AST type to SPIR-V type impl -----*- C++ -*-==//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "LowerTypeVisitor.h"
+
+#include "clang/AST/Attr.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/HlslTypes.h"
+#include "clang/SPIRV/AstTypeProbe.h"
+
+namespace clang {
+namespace spirv {
+
+const SpirvType *LowerTypeVisitor::lowerType(QualType type,
+                                             SpirvLayoutRule rule,
+                                             SourceLocation srcLoc) {
+  const auto desugaredType = desugarType(type);
+
+  if (desugaredType != type) {
+    const auto *spvType = lowerType(desugaredType, rule, srcLoc);
+    // Clear matrix majorness potentially set by previous desugarType() calls.
+    // This field will only be set when we were saying a matrix type. And the
+    // above lowerType() call already takes the majorness into consideration.
+    // So should be fine to clear now.
+    typeMatMajorAttr = llvm::None;
+    return spvType;
+  }
+
+  { // Primitive types
+    QualType ty = {};
+    if (isScalarType(type, &ty)) {
+      if (const auto *builtinType = ty->getAs<BuiltinType>()) {
+        const bool use16Bit = getCodeGenOptions().enable16BitTypes;
+
+        // Cases sorted roughly according to frequency in source code
+        switch (builtinType->getKind()) {
+          // 32-bit types
+        case BuiltinType::Float:
+          // The HalfFloat AST type is just an alias for the Float AST type
+          // and is always 32-bit. The HLSL half keyword is translated to
+          // HalfFloat if -enable-16bit-types is false.
+        case BuiltinType::HalfFloat:
+          return spvContext.getFloatType(32);
+        case BuiltinType::Int:
+          return spvContext.getSIntType(32);
+        case BuiltinType::UInt:
+          return spvContext.getUIntType(32);
+
+          // void and bool
+        case BuiltinType::Void:
+          return spvContext.getVoidType();
+        case BuiltinType::Bool:
+          // According to the SPIR-V spec, there is no physical size or bit
+          // pattern defined for boolean type. Therefore an unsigned integer
+          // is used to represent booleans when layout is required.
+          if (rule == SpirvLayoutRule::Void)
+            return spvContext.getBoolType();
+          else
+            return spvContext.getUIntType(32);
+
+          // 64-bit types
+        case BuiltinType::Double:
+          return spvContext.getFloatType(64);
+        case BuiltinType::LongLong:
+          return spvContext.getSIntType(64);
+        case BuiltinType::ULongLong:
+          return spvContext.getUIntType(64);
+
+          // 16-bit types
+          // The Half AST type is always 16-bit. The HLSL half keyword is
+          // translated to Half if -enable-16bit-types is true.
+        case BuiltinType::Half:
+          return spvContext.getFloatType(16);
+        case BuiltinType::Short: // int16_t
+          return spvContext.getSIntType(16);
+        case BuiltinType::UShort: // uint16_t
+          return spvContext.getUIntType(16);
+
+          // Relaxed precision types
+        case BuiltinType::Min10Float:
+        case BuiltinType::Min16Float:
+          return spvContext.getFloatType(use16Bit ? 16 : 32);
+        case BuiltinType::Min12Int:
+        case BuiltinType::Min16Int:
+          return spvContext.getSIntType(use16Bit ? 16 : 32);
+        case BuiltinType::Min16UInt:
+          return spvContext.getUIntType(use16Bit ? 16 : 32);
+
+        // Literal types.
+        case BuiltinType::LitInt:
+        case BuiltinType::LitFloat: {
+          // TODO: analyze adjacent instructions for type hints
+          emitError("TODO: literal int/float", srcLoc);
+          return spvContext.getVoidType();
+
+        default:
+          emitError("primitive type %0 unimplemented", srcLoc)
+              << builtinType->getTypeClassName();
+          return spvContext.getVoidType();
+        }
+        }
+      }
+    }
+  }
+
+  // AST vector/matrix types are TypedefType of TemplateSpecializationType. We
+  // handle them via HLSL type inspection functions.
+
+  { // Vector types
+    QualType elemType = {};
+    uint32_t elemCount = {};
+    if (isVectorType(type, &elemType, &elemCount))
+      return spvContext.getVectorType(lowerType(elemType, rule, srcLoc),
+                                      elemCount);
+  }
+
+  { // Matrix types
+    QualType elemType = {};
+    uint32_t rowCount = 0, colCount = 0;
+    if (isMxNMatrix(type, &elemType, &rowCount, &colCount)) {
+      const auto *vecType =
+          spvContext.getVectorType(lowerType(elemType, rule, srcLoc), colCount);
+      // HLSL matrices are conceptually row major, while SPIR-V matrices are
+      // conceptually column major. We are mapping what HLSL semantically mean
+      // a row into a column here.
+      const bool isSpirvRowMajor = !isRowMajorMatrix(type);
+
+      return spvContext.getMatrixType(vecType, rowCount, isSpirvRowMajor);
+    }
+  }
+
+  // Struct type
+  if (const auto *structType = type->getAs<RecordType>()) {
+    const auto *decl = structType->getDecl();
+
+    // HLSL resource types are also represented as RecordType in the AST.
+    // (ClassTemplateSpecializationDecl is a subclass of CXXRecordDecl, which
+    // is then a subclass of RecordDecl.) So we need to check them before
+    // checking the general struct type.
+    if (const auto *spvType = lowerResourceType(type, rule, srcLoc))
+      return spvType;
+
+    // Collect all fields' types and names.
+    llvm::SmallVector<const SpirvType *, 8> fieldTypes;
+    llvm::SmallVector<llvm::StringRef, 8> fieldNames;
+
+    // If this struct is derived from some other struct, place an implicit
+    // field at the very beginning for the base struct.
+    if (const auto *cxxDecl = dyn_cast<CXXRecordDecl>(decl))
+      for (const auto base : cxxDecl->bases()) {
+        fieldTypes.push_back(lowerType(base.getType(), rule, srcLoc));
+        fieldNames.push_back("");
+      }
+
+    // Create fields for all members of this struct
+    for (const auto *field : decl->fields()) {
+      fieldTypes.push_back(lowerType(field->getType(), rule, srcLoc));
+      fieldNames.push_back(field->getName());
+    }
+
+    return spvContext.getStructType(fieldTypes, decl->getName(), fieldNames);
+  }
+
+  // Array type
+  if (const auto *arrayType = astContext.getAsArrayType(type)) {
+    const auto *elemType = lowerType(arrayType->getElementType(), rule, srcLoc);
+
+    if (const auto *caType = astContext.getAsConstantArrayType(type)) {
+      const auto size = static_cast<uint32_t>(caType->getSize().getZExtValue());
+      return spvContext.getArrayType(elemType, size);
+    }
+
+    assert(type->isIncompleteArrayType());
+    return spvContext.getRuntimeArrayType(elemType);
+  }
+
+  // Reference types
+  if (const auto *refType = type->getAs<ReferenceType>()) {
+    // Note: Pointer/reference types are disallowed in HLSL source code.
+    // Although developers cannot use them directly, they are generated into
+    // the AST by out/inout parameter modifiers in function signatures.
+    // We already pass function arguments via pointers to tempoary local
+    // variables. So it should be fine to drop the pointer type and treat it
+    // as the underlying pointee type here.
+    return lowerType(refType->getPointeeType(), rule, srcLoc);
+  }
+
+  // Pointer types
+  if (const auto *ptrType = type->getAs<PointerType>()) {
+    // The this object in a struct member function is of pointer type.
+    return lowerType(ptrType->getPointeeType(), rule, srcLoc);
+  }
+
+  emitError("lower type %0 unimplemented", srcLoc) << type->getTypeClassName();
+  type->dump();
+  return 0;
+}
+
+const SpirvType *LowerTypeVisitor::lowerResourceType(QualType type,
+                                                     SpirvLayoutRule rule,
+                                                     SourceLocation srcLoc) {
+  // Resource types are either represented like C struct or C++ class in the
+  // AST. Samplers are represented like C struct, so isStructureType() will
+  // return true for it; textures are represented like C++ class, so
+  // isClassType() will return true for it.
+
+  assert(type->isStructureOrClassType());
+
+  const auto *recordType = type->getAs<RecordType>();
+  assert(recordType);
+  const llvm::StringRef name = recordType->getDecl()->getName();
+
+  // TODO: avoid string comparison once hlsl::IsHLSLResouceType() does that.
+
+  { // Texture types
+    spv::Dim dim = {};
+    bool isArray = {};
+    if ((dim = spv::Dim::Dim1D, isArray = false, name == "Texture1D") ||
+        (dim = spv::Dim::Dim2D, isArray = false, name == "Texture2D") ||
+        (dim = spv::Dim::Dim3D, isArray = false, name == "Texture3D") ||
+        (dim = spv::Dim::Cube, isArray = false, name == "TextureCube") ||
+        (dim = spv::Dim::Dim1D, isArray = true, name == "Texture1DArray") ||
+        (dim = spv::Dim::Dim2D, isArray = true, name == "Texture2DArray") ||
+        (dim = spv::Dim::Dim2D, isArray = false, name == "Texture2DMS") ||
+        (dim = spv::Dim::Dim2D, isArray = true, name == "Texture2DMSArray") ||
+        // There is no Texture3DArray
+        (dim = spv::Dim::Cube, isArray = true, name == "TextureCubeArray")) {
+      const bool isMS = (name == "Texture2DMS" || name == "Texture2DMSArray");
+      const auto sampledType = hlsl::GetHLSLResourceResultType(type);
+      return spvContext.getImageType(
+          lowerType(getElementType(sampledType, srcLoc), rule, srcLoc), dim,
+          isArray, isMS, ImageType::WithSampler::Yes,
+          spv::ImageFormat::Unknown);
+    }
+
+    // There is no RWTexture3DArray
+    if ((dim = spv::Dim::Dim1D, isArray = false, name == "RWTexture1D") ||
+        (dim = spv::Dim::Dim2D, isArray = false, name == "RWTexture2D") ||
+        (dim = spv::Dim::Dim3D, isArray = false, name == "RWTexture3D") ||
+        (dim = spv::Dim::Dim1D, isArray = true, name == "RWTexture1DArray") ||
+        (dim = spv::Dim::Dim2D, isArray = true, name == "RWTexture2DArray")) {
+      const auto sampledType = hlsl::GetHLSLResourceResultType(type);
+      const auto format =
+          translateSampledTypeToImageFormat(sampledType, srcLoc);
+      return spvContext.getImageType(
+          lowerType(getElementType(sampledType, srcLoc), rule, srcLoc), dim,
+          isArray,
+          /*isMultiSampled=*/false, /*sampled=*/ImageType::WithSampler::No,
+          format);
+    }
+  }
+
+  // Sampler types
+  if (name == "SamplerState" || name == "SamplerComparisonState") {
+    return spvContext.getSamplerType();
+  }
+
+  if (name == "StructuredBuffer" || name == "RWStructuredBuffer" ||
+      name == "AppendStructuredBuffer" || name == "ConsumeStructuredBuffer") {
+    // StructureBuffer<S> will be translated into an OpTypeStruct with one
+    // field, which is an OpTypeRuntimeArray of OpTypeStruct (S).
+
+    // If layout rule is void, it means these resource types are used for
+    // declaring local resources, which should be created as alias variables.
+    // The aliased-to variable should surely be in the Uniform storage class,
+    // which has layout decorations.
+    bool asAlias = false;
+    if (rule == SpirvLayoutRule::Void) {
+      asAlias = true;
+      rule = getCodeGenOptions().sBufferLayoutRule;
+    }
+
+    const auto s = hlsl::GetHLSLResourceResultType(type);
+    const auto *structType = lowerType(s, rule, srcLoc);
+    std::string structName;
+    const auto innerType = hlsl::GetHLSLResourceResultType(type);
+    if (innerType->isStructureType())
+      structName = innerType->getAs<RecordType>()->getDecl()->getName();
+    else
+      structName = getAstTypeName(innerType);
+
+    const auto *raType = spvContext.getRuntimeArrayType(structType);
+
+    const std::string typeName = "type." + name.str() + "." + structName;
+    const auto *valType = spvContext.getStructType(raType, typeName);
+
+    if (asAlias) {
+      // All structured buffers are in the Uniform storage class.
+      return spvContext.getPointerType(valType, spv::StorageClass::Uniform);
+    }
+
+    return valType;
+  }
+
+  // ByteAddressBuffer types.
+  if (name == "ByteAddressBuffer") {
+    const auto *bufferType =
+        spvContext.getByteAddressBufferType(/*isRW*/ false);
+    if (rule == SpirvLayoutRule::Void) {
+      // All byte address buffers are in the Uniform storage class.
+      return spvContext.getPointerType(bufferType, spv::StorageClass::Uniform);
+    }
+    return bufferType;
+  }
+  // RWByteAddressBuffer types.
+  if (name == "RWByteAddressBuffer") {
+    const auto *bufferType = spvContext.getByteAddressBufferType(/*isRW*/ true);
+    if (rule == SpirvLayoutRule::Void) {
+      // All byte address buffers are in the Uniform storage class.
+      return spvContext.getPointerType(bufferType, spv::StorageClass::Uniform);
+    }
+    return bufferType;
+  }
+
+  // Buffer and RWBuffer types
+  if (name == "Buffer" || name == "RWBuffer") {
+    const auto sampledType = hlsl::GetHLSLResourceResultType(type);
+    if (sampledType->isStructureType() && name.startswith("RW")) {
+      // Note: actually fxc supports RWBuffer over struct types. However, the
+      // struct member must fit into a 4-component vector and writing to a
+      // RWBuffer element must write all components. This is a feature that
+      // are rarely used by developers. We just emit an error saying not
+      // supported for now.
+      emitError("cannot instantiate RWBuffer with struct type %0", srcLoc)
+          << sampledType;
+      return 0;
+    }
+    const auto format = translateSampledTypeToImageFormat(sampledType, srcLoc);
+    return spvContext.getImageType(
+        lowerType(getElementType(sampledType, srcLoc), rule, srcLoc),
+        spv::Dim::Buffer,
+        /*isArrayed=*/false, /*isMultiSampled=*/false,
+        /*sampled*/ name == "Buffer" ? ImageType::WithSampler::Yes
+                                     : ImageType::WithSampler::No,
+        format);
+  }
+
+  // InputPatch
+  if (name == "InputPatch") {
+    const auto elemType = hlsl::GetHLSLInputPatchElementType(type);
+    const auto elemCount = hlsl::GetHLSLInputPatchCount(type);
+    return spvContext.getArrayType(lowerType(elemType, rule, srcLoc),
+                                   elemCount);
+  }
+  // OutputPatch
+  if (name == "OutputPatch") {
+    const auto elemType = hlsl::GetHLSLOutputPatchElementType(type);
+    const auto elemCount = hlsl::GetHLSLOutputPatchCount(type);
+    return spvContext.getArrayType(lowerType(elemType, rule, srcLoc),
+                                   elemCount);
+  }
+  // Output stream objects (TriangleStream, LineStream, and PointStream)
+  if (name == "TriangleStream" || name == "LineStream" ||
+      name == "PointStream") {
+    return lowerType(hlsl::GetHLSLResourceResultType(type), rule, srcLoc);
+  }
+
+  if (name == "SubpassInput" || name == "SubpassInputMS") {
+    const auto sampledType = hlsl::GetHLSLResourceResultType(type);
+    return spvContext.getImageType(
+        lowerType(getElementType(sampledType, srcLoc), rule, srcLoc),
+        spv::Dim::SubpassData, /*isArrayed=*/false,
+        /*isMultipleSampled=*/name == "SubpassInputMS",
+        ImageType::WithSampler::No, spv::ImageFormat::Unknown);
+  }
+
+  return nullptr;
+}
+
+QualType LowerTypeVisitor::getElementType(QualType type,
+                                          SourceLocation srcLoc) {
+  QualType elemType = {};
+  if (isScalarType(type, &elemType) || isVectorType(type, &elemType) ||
+      isMxNMatrix(type, &elemType) || canFitIntoOneRegister(type, &elemType)) {
+    return elemType;
+  }
+
+  if (const auto *arrType = astContext.getAsConstantArrayType(type)) {
+    return arrType->getElementType();
+  }
+
+  emitError("unsupported resource type parameter %0", srcLoc) << type;
+  // Note: We are returning the original type instead of a null QualType here
+  // to keep the translation going and avoid hitting asserts trying to query
+  // info from null QualType in other places of the compiler. Although we are
+  // likely generating invalid code here, it should be fine since the error
+  // reported will prevent the CodeGen from actually outputing.
+  return type;
+}
+
+bool LowerTypeVisitor::canFitIntoOneRegister(QualType structType,
+                                             QualType *elemType,
+                                             uint32_t *elemCount) {
+  if (structType->getAsStructureType() == nullptr)
+    return false;
+
+  const auto *structDecl = structType->getAsStructureType()->getDecl();
+  QualType firstElemType;
+  uint32_t totalCount = 0;
+
+  for (const auto *field : structDecl->fields()) {
+    QualType type;
+    uint32_t count = 1;
+
+    if (isScalarType(field->getType(), &type) ||
+        isVectorType(field->getType(), &type, &count)) {
+      if (firstElemType.isNull()) {
+        firstElemType = type;
+      } else {
+        if (!canTreatAsSameScalarType(firstElemType, type)) {
+          emitError("all struct members should have the same element type for "
+                    "resource template instantiation",
+                    structDecl->getLocation());
+          return false;
+        }
+      }
+      totalCount += count;
+    } else {
+      emitError("unsupported struct element type for resource template "
+                "instantiation",
+                structDecl->getLocation());
+      return false;
+    }
+  }
+
+  if (totalCount > 4) {
+    emitError(
+        "resource template element type %0 cannot fit into four 32-bit scalars",
+        structDecl->getLocation())
+        << structType;
+    return false;
+  }
+
+  if (elemType)
+    *elemType = firstElemType;
+  if (elemCount)
+    *elemCount = totalCount;
+  return true;
+}
+
+spv::ImageFormat
+LowerTypeVisitor::translateSampledTypeToImageFormat(QualType sampledType,
+                                                    SourceLocation srcLoc) {
+  uint32_t elemCount = 1;
+  QualType ty = {};
+  if (isScalarType(sampledType, &ty) ||
+      isVectorType(sampledType, &ty, &elemCount) ||
+      canFitIntoOneRegister(sampledType, &ty, &elemCount)) {
+    if (const auto *builtinType = ty->getAs<BuiltinType>()) {
+      switch (builtinType->getKind()) {
+      case BuiltinType::Int:
+        return elemCount == 1 ? spv::ImageFormat::R32i
+                              : elemCount == 2 ? spv::ImageFormat::Rg32i
+                                               : spv::ImageFormat::Rgba32i;
+      case BuiltinType::UInt:
+        return elemCount == 1 ? spv::ImageFormat::R32ui
+                              : elemCount == 2 ? spv::ImageFormat::Rg32ui
+                                               : spv::ImageFormat::Rgba32ui;
+      case BuiltinType::Float:
+        return elemCount == 1 ? spv::ImageFormat::R32f
+                              : elemCount == 2 ? spv::ImageFormat::Rg32f
+                                               : spv::ImageFormat::Rgba32f;
+      default:
+        // Other sampled types unimplemented or irrelevant.
+        break;
+      }
+    }
+  }
+  emitError(
+      "cannot translate resource type parameter %0 to proper image format",
+      srcLoc)
+      << sampledType;
+
+  return spv::ImageFormat::Unknown;
+}
+
+bool LowerTypeVisitor::canTreatAsSameScalarType(QualType type1,
+                                                QualType type2) {
+  // Treat const int/float the same as const int/float
+  type1.removeLocalConst();
+  type2.removeLocalConst();
+
+  return (type1.getCanonicalType() == type2.getCanonicalType()) ||
+         // Treat 'literal float' and 'float' as the same
+         (type1->isSpecificBuiltinType(BuiltinType::LitFloat) &&
+          type2->isFloatingType()) ||
+         (type2->isSpecificBuiltinType(BuiltinType::LitFloat) &&
+          type1->isFloatingType()) ||
+         // Treat 'literal int' and 'int'/'uint' as the same
+         (type1->isSpecificBuiltinType(BuiltinType::LitInt) &&
+          type2->isIntegerType() &&
+          // Disallow boolean types
+          !type2->isSpecificBuiltinType(BuiltinType::Bool)) ||
+         (type2->isSpecificBuiltinType(BuiltinType::LitInt) &&
+          type1->isIntegerType() &&
+          // Disallow boolean types
+          !type1->isSpecificBuiltinType(BuiltinType::Bool));
+}
+
+QualType LowerTypeVisitor::desugarType(QualType type) {
+  if (const auto *attrType = type->getAs<AttributedType>()) {
+    switch (auto kind = attrType->getAttrKind()) {
+    case AttributedType::attr_hlsl_row_major:
+    case AttributedType::attr_hlsl_column_major:
+      typeMatMajorAttr = kind;
+      break;
+    default:
+      // We only need to update internal bookkeeping for matrix majorness.
+      break;
+    }
+
+    return desugarType(
+        attrType->getLocallyUnqualifiedSingleStepDesugaredType());
+  }
+
+  if (const auto *typedefType = type->getAs<TypedefType>()) {
+    return desugarType(typedefType->desugar());
+  }
+
+  return type;
+}
+
+bool LowerTypeVisitor::isRowMajorMatrix(QualType type) const {
+  assert(isMxNMatrix(type));
+
+  // Use the majorness info we recorded before.
+  if (typeMatMajorAttr.hasValue()) {
+    switch (typeMatMajorAttr.getValue()) {
+    case AttributedType::attr_hlsl_row_major:
+      return true;
+    case AttributedType::attr_hlsl_column_major:
+      return false;
+    default:
+      // Only oriented matrices are relevant.
+      break;
+    }
+  }
+
+  return getCodeGenOptions().defaultRowMajor;
+}
+
+} // namespace spirv
+} // namespace clang

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -1,0 +1,93 @@
+//===--- LowerTypeVisitor.h - AST type to SPIR-V type visitor ----*- C++ -*-==//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_LIB_SPIRV_LOWERTYPEVISITOR_H
+#define LLVM_CLANG_LIB_SPIRV_LOWERTYPEVISITOR_H
+
+#include "clang/AST/ASTContext.h"
+#include "clang/SPIRV/SPIRVContext.h"
+#include "clang/SPIRV/SpirvVisitor.h"
+#include "llvm/ADT/Optional.h"
+
+namespace clang {
+namespace spirv {
+
+/// The class responsible to translate Clang frontend types into SPIR-V types.
+class LowerTypeVisitor : public Visitor {
+public:
+  LowerTypeVisitor(ASTContext &astCtx, SpirvContext &spvCtx,
+                   const SpirvCodeGenOptions &opts)
+      : Visitor(opts), astContext(astCtx), spvContext(spvCtx) {}
+
+private:
+  /// Emits error to the diagnostic engine associated with this visitor.
+  template <unsigned N>
+  DiagnosticBuilder emitError(const char (&message)[N], SourceLocation srcLoc) {
+    const auto diagId = astContext.getDiagnostics().getCustomDiagID(
+        clang::DiagnosticsEngine::Error, message);
+    return astContext.getDiagnostics().Report(srcLoc, diagId);
+  }
+
+  /// Lowers the given AST QualType into the corresponding SPIR-V type.
+  ///
+  /// The lowering is recursive; all the types that the target type depends
+  /// on will be created in SpirvContext.
+  const SpirvType *lowerType(QualType type, SpirvLayoutRule, SourceLocation);
+
+  /// Lowers the given HLSL resource type into its SPIR-V type.
+  const SpirvType *lowerResourceType(QualType type, SpirvLayoutRule rule,
+                                     SourceLocation);
+
+  QualType getElementType(QualType type, SourceLocation);
+
+  /// Returns true if all members in structType are of the same element
+  /// type and can be fit into a 4-component vector. Writes element type and
+  /// count to *elemType and *elemCount if not nullptr. Otherwise, emit errors
+  /// explaining why not.
+  bool canFitIntoOneRegister(QualType structType, QualType *elemType,
+                             uint32_t *elemCount = nullptr);
+
+  /// For the given sampled type, returns the corresponding image format
+  /// that can be used to create an image object.
+  spv::ImageFormat translateSampledTypeToImageFormat(QualType sampledType,
+                                                     SourceLocation);
+
+  /// Returns true if the two types can be treated as the same scalar
+  /// type, which means they have the same canonical type, regardless of
+  /// constnesss and literalness.
+  bool canTreatAsSameScalarType(QualType type1, QualType type2);
+
+  /// Strips the attributes and typedefs from the given type and returns the
+  /// desugared one.
+  ///
+  /// This method will update internal bookkeeping regarding matrix majorness.
+  QualType desugarType(QualType type);
+
+  /// Returns true if type is a HLSL row-major matrix, either with explicit
+  /// attribute or implicit command-line option.
+  bool isRowMajorMatrix(QualType type) const;
+
+private:
+  ASTContext &astContext;   /// AST context
+  SpirvContext &spvContext; /// SPIR-V context
+
+  /// A place to keep the matrix majorness attributes so that we can retrieve
+  /// the information when really processing the desugared matrix type.
+  ///
+  /// This is needed because the majorness attribute is decorated on a
+  /// TypedefType (i.e., floatMxN) of the real matrix type (i.e., matrix<elem,
+  /// row, col>). When we reach the desugared matrix type, this information
+  /// is already gone.
+  llvm::Optional<AttributedType::Kind> typeMatMajorAttr;
+};
+
+} // end namespace spirv
+} // end namespace clang
+
+#endif // LLVM_CLANG_LIB_SPIRV_LOWERTYPEVISITOR_H

--- a/tools/clang/lib/SPIRV/SpirvType.cpp
+++ b/tools/clang/lib/SPIRV/SpirvType.cpp
@@ -27,6 +27,16 @@ bool ScalarType::classof(const SpirvType *t) {
   return false;
 }
 
+MatrixType::MatrixType(const VectorType *vecType, uint32_t vecCount,
+                       bool rowMajor)
+    : SpirvType(TK_Matrix), vectorType(vecType), vectorCount(vecCount),
+      isRowMajor(rowMajor) {}
+
+bool MatrixType::operator==(const MatrixType &that) const {
+  return vectorType == that.vectorType && vectorCount == that.vectorCount &&
+         isRowMajor == that.isRowMajor;
+}
+
 ImageType::ImageType(const NumericalType *type, spv::Dim dim, bool arrayed,
                      bool ms, WithSampler sampled, spv::ImageFormat format)
     : SpirvType(TK_Image), sampledType(type), dimension(dim),
@@ -41,14 +51,16 @@ bool ImageType::operator==(const ImageType &that) const {
 
 StructType::StructType(llvm::ArrayRef<const SpirvType *> memberTypes,
                        llvm::StringRef name,
-                       llvm::ArrayRef<llvm::StringRef> memberNames)
+                       llvm::ArrayRef<llvm::StringRef> memberNames,
+                       bool isReadOnly)
     : SpirvType(TK_Struct), structName(name),
       fieldTypes(memberTypes.begin(), memberTypes.end()),
-      fieldNames(memberNames.begin(), memberNames.end()) {}
+      fieldNames(memberNames.begin(), memberNames.end()), readOnly(isReadOnly) {
+}
 
 bool StructType::operator==(const StructType &that) const {
   return structName == that.structName && fieldTypes == that.fieldTypes &&
-         fieldNames == that.fieldNames;
+         fieldNames == that.fieldNames && readOnly == that.readOnly;
 }
 
 } // namespace spirv


### PR DESCRIPTION
This visitor will be used in the new CodeGen infra for lowering
Clang AST QualType into SPIR-V types.

The logic for layout decorations is removed from this visitor;
we will have a separate class for layout decorations.