### PR TITLE
[spirv] Improve SpirvConstant class APIs.

### DIFF
--- a/tools/clang/include/clang/SPIRV/SPIRVContext.h
+++ b/tools/clang/include/clang/SPIRV/SPIRVContext.h
@@ -146,7 +146,7 @@ struct StorageClassDenseMapInfo {
 /// the SPIR-V entities allocated in memory.
 class SpirvContext {
 public:
-  SpirvContext(const ASTContext &ctx);
+  SpirvContext();
   ~SpirvContext() = default;
 
   // Forbid copy construction and assignment
@@ -200,12 +200,10 @@ public:
 
   const StructType *getByteAddressBufferType(bool isWritable);
 
-  SpirvConstant *getConstantUint32(uint32_t value, SourceLocation loc = {});
+  SpirvConstant *getConstantUint32(uint32_t value);
   // TODO: Add getConstant* methods for other types.
 
 private:
-  const ASTContext &astContext;
-
   /// \brief The allocator used to create SPIR-V entity objects.
   ///
   /// SPIR-V entity objects are never destructed; rather, all memory associated
@@ -254,10 +252,10 @@ private:
   llvm::SmallVector<const FunctionType *, 8> functionTypes;
 
   // Unique constants
-  // Avoid premature optimiztion: we do a linear search to find an existing
-  // constant (if any). This can be done faster if we use maps or use different
-  // vectors based on the constant type.
-  llvm::SmallVector<SpirvConstant *, 8> constants;
+  // We currently do a linear search to find an existing constant (if any). This
+  // can be done in a more efficient way if needed.
+  llvm::SmallVector<SpirvConstantInteger *, 8> integerConstants;
+  // TODO: Add vectors of other constant types here.
 };
 
 } // end namespace spirv

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -25,6 +25,9 @@ class SpirvBasicBlock;
 class SpirvFunction;
 class SpirvVariable;
 class SpirvType;
+class BoolType;
+class IntegerType;
+class FloatType;
 
 /// \brief The base class for representing SPIR-V instructions.
 class SpirvInstruction {
@@ -123,7 +126,8 @@ public:
   void setResultTypeId(uint32_t id) { resultTypeId = id; }
 
   bool hasResultType() const { return resultType != nullptr; }
-  SpirvType *getResultType() const { return resultType; }
+  const SpirvType *getResultType() const { return resultType; }
+  void setResultType(const SpirvType *t) { resultType = t; }
 
   // TODO: The responsibility of assigning the result-id of an instruction
   // shouldn't be on the instruction itself.
@@ -140,10 +144,10 @@ public:
 
 protected:
   // Forbid creating SpirvInstruction directly
-  SpirvInstruction(Kind kind, spv::Op opcode, QualType resultType,
+  SpirvInstruction(Kind kind, spv::Op opcode, QualType astResultType,
                    uint32_t resultId, SourceLocation loc);
 
-private:
+protected:
   const Kind kind;
 
   spv::Op opcode;
@@ -151,7 +155,7 @@ private:
   uint32_t resultId;
   SourceLocation srcLoc;
   std::string debugName;
-  SpirvType *resultType;
+  const SpirvType *resultType;
   uint32_t resultTypeId;
   SpirvLayoutRule layoutRule;
 };
@@ -910,19 +914,19 @@ public:
   }
 
 protected:
-  SpirvConstant(Kind, spv::Op, QualType resultType, uint32_t resultId,
-                SourceLocation);
+  SpirvConstant(Kind, spv::Op, const SpirvType *);
 };
 
 class SpirvConstantBoolean : public SpirvConstant {
 public:
-  SpirvConstantBoolean(bool value, QualType resultType, uint32_t resultId,
-                       SourceLocation loc);
+  SpirvConstantBoolean(const BoolType *type, bool value);
 
   // For LLVM-style RTTI
   static bool classof(const SpirvInstruction *inst) {
     return inst->getKind() == IK_ConstantBoolean;
   }
+
+  bool operator==(const SpirvConstantBoolean &that) const;
 
   DECLARE_INVOKE_VISITOR_FOR_CLASS(SpirvConstantBoolean)
 
@@ -935,23 +939,19 @@ private:
 /// \brief Represent OpConstant for integer values.
 class SpirvConstantInteger : public SpirvConstant {
 public:
-  SpirvConstantInteger(uint16_t value, QualType resultType, uint32_t resultId,
-                       SourceLocation loc);
-  SpirvConstantInteger(int16_t value, QualType resultType, uint32_t resultId,
-                       SourceLocation loc);
-  SpirvConstantInteger(uint32_t value, QualType resultType, uint32_t resultId,
-                       SourceLocation loc);
-  SpirvConstantInteger(int32_t value, QualType resultType, uint32_t resultId,
-                       SourceLocation loc);
-  SpirvConstantInteger(uint64_t value, QualType resultType, uint32_t resultId,
-                       SourceLocation loc);
-  SpirvConstantInteger(int64_t value, QualType resultType, uint32_t resultId,
-                       SourceLocation loc);
+  SpirvConstantInteger(const IntegerType *type, uint16_t value);
+  SpirvConstantInteger(const IntegerType *type, int16_t value);
+  SpirvConstantInteger(const IntegerType *type, uint32_t value);
+  SpirvConstantInteger(const IntegerType *type, int32_t value);
+  SpirvConstantInteger(const IntegerType *type, uint64_t value);
+  SpirvConstantInteger(const IntegerType *type, int64_t value);
 
   // For LLVM-style RTTI
   static bool classof(const SpirvInstruction *inst) {
     return inst->getKind() == IK_ConstantInteger;
   }
+
+  bool operator==(const SpirvConstantInteger &that) const;
 
   DECLARE_INVOKE_VISITOR_FOR_CLASS(SpirvConstantInteger)
 
@@ -962,66 +962,68 @@ public:
   uint64_t getUnsignedInt64Value() const;
   int64_t getSignedInt64Value() const;
 
-  uint32_t getBitwidth() const { return bitwidth; }
-  void setBitwidth(uint32_t width) { bitwidth = width; }
-  bool isSigned() const { return getAstResultType()->isSignedIntegerType(); }
+  uint32_t getBitwidth() const;
+  bool isSigned() const;
 
 private:
-  uint32_t bitwidth;
+  uint64_t getValueBits() const { return value; }
+
+private:
   uint64_t value;
 };
 
 class SpirvConstantFloat : public SpirvConstant {
 public:
-  SpirvConstantFloat(uint16_t value, QualType resultType, uint32_t resultId,
-                     SourceLocation loc);
-  SpirvConstantFloat(float value, QualType resultType, uint32_t resultId,
-                     SourceLocation loc);
-  SpirvConstantFloat(double value, QualType resultType, uint32_t resultId,
-                     SourceLocation loc);
+  SpirvConstantFloat(const FloatType *type, uint16_t value);
+  SpirvConstantFloat(const FloatType *type, float value);
+  SpirvConstantFloat(const FloatType *type, double value);
 
   // For LLVM-style RTTI
   static bool classof(const SpirvInstruction *inst) {
     return inst->getKind() == IK_ConstantFloat;
   }
 
+  bool operator==(const SpirvConstantFloat &that) const;
+
   DECLARE_INVOKE_VISITOR_FOR_CLASS(SpirvConstantFloat)
 
   uint16_t getValue16() const;
   float getValue32() const;
   double getValue64() const;
-  uint32_t getBitwidth() const { return bitwidth; }
-  void setBitwidth(uint32_t width) { bitwidth = width; }
+  uint32_t getBitwidth() const;
 
 private:
-  uint32_t bitwidth;
+  uint64_t getValueBits() const { return value; }
+
+private:
   uint64_t value;
 };
 
 class SpirvConstantComposite : public SpirvConstant {
 public:
-  SpirvConstantComposite(llvm::ArrayRef<SpirvConstant *> constituents,
-                         QualType resultType, uint32_t resultId,
-                         SourceLocation loc);
+  SpirvConstantComposite(const SpirvType *type,
+                         llvm::ArrayRef<const SpirvConstant *> constituents);
 
   // For LLVM-style RTTI
   static bool classof(const SpirvInstruction *inst) {
     return inst->getKind() == IK_ConstantComposite;
   }
 
+  bool operator==(const SpirvConstantComposite &that) const;
+
   DECLARE_INVOKE_VISITOR_FOR_CLASS(SpirvConstantComposite)
 
-  llvm::ArrayRef<SpirvConstant *> getConstituents() const {
+  llvm::ArrayRef<const SpirvConstant *> getConstituents() const {
     return constituents;
   }
 
 private:
-  std::vector<SpirvConstant *> constituents;
+  llvm::SmallVector<const SpirvConstant *, 4> constituents;
 };
 
 class SpirvConstantNull : public SpirvConstant {
 public:
-  SpirvConstantNull(QualType resultType, uint32_t resultId, SourceLocation loc);
+  SpirvConstantNull(const SpirvType *type);
 
   DECLARE_INVOKE_VISITOR_FOR_CLASS(SpirvConstantNull)
 
@@ -1029,6 +1031,8 @@ public:
   static bool classof(const SpirvInstruction *inst) {
     return inst->getKind() == IK_ConstantNull;
   }
+
+  bool operator==(const SpirvConstantNull &that) const;
 };
 
 /// \brief Composition instructions

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -20,14 +20,14 @@
 namespace clang {
 namespace spirv {
 
-class Visitor;
+class BoolType;
+class FloatType;
+class IntegerType;
 class SpirvBasicBlock;
 class SpirvFunction;
-class SpirvVariable;
 class SpirvType;
-class BoolType;
-class IntegerType;
-class FloatType;
+class SpirvVariable;
+class Visitor;
 
 /// \brief The base class for representing SPIR-V instructions.
 class SpirvInstruction {

--- a/tools/clang/include/clang/SPIRV/SpirvModule.h
+++ b/tools/clang/include/clang/SPIRV/SpirvModule.h
@@ -20,9 +20,6 @@ namespace spirv {
 
 class SpirvVisitor;
 
-// TODO: flesh this out
-class SpirvTypeConstant;
-
 /// The class representing a SPIR-V module in memory.
 ///
 /// A SPIR-V module contains two main parts: instructions for "metadata" (e.g.,
@@ -102,7 +99,7 @@ private:
   llvm::SmallVector<SpirvExecutionMode *, 4> executionModes;
   SpirvSource *debugSource;
   std::vector<SpirvDecoration *> decorations;
-  std::vector<SpirvTypeConstant *> typeConstants;
+  std::vector<SpirvConstant *> constants;
   std::vector<SpirvVariable *> variables;
 
   // Shader logic instructions

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -956,8 +956,7 @@ uint32_t EmitTypeHandler::emitType(const SpirvType *type,
   else if (const auto *arrayType = dyn_cast<ArrayType>(type)) {
     // Emit the OpConstant instruction that is needed to get the result-id for
     // the array length.
-    SpirvConstant *constant =
-        context.getConstantUint32(arrayType->getElementCount());
+    auto *constant = context.getConstantUint32(arrayType->getElementCount());
     if (constant->getResultId() == 0) {
       constant->setResultId(takeNextIdFunction());
     }

--- a/tools/clang/lib/SPIRV/SPIRVContext.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVContext.cpp
@@ -74,9 +74,9 @@ const Decoration *SPIRVContext::registerDecoration(const Decoration &d) {
   return &*it;
 }
 
-SpirvContext::SpirvContext(const ASTContext &ctx)
-    : astContext(ctx), allocator(), voidType(nullptr), boolType(nullptr),
-      sintTypes({}), uintTypes({}), floatTypes({}), samplerType(nullptr) {
+SpirvContext::SpirvContext()
+    : allocator(), voidType(nullptr), boolType(nullptr), sintTypes({}),
+      uintTypes({}), floatTypes({}), samplerType(nullptr) {
   voidType = new (this) VoidType;
   boolType = new (this) BoolType;
   samplerType = new (this) SamplerType;
@@ -292,18 +292,22 @@ const StructType *SpirvContext::getByteAddressBufferType(bool isWritable) {
                        {}, !isWritable);
 }
 
-SpirvConstant *SpirvContext::getConstantUint32(uint32_t value,
-                                               SourceLocation loc) {
-  for (auto *constant : constants)
-    if (auto *intConst = dyn_cast<SpirvConstantInteger>(constant))
-      if (!intConst->isSigned() && intConst->getBitwidth() == 32 &&
-          intConst->getUnsignedInt32Value() == value)
-        return constant;
+SpirvConstant *SpirvContext::getConstantUint32(uint32_t value) {
+  const IntegerType *intType = getUIntType(32);
+  SpirvConstantInteger tempConstant(intType, value);
+
+  auto found =
+      std::find_if(integerConstants.begin(), integerConstants.end(),
+                   [&tempConstant](SpirvConstantInteger *cachedConstant) {
+                     return tempConstant == *cachedConstant;
+                   });
+
+  if (found != integerConstants.end())
+    return *found;
 
   // Couldn't find the constant. Create one.
-  SpirvConstant *intConst =
-      new (this) SpirvConstantInteger(value, astContext.UnsignedIntTy, 0, loc);
-  constants.push_back(intConst);
+  auto *intConst = new (this) SpirvConstantInteger(intType, value);
+  integerConstants.push_back(intConst);
   return intConst;
 }
 

--- a/tools/clang/lib/SPIRV/SpirvModule.cpp
+++ b/tools/clang/lib/SPIRV/SpirvModule.cpp
@@ -50,7 +50,8 @@ bool SpirvModule::invokeVisitor(Visitor *visitor) {
     if (!decoration->invokeVisitor(visitor))
       return false;
 
-  // TODO: type and constants
+  for (auto constant : constants)
+    constant->invokeVisitor(visitor);
 
   for (auto var : variables)
     if (!var->invokeVisitor(visitor))

--- a/tools/clang/lib/SPIRV/SpirvType.cpp
+++ b/tools/clang/lib/SPIRV/SpirvType.cpp
@@ -6,7 +6,7 @@
 // License. See LICENSE.TXT for details.
 //===----------------------------------------------------------------------===//
 //
-//  This file implements the in-memory representation of SPIR-V instructions.
+//  This file implements the in-memory representation of SPIR-V types.
 //
 //===----------------------------------------------------------------------===//
 

--- a/tools/clang/unittests/SPIRV/SpirvConstantTest.cpp
+++ b/tools/clang/unittests/SPIRV/SpirvConstantTest.cpp
@@ -16,6 +16,62 @@
 namespace {
 using namespace clang::spirv;
 
+TEST(SpirvConstant, BoolFalse) {
+  SpirvContext ctx;
+  const bool val = false;
+  SpirvConstantBoolean constant(ctx.getBoolType(), val);
+  EXPECT_EQ(val, constant.getValue());
+}
+
+TEST(SpirvConstant, BoolTrue) {
+  SpirvContext ctx;
+  const bool val = true;
+  SpirvConstantBoolean constant(ctx.getBoolType(), val);
+  EXPECT_EQ(val, constant.getValue());
+}
+
+TEST(SpirvConstant, Uint16) {
+  SpirvContext ctx;
+  const uint16_t u16 = 12;
+  SpirvConstantInteger constant(ctx.getUIntType(16), u16);
+  EXPECT_EQ(u16, constant.getUnsignedInt16Value());
+}
+
+TEST(SpirvConstant, Int16) {
+  SpirvContext ctx;
+  const int16_t i16 = -12;
+  SpirvConstantInteger constant(ctx.getSIntType(16), i16);
+  EXPECT_EQ(i16, constant.getSignedInt16Value());
+}
+
+TEST(SpirvConstant, Uint32) {
+  SpirvContext ctx;
+  const uint32_t u32 = 65536;
+  SpirvConstantInteger constant(ctx.getUIntType(32), u32);
+  EXPECT_EQ(u32, constant.getUnsignedInt32Value());
+}
+
+TEST(SpirvConstant, Int32) {
+  SpirvContext ctx;
+  const int32_t i32 = -65536;
+  SpirvConstantInteger constant(ctx.getSIntType(32), i32);
+  EXPECT_EQ(i32, constant.getSignedInt32Value());
+}
+
+TEST(SpirvConstant, Uint64) {
+  SpirvContext ctx;
+  const uint64_t u64 = 4294967296;
+  SpirvConstantInteger constant(ctx.getUIntType(64), u64);
+  EXPECT_EQ(u64, constant.getUnsignedInt64Value());
+}
+
+TEST(SpirvConstant, Int64) {
+  SpirvContext ctx;
+  const int64_t i64 = -4294967296;
+  SpirvConstantInteger constant(ctx.getSIntType(64), i64);
+  EXPECT_EQ(i64, constant.getSignedInt64Value());
+}
+
 TEST(SpirvConstant, Float16) {
   SpirvContext ctx;
   const uint16_t f16 = 12;
@@ -35,6 +91,107 @@ TEST(SpirvConstant, Float64) {
   const double f64 = 3.14;
   SpirvConstantFloat constant(ctx.getFloatType(64), f64);
   EXPECT_EQ(f64, constant.getValue64());
+}
+
+TEST(SpirvConstant, CheckOperatorEqualOnBool) {
+  SpirvContext ctx;
+  const bool val = true;
+  SpirvConstantBoolean constant1(ctx.getBoolType(), val);
+  SpirvConstantBoolean constant2(ctx.getBoolType(), val);
+  EXPECT_TRUE(constant1 == constant2);
+}
+
+TEST(SpirvConstant, CheckOperatorEqualOnInt) {
+  SpirvContext ctx;
+  const int32_t i32 = -65536;
+  SpirvConstantInteger constant1(ctx.getSIntType(32), i32);
+  SpirvConstantInteger constant2(ctx.getSIntType(32), i32);
+  EXPECT_TRUE(constant1 == constant2);
+}
+
+TEST(SpirvConstant, CheckOperatorEqualOnFloat) {
+  SpirvContext ctx;
+  const double f64 = 3.14;
+  SpirvConstantFloat constant1(ctx.getFloatType(64), f64);
+  SpirvConstantFloat constant2(ctx.getFloatType(64), f64);
+  EXPECT_TRUE(constant1 == constant2);
+}
+
+TEST(SpirvConstant, CheckOperatorEqualOnNull) {
+  SpirvContext ctx;
+  SpirvConstantNull constant1(ctx.getSIntType(32));
+  SpirvConstantNull constant2(ctx.getSIntType(32));
+  EXPECT_TRUE(constant1 == constant2);
+}
+
+TEST(SpirvConstant, CheckOperatorEqualOnBool2) {
+  SpirvContext ctx;
+  SpirvConstantBoolean constant1(ctx.getBoolType(), true);
+  SpirvConstantBoolean constant2(ctx.getBoolType(), false);
+  EXPECT_FALSE(constant1 == constant2);
+}
+
+TEST(SpirvConstant, CheckOperatorEqualOnInt2) {
+  SpirvContext ctx;
+  SpirvConstantInteger constant1(ctx.getSIntType(32), 5);
+  SpirvConstantInteger constant2(ctx.getSIntType(32), 7);
+  EXPECT_FALSE(constant1 == constant2);
+}
+
+TEST(SpirvConstant, CheckOperatorEqualOnFloat2) {
+  SpirvContext ctx;
+  SpirvConstantFloat constant1(ctx.getFloatType(64), 3.14);
+  SpirvConstantFloat constant2(ctx.getFloatType(64), 3.15);
+  EXPECT_FALSE(constant1 == constant2);
+}
+
+TEST(SpirvConstant, CheckOperatorEqualOnNull2) {
+  SpirvContext ctx;
+  SpirvConstantNull constant1(ctx.getSIntType(32));
+  SpirvConstantNull constant2(ctx.getUIntType(32));
+  EXPECT_FALSE(constant1 == constant2);
+}
+
+TEST(SpirvConstant, CheckOperatorEqualOnComposite) {
+  // Make a constant array of size 2.
+  // Each array element is a vector of 4 floats.
+  SpirvContext ctx;
+  const FloatType *f32Type = ctx.getFloatType(32);
+  const VectorType *vecType = ctx.getVectorType(f32Type, 4);
+  const ArrayType *arrType = ctx.getArrayType(vecType, 2);
+  SpirvConstantFloat f1(f32Type, 3.14);
+  SpirvConstantFloat f2(f32Type, 5.f);
+  SpirvConstantFloat f3(f32Type, -1.f);
+  SpirvConstantFloat f4(f32Type, 0.f);
+  llvm::SmallVector<SpirvConstant *, 4> vectorValues = {&f1, &f2, &f3, &f4};
+  SpirvConstantComposite vec4(vecType, vectorValues);
+  llvm::SmallVector<SpirvConstant *, 2> arrayValues = {&vec4, &vec4};
+  SpirvConstantComposite arrayConstant1(arrType, arrayValues);
+  SpirvConstantComposite arrayConstant2(arrType, arrayValues);
+  EXPECT_TRUE(arrayConstant1 == arrayConstant2);
+}
+
+TEST(SpirvConstant, CheckOperatorEqualOnComposite2) {
+  // Make a constant array of size 1.
+  // Each array element is a vector of 4 floats.
+  SpirvContext ctx;
+  const FloatType *f32Type = ctx.getFloatType(32);
+  const VectorType *vecType = ctx.getVectorType(f32Type, 4);
+  const ArrayType *arrType = ctx.getArrayType(vecType, 1);
+  SpirvConstantFloat f1(f32Type, 3.14);
+  SpirvConstantFloat f2(f32Type, 5.f);
+  SpirvConstantFloat f3(f32Type, -1.f);
+  SpirvConstantFloat f4(f32Type, 0.f);
+  // Make the first component of the two vectors different intentionally.
+  llvm::SmallVector<SpirvConstant *, 4> vectorValues1 = {&f1, &f2, &f3, &f4};
+  llvm::SmallVector<SpirvConstant *, 4> vectorValues2 = {&f2, &f2, &f3, &f4};
+  SpirvConstantComposite vecConstant1(vecType, vectorValues1);
+  SpirvConstantComposite vecConstant2(vecType, vectorValues2);
+  llvm::SmallVector<SpirvConstant *, 2> arrayValues1 = {&vecConstant1};
+  llvm::SmallVector<SpirvConstant *, 2> arrayValues2 = {&vecConstant2};
+  SpirvConstantComposite arrayConstant1(arrType, arrayValues1);
+  SpirvConstantComposite arrayConstant2(arrType, arrayValues2);
+  EXPECT_FALSE(arrayConstant1 == arrayConstant2);
 }
 
 } // anonymous namespace

--- a/tools/clang/unittests/SPIRV/SpirvConstantTest.cpp
+++ b/tools/clang/unittests/SPIRV/SpirvConstantTest.cpp
@@ -10,26 +10,30 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include "clang/SPIRV/SPIRVContext.h"
 #include "clang/SPIRV/SpirvInstruction.h"
 
 namespace {
 using namespace clang::spirv;
 
 TEST(SpirvConstant, Float16) {
+  SpirvContext ctx;
   const uint16_t f16 = 12;
-  SpirvConstantFloat constant(f16, {}, 0, {});
+  SpirvConstantFloat constant(ctx.getFloatType(16), f16);
   EXPECT_EQ(f16, constant.getValue16());
 }
 
 TEST(SpirvConstant, Float32) {
+  SpirvContext ctx;
   const float f32 = 1.5;
-  SpirvConstantFloat constant(f32, {}, 0, {});
+  SpirvConstantFloat constant(ctx.getFloatType(32), f32);
   EXPECT_EQ(f32, constant.getValue32());
 }
 
 TEST(SpirvConstant, Float64) {
+  SpirvContext ctx;
   const double f64 = 3.14;
-  SpirvConstantFloat constant(f64, {}, 0, {});
+  SpirvConstantFloat constant(ctx.getFloatType(64), f64);
   EXPECT_EQ(f64, constant.getValue64());
 }
 


### PR DESCRIPTION
The main motivation of this change is to eliminate usage of ASTContext and QualType when asking for SPIR-V constants.