### PR TITLE
[spirv] set function's parent info correctly

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBasicBlock.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBasicBlock.h
@@ -70,9 +70,16 @@ public:
   /// OpLoopMerge instruction. Returns nullptr otherwise.
   SpirvBasicBlock *getContinueTarget() const { return continueTarget; }
 
+  /// Get/set DebugScope for this basic block.
+  SpirvDebugScope *getDebugScope() const { return debugScope; }
+  void setDebugScope(SpirvDebugScope *scope) { debugScope = scope; }
+
   /// Adds an instruction to the vector of instructions belonging to this basic
   /// block.
   void addInstruction(SpirvInstruction *inst) { instructions.push_back(inst); }
+
+  /// Return true if instructions is empty. Otherwise, return false.
+  bool empty() { return instructions.empty(); }
 
   /// Returns true if the last instruction in this basic block is a termination
   /// instruction.
@@ -106,6 +113,9 @@ private:
   /// The continue merge targets if this basic block is a header block
   /// of structured control flow.
   SpirvBasicBlock *continueTarget;
+
+  /// DebugScope that groups all instructions in this basic block.
+  SpirvDebugScope *debugScope;
 };
 
 } // end namespace spirv

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -433,6 +433,9 @@ public:
       llvm::StringRef linkageName, SpirvVariable *var, uint32_t flags,
       llvm::Optional<SpirvInstruction *> staticMemberDebugType = llvm::None);
 
+  // Get a DebugInfoNone if exists. Otherwise, create one and return it.
+  SpirvDebugInfoNone *getOrCreateDebugInfoNone();
+
   // Get a null DebugExpression if exists. Otherwise, create one and return it.
   SpirvDebugExpression *getOrCreateNullDebugExpression();
 
@@ -640,6 +643,8 @@ private:
   };
   /// Used as caches for all created builtin variables to avoid duplication.
   llvm::SmallVector<BuiltInVarInfo, 16> builtinVars;
+
+  SpirvDebugInfoNone *debugNone;
 
   /// DebugExpression that does not reference any DebugOperation
   SpirvDebugExpression *nullDebugExpr;

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -427,6 +427,12 @@ public:
       uint32_t line, uint32_t column, SpirvDebugInstruction *parentScope,
       uint32_t flags, llvm::Optional<uint32_t> argNumber = llvm::None);
 
+  SpirvDebugGlobalVariable *createDebugGlobalVariable(
+      QualType debugType, llvm::StringRef varName, SpirvDebugSource *src,
+      uint32_t line, uint32_t column, SpirvDebugInstruction *parentScope,
+      llvm::StringRef linkageName, SpirvVariable *var, uint32_t flags,
+      llvm::Optional<SpirvInstruction *> staticMemberDebugType = llvm::None);
+
   // Get a null DebugExpression if exists. Otherwise, create one and return it.
   SpirvDebugExpression *getOrCreateNullDebugExpression();
 

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -414,7 +414,7 @@ public:
 
   // === SPIR-V Rich Debug Info Creation ===
   SpirvDebugSource *createDebugSource(llvm::StringRef file,
-                                      llvm::StringRef text);
+                                      llvm::StringRef text = "");
 
   SpirvDebugCompilationUnit *createDebugCompilationUnit(SpirvDebugSource *);
 

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -427,6 +427,13 @@ public:
       uint32_t line, uint32_t column, SpirvDebugInstruction *parentScope,
       uint32_t flags, llvm::Optional<uint32_t> argNumber = llvm::None);
 
+  // Get a null DebugExpression if exists. Otherwise, create one and return it.
+  SpirvDebugExpression *getOrCreateNullDebugExpression();
+
+  SpirvDebugDeclare *createDebugDeclare(
+      SpirvDebugLocalVariable *dbgVar, SpirvInstruction *var,
+      llvm::Optional<SpirvDebugExpression *> dbgExpr = llvm::None);
+
   SpirvDebugFunction *createDebugFunction(llvm::StringRef name,
                                           SpirvDebugSource *src,
                                           uint32_t fnLine, uint32_t fnColumn,
@@ -625,6 +632,9 @@ private:
   };
   /// Used as caches for all created builtin variables to avoid duplication.
   llvm::SmallVector<BuiltInVarInfo, 16> builtinVars;
+
+  /// DebugExpression that does not reference any DebugOperation
+  SpirvDebugExpression *nullDebugExpr;
 };
 
 void SpirvBuilder::requireCapability(spv::Capability cap, SourceLocation loc) {

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -575,6 +575,8 @@ public:
                        bool specConst = false);
   SpirvConstant *getConstantNull(QualType);
 
+  void setCurrentLexicalScope(SpirvDebugInstruction *inst);
+
 public:
   std::vector<uint32_t> takeModule();
 
@@ -635,6 +637,9 @@ private:
 
   /// DebugExpression that does not reference any DebugOperation
   SpirvDebugExpression *nullDebugExpr;
+
+  /// A debug instruction for the current lexical scope.
+  SpirvDebugInstruction *currentLexicalScope;
 };
 
 void SpirvBuilder::requireCapability(spv::Capability cap, SourceLocation loc) {

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -660,7 +660,7 @@ SpirvBuilder::setDebugSource(uint32_t major, uint32_t minor,
     SpirvSource *debugSource = new (context)
         SpirvSource(/*SourceLocation*/ {}, spv::SourceLanguage::HLSL, version,
                     fileString, content);
-    module->addDebugSource(debugSource);
+    module->addSource(debugSource);
     if (!mainSource)
       mainSource = debugSource;
   }
@@ -671,7 +671,7 @@ SpirvBuilder::setDebugSource(uint32_t major, uint32_t minor,
     mainSource = new (context)
         SpirvSource(/*SourceLocation*/ {}, spv::SourceLanguage::HLSL, version,
                     nullptr, content);
-    module->addDebugSource(mainSource);
+    module->addSource(mainSource);
   }
   return mainSource->getFile();
 }

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -161,8 +161,7 @@ public:
                        SpirvDebugInstruction *ret,
                        llvm::ArrayRef<SpirvDebugInstruction *> params);
 
-  llvm::MapVector<const SpirvType *, SpirvDebugInstruction *>
-  getDebugTypes() const {
+  llvm::MapVector<const SpirvType *, SpirvDebugType *> getDebugTypes() const {
     return debugTypes;
   }
 
@@ -309,7 +308,7 @@ private:
   // Mapping from SPIR-V type to debug type instruction.
   // The purpose is not to generate several DebugType* instructions for the same
   // type if the type is used for several variables.
-  llvm::MapVector<const SpirvType *, SpirvDebugInstruction *> debugTypes;
+  llvm::MapVector<const SpirvType *, SpirvDebugType *> debugTypes;
 };
 
 } // end namespace spirv

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -194,6 +194,14 @@ public:
                        SpirvDebugType *ret,
                        llvm::ArrayRef<SpirvDebugType *> params);
 
+  SpirvDebugInstruction *getDebugTypeTemplate(const SpirvType *spirvType,
+                                              SpirvDebugInstruction *target);
+
+  SpirvDebugInstruction *getDebugTypeTemplateParameter(
+      const SpirvType *spirvType, llvm::StringRef name,
+      SpirvDebugType *actualType, SpirvConstant *value,
+      SpirvDebugSource *source, uint32_t line, uint32_t column);
+
   llvm::MapVector<const SpirvType *, SpirvDebugType *> getDebugTypes() const {
     return debugTypes;
   }

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -179,7 +179,7 @@ public:
                         llvm::StringRef linkageName, uint32_t size,
                         uint32_t flags, uint32_t tag);
 
-  SpirvDebugInstruction *getDebugTypeComposite(const SpirvType *spirvType);
+  SpirvDebugInstruction *getDebugType(const SpirvType *spirvType);
 
   SpirvDebugInstruction *getDebugTypeArray(const SpirvType *spirvType,
                                            SpirvDebugInstruction *elemType,
@@ -197,10 +197,10 @@ public:
   SpirvDebugInstruction *getDebugTypeTemplate(const SpirvType *spirvType,
                                               SpirvDebugInstruction *target);
 
-  SpirvDebugInstruction *getDebugTypeTemplateParameter(
-      const SpirvType *spirvType, llvm::StringRef name,
-      SpirvDebugType *actualType, SpirvConstant *value,
-      SpirvDebugSource *source, uint32_t line, uint32_t column);
+  SpirvDebugInstruction *
+  getDebugTypeTemplateParameter(llvm::StringRef name, const SpirvType *type,
+                                SpirvConstant *value, SpirvDebugSource *source,
+                                uint32_t line, uint32_t column);
 
   llvm::MapVector<const SpirvType *, SpirvDebugType *> getDebugTypes() const {
     return debugTypes;

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -189,8 +189,8 @@ public:
 
   SpirvDebugInstruction *
   getDebugTypeFunction(const SpirvType *spirvType, uint32_t flags,
-                       SpirvDebugInstruction *ret,
-                       llvm::ArrayRef<SpirvDebugInstruction *> params);
+                       SpirvDebugType *ret,
+                       llvm::ArrayRef<SpirvDebugType *> params);
 
   llvm::MapVector<const SpirvType *, SpirvDebugType *> getDebugTypes() const {
     return debugTypes;

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -179,6 +179,8 @@ public:
                         llvm::StringRef linkageName, uint32_t size,
                         uint32_t flags, uint32_t tag);
 
+  SpirvDebugInstruction *getDebugTypeComposite(const SpirvType *spirvType);
+
   SpirvDebugInstruction *getDebugTypeArray(const SpirvType *spirvType,
                                            SpirvDebugInstruction *elemType,
                                            llvm::ArrayRef<uint32_t> elemCount);

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -197,10 +197,9 @@ public:
   SpirvDebugInstruction *getDebugTypeTemplate(const SpirvType *spirvType,
                                               SpirvDebugInstruction *target);
 
-  SpirvDebugInstruction *
-  getDebugTypeTemplateParameter(llvm::StringRef name, const SpirvType *type,
-                                SpirvConstant *value, SpirvDebugSource *source,
-                                uint32_t line, uint32_t column);
+  SpirvDebugInstruction *getDebugTypeTemplateParameter(
+      llvm::StringRef name, const SpirvType *type, SpirvInstruction *value,
+      SpirvDebugSource *source, uint32_t line, uint32_t column);
 
   llvm::MapVector<const SpirvType *, SpirvDebugType *> getDebugTypes() const {
     return debugTypes;

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -166,11 +166,11 @@ public:
                                            uint32_t encoding);
 
   SpirvDebugInstruction *
-  getDebugTypeMember(llvm::StringRef name, SpirvDebugType *type,
+  getDebugTypeMember(llvm::StringRef name, const SpirvType *type,
                      SpirvDebugSource *source, uint32_t line, uint32_t column,
-                     SpirvDebugInstruction *parent, uint32_t offset,
-                     uint32_t size, uint32_t flags,
-                     llvm::Optional<SpirvInstruction *> value = llvm::None);
+                     SpirvDebugInstruction *parent, uint32_t flags,
+                     uint32_t offset = UINT32_MAX,
+                     const APValue *value = nullptr);
 
   SpirvDebugInstruction *
   getDebugTypeComposite(const SpirvType *spirvType, llvm::StringRef name,

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -232,8 +232,7 @@ public:
   const StructType *getStructType(
       llvm::ArrayRef<StructType::FieldInfo> fields, llvm::StringRef name,
       bool isReadOnly = false,
-      StructInterfaceType interfaceType = StructInterfaceType::InternalStorage,
-      llvm::Optional<const RecordDecl *> decl = llvm::None);
+      StructInterfaceType interfaceType = StructInterfaceType::InternalStorage);
 
   void saveFuntionInfo(const CXXMethodDecl *decl, SpirvDebugFunction *fn) {
     structDeclToFnList[decl] = fn;

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -233,12 +233,14 @@ public:
       StructInterfaceType interfaceType = StructInterfaceType::InternalStorage,
       llvm::Optional<const RecordDecl *> decl = llvm::None);
 
-  void saveFuntionInfo(const RecordDecl *decl, const SpirvDebugFunction *fn) {
+  void saveFuntionInfo(const CXXMethodDecl *decl, SpirvDebugFunction *fn) {
+    structDeclToFnList[decl] = fn;
+  }
+  SpirvDebugFunction *findFunctionInfo(const CXXMethodDecl *decl) {
     auto it = structDeclToFnList.find(decl);
     if (it != structDeclToFnList.end())
-      it->second.push_back(fn);
-    else
-      structDeclToFnList[decl] = {fn};
+      return it->second;
+    return nullptr;
   }
 
   const SpirvPointerType *getPointerType(const SpirvType *pointee,
@@ -375,7 +377,7 @@ private:
 
   // Mapping from RecordDecl (struct or class or enum) to a vector of its member
   // function info.
-  llvm::DenseMap<const RecordDecl *, std::vector<const SpirvDebugFunction *>>
+  llvm::DenseMap<const CXXMethodDecl *, SpirvDebugFunction *>
       structDeclToFnList;
 };
 

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -206,8 +206,8 @@ public:
     return debugTypes;
   }
 
-  llvm::SmallVector<SpirvDebugInstruction *, 16> getMemberTypes() const {
-    return memberTypes;
+  llvm::SmallVector<SpirvDebugInstruction *, 16> getTailDebugTypes() const {
+    return tailDebugTypes;
   }
 
   // === Types ===
@@ -376,13 +376,13 @@ private:
   // type if the type is used for several variables.
   llvm::MapVector<const SpirvType *, SpirvDebugType *> debugTypes;
 
-  // Keep DebugTypeMember and DebugTypeInheritance.
-  // Since both DebugTypeMember and DebugTypeInheritance do not have
-  // corresponding SpirvType, we cannot keep them in debugTypes.
-  // No component reference DebugTypeMember and DebugTypeInheritance,
+  // Keep DebugTypeMember, DebugTypeInheritance, DebugTypeTemplate,
+  // and DebugTypeTemplateParameter.
+  // Since they do not have corresponding SpirvType, we cannot keep them
+  // in debugTypes. No component references them other than themselves,
   // there by being able to safely emit them at the end of other debug
   // extension instructions.
-  llvm::SmallVector<SpirvDebugInstruction *, 16> memberTypes;
+  llvm::SmallVector<SpirvDebugInstruction *, 16> tailDebugTypes;
 
   // Mapping from RecordDecl (struct or class or enum) to a vector of its member
   // function info.

--- a/tools/clang/include/clang/SPIRV/SpirvFunction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvFunction.h
@@ -95,6 +95,10 @@ public:
   void setRValue() { rvalue = true; }
   bool isRValue() { return rvalue; }
 
+  /// Get/set DebugScope for this function.
+  SpirvDebugScope *getDebugScope() const { return debugScope; }
+  void setDebugScope(SpirvDebugScope *scope) { debugScope = scope; }
+
 private:
   uint32_t functionId; ///< This function's <result-id>
 
@@ -130,6 +134,9 @@ private:
 
   /// Basic blocks inside this function.
   std::vector<SpirvBasicBlock *> basicBlocks;
+
+  /// DebugScope that groups all instructions in this basic block.
+  SpirvDebugScope *debugScope;
 };
 
 } // end namespace spirv

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -129,6 +129,7 @@ public:
     IK_DebugDeclare,
     IK_DebugValue,
     IK_DebugLexicalBlock,
+    IK_DebugScope,
     IK_DebugTypeBasic,
     IK_DebugTypeArray,
     IK_DebugTypeVector,
@@ -2065,6 +2066,24 @@ private:
   uint32_t line;
   uint32_t column;
   SpirvDebugInstruction *parent;
+};
+
+/// Represent DebugScope. We assume that DXC does not generate inlining
+/// information. We do not add "Inlined" operand.
+class SpirvDebugScope : public SpirvDebugInstruction {
+public:
+  SpirvDebugScope(SpirvDebugInstruction *);
+
+  static bool classof(const SpirvInstruction *inst) {
+    return inst->getKind() == IK_DebugScope;
+  }
+
+  bool invokeVisitor(Visitor *v) override;
+
+  SpirvDebugInstruction *getScope() const { return scope; }
+
+private:
+  SpirvDebugInstruction *scope;
 };
 
 /// The following classes represent debug types defined in the

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -2212,7 +2212,7 @@ public:
   bool invokeVisitor(Visitor *v) override;
 
   SpirvDebugType *getElementType() const { return elementType; }
-  llvm::ArrayRef<uint32_t> getElementCount() const { return elementCount; }
+  llvm::SmallVector<uint32_t, 2> &getElementCount() { return elementCount; }
 
   uint32_t getSizeInBits() const override {
     uint32_t nElem = elementType->getSizeInBits();
@@ -2223,7 +2223,7 @@ public:
 
 private:
   SpirvDebugType *elementType;
-  llvm::SmallVector<uint32_t, 4> elementCount;
+  llvm::SmallVector<uint32_t, 2> elementCount;
 };
 
 /// Represents vector debug types

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -1798,13 +1798,11 @@ public:
            inst->getKind() <= IK_DebugTypeMember;
   }
 
-  void setDebugType(SpirvDebugInstruction *type) { debugType = type; }
   void setInstructionSet(SpirvExtInstImport *set) { instructionSet = set; }
   SpirvExtInstImport *getInstructionSet() const { return instructionSet; }
   uint32_t getDebugOpcode() const { return debugOpcode; }
   QualType getDebugQualType() const { return debugQualType; }
   const SpirvType *getDebugSpirvType() const { return debugSpirvType; }
-  SpirvDebugInstruction *getDebugType() const { return debugType; }
   void setDebugQualType(QualType type) { debugQualType = type; }
   void setDebugSpirvType(const SpirvType *type) { debugSpirvType = type; }
 
@@ -1821,11 +1819,6 @@ private:
 
   QualType debugQualType;
   const SpirvType *debugSpirvType;
-
-  // The constructor for SpirvDebugInstruction sets the debug type to nullptr.
-  // A type lowering IMR pass will set debug types for all debug instructions
-  // that do contain a debug type.
-  SpirvDebugInstruction *debugType;
 
   // The pointer to the debug info extended instruction set.
   // This is not required by the constructor, and can be set via any IMR pass.
@@ -1896,6 +1889,9 @@ public:
   uint32_t getScopeLine() const { return scopeLine; }
   SpirvFunction *getSpirvFunction() const { return fn; }
 
+  void setDebugType(SpirvDebugInstruction *type) { debugType = type; }
+  SpirvDebugInstruction *getDebugType() const { return debugType; }
+
 private:
   SpirvDebugSource *source;
   // Source line number at which the function appears
@@ -1911,6 +1907,11 @@ private:
   uint32_t scopeLine;
   // The function to which this debug instruction belongs
   SpirvFunction *fn;
+
+  // The constructor for SpirvDebugFunction sets the debug type to nullptr.
+  // A type lowering IMR pass will set debug types for all debug instructions
+  // that do contain a debug type.
+  SpirvDebugInstruction *debugType;
 };
 
 class SpirvDebugLocalVariable : public SpirvDebugInstruction {
@@ -1933,6 +1934,9 @@ public:
   uint32_t getFlags() const { return flags; }
   llvm::Optional<uint32_t> getArgNumber() const { return argNumber; }
 
+  void setDebugType(SpirvDebugInstruction *type) { debugType = type; }
+  SpirvDebugInstruction *getDebugType() const { return debugType; }
+
 private:
   SpirvDebugSource *source;
   uint32_t line;
@@ -1941,6 +1945,11 @@ private:
   // TODO: Replace this with an enum, when it is available in SPIRV-Headers
   uint32_t flags;
   llvm::Optional<uint32_t> argNumber;
+
+  // The constructor sets the debug type to nullptr.
+  // A type lowering IMR pass will set debug types for all debug instructions
+  // that do contain a debug type.
+  SpirvDebugInstruction *debugType;
 };
 
 class SpirvDebugGlobalVariable : public SpirvDebugInstruction {
@@ -1959,6 +1968,9 @@ public:
 
   SpirvDebugInstruction *getParent() const override { return parentScope; }
 
+  void setDebugType(SpirvDebugInstruction *type) { debugType = type; }
+  SpirvDebugInstruction *getDebugType() const { return debugType; }
+
 private:
   SpirvDebugSource *source;
   uint32_t line;
@@ -1969,6 +1981,11 @@ private:
   // TODO: Replace this with an enum, when it is available in SPIRV-Headers
   uint32_t flags;
   llvm::Optional<SpirvInstruction *> staticMemberDebugType;
+
+  // The constructor sets the debug type to nullptr.
+  // A type lowering IMR pass will set debug types for all debug instructions
+  // that do contain a debug type.
+  SpirvDebugInstruction *debugType;
 };
 
 class SpirvDebugOperation : public SpirvDebugInstruction {

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -2341,6 +2341,9 @@ public:
   void setSizeInBits(uint32_t size_) { size = size_; }
   uint32_t getSizeInBits() const override { return size; }
 
+  void setFullyLowered() { fullyLowered = true; }
+  bool getFullyLowered() const { return fullyLowered; }
+
 private:
   std::string name;         //< Name of the member as it appears in the program
   SpirvDebugSource *source; //< DebugSource containing this type
@@ -2367,6 +2370,11 @@ private:
   // DebugTypeInheritance. Since DebugFunction may be a member, we cannot use a
   // vector of SpirvDebugType.
   llvm::SmallVector<SpirvDebugInstruction *, 4> members;
+
+  // It is first lowered by LowerTypeVisitor and then lowered by
+  // DebugTypeVisitor. We set fullyLowered true after it is lowered
+  // by DebugTypeVisitor.
+  bool fullyLowered;
 };
 
 #undef DECLARE_INVOKE_VISITOR_FOR_CLASS

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -2309,7 +2309,9 @@ public:
 
   bool invokeVisitor(Visitor *v) override;
 
-  llvm::SmallVector<SpirvDebugTypeTemplateParameter *, 2> &getParams() { return params; }
+  llvm::SmallVector<SpirvDebugTypeTemplateParameter *, 2> &getParams() {
+    return params;
+  }
   SpirvDebugInstruction *getTarget() const { return target; }
 
 private:
@@ -2414,7 +2416,7 @@ public:
   uint32_t getSizeInBits() const override { return size; }
 
   void setTypeTemplate(SpirvDebugTypeTemplate *t) { typeTemplate = t; }
-  SpirvDebugTypeTemplate * getTypeTemplate() const { return typeTemplate; }
+  SpirvDebugTypeTemplate *getTypeTemplate() const { return typeTemplate; }
 
   void setFullyLowered() { fullyLowered = true; }
   bool getFullyLowered() const { return fullyLowered; }

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -2179,13 +2179,11 @@ public:
 
   bool invokeVisitor(Visitor *v) override;
 
-  llvm::StringRef getName() const { return name; }
   SpirvConstant *getSize() const { return size; }
   uint32_t getEncoding() const { return encoding; }
   uint32_t getSizeInBits() const override;
 
 private:
-  std::string name;
   SpirvConstant *size;
   // TODO: Replace uint32_t with enum from SPIRV-Headers once available.
   // 0, Unspecified
@@ -2363,8 +2361,6 @@ public:
 
   SpirvDebugInstruction *getParent() const override { return parent; }
 
-  llvm::StringRef getName() const { return name; }
-
   void setType(SpirvDebugType *type_) { type = type_; }
   SpirvDebugType *getType() const { return type; }
   SpirvDebugSource *getSource() const { return source; }
@@ -2378,7 +2374,6 @@ public:
   const SpirvType *getSpirvType() const { return spvType; }
 
 private:
-  std::string name;         //< Name of the member as it appears in the program
   SpirvDebugType *type;     //< The type of the current member
   SpirvDebugSource *source; //< DebugSource containing this type
   uint32_t line;            //< Line number
@@ -2417,12 +2412,11 @@ public:
     return members;
   }
   SpirvDebugInstruction *getParent() const override { return parent; }
-  llvm::StringRef getName() const { return name; }
   uint32_t getTag() const { return tag; }
   SpirvDebugSource *getSource() const { return source; }
   uint32_t getLine() const { return line; }
   uint32_t getColumn() const { return column; }
-  llvm::StringRef getLinkageName() const { return name; }
+  llvm::StringRef getLinkageName() const { return linkageName; }
   uint32_t getDebugFlags() const { return debugFlags; }
 
   void setSizeInBits(uint32_t size_) { size = size_; }
@@ -2435,7 +2429,6 @@ public:
   bool getFullyLowered() const { return fullyLowered; }
 
 private:
-  std::string name;         //< Name of the member as it appears in the program
   SpirvDebugSource *source; //< DebugSource containing this type
   uint32_t line;            //< Line number
   uint32_t column;          //< Column number

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -2229,8 +2229,8 @@ private:
 /// parameter types.
 class SpirvDebugTypeFunction : public SpirvDebugType {
 public:
-  SpirvDebugTypeFunction(uint32_t flags, SpirvDebugInstruction *ret,
-                         llvm::ArrayRef<SpirvDebugInstruction *> params);
+  SpirvDebugTypeFunction(uint32_t flags, SpirvDebugType *ret,
+                         llvm::ArrayRef<SpirvDebugType *> params);
 
   static bool classof(const SpirvInstruction *inst) {
     return inst->getKind() == IK_DebugTypeFunction;
@@ -2239,10 +2239,8 @@ public:
   bool invokeVisitor(Visitor *v) override;
 
   uint32_t getDebugFlags() const { return debugFlags; }
-  SpirvDebugInstruction *getReturnType() const { return returnType; }
-  llvm::ArrayRef<SpirvDebugInstruction *> getParamTypes() const {
-    return paramTypes;
-  }
+  SpirvDebugType *getReturnType() const { return returnType; }
+  llvm::ArrayRef<SpirvDebugType *> getParamTypes() const { return paramTypes; }
 
 private:
   // TODO: Replace uint32_t with enum in the SPIRV-Headers once it is available.
@@ -2250,8 +2248,8 @@ private:
   // Return Type is a debug instruction which represents type of return value of
   // the function. If the function has no return value, this operand is
   // OpTypeVoid, in which case we will use nullptr for this member.
-  SpirvDebugInstruction *returnType;
-  llvm::SmallVector<SpirvDebugInstruction *, 4> paramTypes;
+  SpirvDebugType *returnType;
+  llvm::SmallVector<SpirvDebugType *, 4> paramTypes;
 };
 
 /// Represents the debug type of a struct/union/class member.

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -1898,6 +1898,7 @@ public:
   SpirvDebugSource *getSource() const { return source; }
   uint32_t getLine() const { return fnLine; }
   uint32_t getColumn() const { return fnColumn; }
+  void setParent(SpirvDebugInstruction *scope) { parentScope = scope; }
   SpirvDebugInstruction *getParent() const override { return parentScope; }
   llvm::StringRef getLinkageName() const { return linkageName; }
   uint32_t getFlags() const { return flags; }

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -120,6 +120,7 @@ public:
     IK_RayTracingOpNV,            // NV raytracing ops
 
     // For DebugInfo instructions defined in OpenCL.DebugInfo.100
+    IK_DebugInfoNone,
     IK_DebugCompilationUnit,
     IK_DebugSource,
     IK_DebugFunction,
@@ -1828,6 +1829,17 @@ private:
   SpirvExtInstImport *instructionSet;
 };
 
+class SpirvDebugInfoNone : public SpirvDebugInstruction {
+public:
+  SpirvDebugInfoNone();
+
+  static bool classof(const SpirvInstruction *inst) {
+    return inst->getKind() == IK_DebugInfoNone;
+  }
+
+  bool invokeVisitor(Visitor *v) override;
+};
+
 class SpirvDebugSource : public SpirvDebugInstruction {
 public:
   SpirvDebugSource(llvm::StringRef file, llvm::StringRef text);
@@ -2267,7 +2279,7 @@ private:
 class SpirvDebugTypeTemplateParameter : public SpirvDebugType {
 public:
   SpirvDebugTypeTemplateParameter(llvm::StringRef name, const SpirvType *type,
-                                  SpirvConstant *value,
+                                  SpirvInstruction *value,
                                   SpirvDebugSource *source, uint32_t line,
                                   uint32_t column);
 
@@ -2279,7 +2291,8 @@ public:
 
   SpirvDebugType *getActualType() const { return actualType; }
   void setActualType(SpirvDebugType *ty) { actualType = ty; }
-  SpirvConstant *getValue() const { return value; }
+  void setValue(SpirvInstruction *c) { value = c; }
+  SpirvInstruction *getValue() const { return value; }
   SpirvDebugSource *getSource() const { return source; }
   uint32_t getLine() const { return line; }
   uint32_t getColumn() const { return column; }
@@ -2288,7 +2301,7 @@ public:
 
 private:
   SpirvDebugType *actualType; //< Type for type param
-  SpirvConstant *value;       //< Value. It must be null for type.
+  SpirvInstruction *value;    //< Value. It must be null for type.
   SpirvDebugSource *source;   //< DebugSource containing this type
   uint32_t line;              //< Line number
   uint32_t column;            //< Column number

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -1956,8 +1956,8 @@ private:
 class SpirvDebugGlobalVariable : public SpirvDebugInstruction {
 public:
   SpirvDebugGlobalVariable(
-      llvm::StringRef varName, SpirvDebugSource *src, uint32_t line,
-      uint32_t column, SpirvDebugInstruction *parentScope,
+      QualType debugQualType, llvm::StringRef varName, SpirvDebugSource *src,
+      uint32_t line, uint32_t column, SpirvDebugInstruction *parentScope,
       llvm::StringRef linkageName, SpirvVariable *var, uint32_t flags,
       llvm::Optional<SpirvInstruction *> staticMemberDebugType = llvm::None);
 
@@ -1967,7 +1967,16 @@ public:
 
   bool invokeVisitor(Visitor *v) override;
 
+  SpirvDebugSource *getSource() const { return source; }
+  uint32_t getLine() const { return line; }
+  uint32_t getColumn() const { return column; }
   SpirvDebugInstruction *getParent() const override { return parentScope; }
+  llvm::StringRef getLinkageName() const { return linkageName; }
+  uint32_t getFlags() const { return flags; }
+  SpirvInstruction *getVariable() const { return var; }
+  llvm::Optional<SpirvInstruction *> getStaticMemberDebugDecl() const {
+    return staticMemberDebugDecl;
+  }
 
   void setDebugType(SpirvDebugInstruction *type) { debugType = type; }
   SpirvDebugInstruction *getDebugType() const { return debugType; }
@@ -1981,7 +1990,7 @@ private:
   SpirvVariable *var;
   // TODO: Replace this with an enum, when it is available in SPIRV-Headers
   uint32_t flags;
-  llvm::Optional<SpirvInstruction *> staticMemberDebugType;
+  llvm::Optional<SpirvInstruction *> staticMemberDebugDecl;
 
   // The constructor sets the debug type to nullptr.
   // A type lowering IMR pass will set debug types for all debug instructions

--- a/tools/clang/include/clang/SPIRV/SpirvModule.h
+++ b/tools/clang/include/clang/SPIRV/SpirvModule.h
@@ -22,6 +22,23 @@ namespace spirv {
 class SpirvFunction;
 class SpirvVisitor;
 
+struct RichDebugInfo {
+  RichDebugInfo(SpirvDebugSource *src, SpirvDebugCompilationUnit *cu)
+      : source(src), compilationUnit(cu) {
+    scopeStack.push_back(cu);
+  }
+  RichDebugInfo() : source(nullptr), compilationUnit(nullptr), scopeStack() {}
+
+  // The HLL source code
+  SpirvDebugSource *source;
+
+  // The compilation unit (topmost debug info node)
+  SpirvDebugCompilationUnit *compilationUnit;
+
+  // Stack of lexical scopes
+  std::vector<SpirvDebugInstruction *> scopeStack;
+};
+
 struct ExtensionComparisonInfo {
   static inline SpirvExtension *getEmptyKey() { return nullptr; }
   static inline SpirvExtension *getTombstoneKey() { return nullptr; }

--- a/tools/clang/include/clang/SPIRV/SpirvModule.h
+++ b/tools/clang/include/clang/SPIRV/SpirvModule.h
@@ -127,8 +127,9 @@ public:
   // Adds the debug source to the module.
   void addSource(SpirvSource *);
 
-  // Adds the given DebugOperation and DebugExpression instruction to
-  // debugOp and debugExpr, respectively.
+  // Adds the given DebugInfoNone, DebugOperation, and DebugExpression
+  // instruction to debugNone, debugOp, and debugExpr, respectively.
+  void addDebugInfo(SpirvDebugInfoNone *none) { debugNone = none; }
   void addDebugInfo(SpirvDebugOperation *);
   void addDebugInfo(SpirvDebugExpression *);
 
@@ -224,8 +225,7 @@ private:
   // be invalid because of forward references.
 
   // Keep DebugOperation and DebugExpression.
-  // TODO: Add DebugInfoNone to debugOp if exists (and change the name of
-  // debugOp).
+  SpirvDebugInfoNone *debugNone;
   std::vector<SpirvDebugOperation *> debugOp;
   std::vector<SpirvDebugExpression *> debugExpr;
 

--- a/tools/clang/include/clang/SPIRV/SpirvModule.h
+++ b/tools/clang/include/clang/SPIRV/SpirvModule.h
@@ -218,6 +218,7 @@ private:
   //    7.3. For each DebugLexicalBlock defined in this function
   //         7.3.1. DebugTypeXXX defined in block
   //         7.3.2. DebugLocalVariable defined in block
+  // 8. DebugTypeMember and DebugTypeInheritance
   //
   // If we do not follow this order, generated SPIR-V code would
   // be invalid because of forward references.

--- a/tools/clang/include/clang/SPIRV/SpirvType.h
+++ b/tools/clang/include/clang/SPIRV/SpirvType.h
@@ -296,7 +296,7 @@ public:
         : type(type_), name(name_), offset(offset_),
           matrixStride(matrixStride_), isRowMajor(isRowMajor_),
           isRelaxedPrecision(relaxedPrecision), isPrecise(precise),
-          size(llvm::None), decl(nullptr) {
+          size(llvm::None) {
       // A StructType may not contain any hybrid types.
       assert(!isa<HybridType>(type_));
     }
@@ -319,14 +319,11 @@ public:
     bool isPrecise;
     // The integer size in byte for this field.
     llvm::Optional<uint32_t> size;
-    // Used to get source, line, column debug information.
-    const FieldDecl *decl;
   };
 
   StructType(
       llvm::ArrayRef<FieldInfo> fields, llvm::StringRef name, bool isReadOnly,
-      StructInterfaceType interfaceType = StructInterfaceType::InternalStorage,
-      llvm::Optional<const RecordDecl *> decl = llvm::None);
+      StructInterfaceType interfaceType = StructInterfaceType::InternalStorage);
 
   static bool classof(const SpirvType *t) { return t->getKind() == TK_Struct; }
 
@@ -336,8 +333,6 @@ public:
   StructInterfaceType getInterfaceType() const { return interfaceType; }
 
   bool operator==(const StructType &that) const;
-
-  const RecordDecl *getDecl() const { return decl; }
 
 private:
   // Reflection is heavily used in graphics pipelines. Reflection relies on
@@ -351,9 +346,6 @@ private:
   // If this structure is a uniform buffer shader-interface, it will be
   // decorated with 'Block'.
   StructInterfaceType interfaceType;
-
-  // Used to get source, line, column debug information.
-  const RecordDecl *decl;
 };
 
 /// Represents a SPIR-V pointer type.
@@ -435,7 +427,7 @@ public:
               hlsl::ConstantPacking *packOffset = nullptr,
               const hlsl::RegisterAssignment *regC = nullptr,
               bool precise = false)
-        : astType(astType_), name(name_), decl(decl_), vkOffsetAttr(offset),
+        : astType(astType_), name(name_), vkOffsetAttr(offset),
           packOffsetAttr(packOffset), registerC(regC), isPrecise(precise) {}
 
     // The field's type.
@@ -450,8 +442,6 @@ public:
     const hlsl::RegisterAssignment *registerC;
     // Whether this field is marked as 'precise'.
     bool isPrecise;
-    // Used to get source, line, column debug information.
-    const FieldDecl *decl;
   };
 
   HybridStructType(

--- a/tools/clang/include/clang/SPIRV/SpirvType.h
+++ b/tools/clang/include/clang/SPIRV/SpirvType.h
@@ -23,7 +23,6 @@ namespace clang {
 namespace spirv {
 
 class HybridType;
-class SpirvDebugFunction;
 
 enum class StructInterfaceType : uint32_t {
   InternalStorage = 0,
@@ -338,13 +337,6 @@ public:
 
   bool operator==(const StructType &that) const;
 
-  void setMemberFunctionInfo(std::vector<const SpirvDebugFunction *> v) {
-    memberFnInfo = v;
-  }
-  std::vector<const SpirvDebugFunction *> &getMemberFunctionInfo() {
-    return memberFnInfo;
-  }
-
   const RecordDecl *getDecl() const { return decl; }
 
 private:
@@ -359,9 +351,6 @@ private:
   // If this structure is a uniform buffer shader-interface, it will be
   // decorated with 'Block'.
   StructInterfaceType interfaceType;
-
-  // A vector of member function info.
-  std::vector<const SpirvDebugFunction *> memberFnInfo;
 
   // Used to get source, line, column debug information.
   const RecordDecl *decl;

--- a/tools/clang/include/clang/SPIRV/SpirvVisitor.h
+++ b/tools/clang/include/clang/SPIRV/SpirvVisitor.h
@@ -113,6 +113,7 @@ public:
   DEFINE_VISIT_METHOD(SpirvVectorShuffle)
   DEFINE_VISIT_METHOD(SpirvArrayLength)
   DEFINE_VISIT_METHOD(SpirvRayTracingOpNV)
+  DEFINE_VISIT_METHOD(SpirvDebugInfoNone)
   DEFINE_VISIT_METHOD(SpirvDebugSource)
   DEFINE_VISIT_METHOD(SpirvDebugCompilationUnit)
   DEFINE_VISIT_METHOD(SpirvDebugFunction)

--- a/tools/clang/include/clang/SPIRV/SpirvVisitor.h
+++ b/tools/clang/include/clang/SPIRV/SpirvVisitor.h
@@ -123,6 +123,7 @@ public:
   DEFINE_VISIT_METHOD(SpirvDebugDeclare)
   DEFINE_VISIT_METHOD(SpirvDebugValue)
   DEFINE_VISIT_METHOD(SpirvDebugLexicalBlock)
+  DEFINE_VISIT_METHOD(SpirvDebugScope)
   DEFINE_VISIT_METHOD(SpirvDebugTypeBasic)
   DEFINE_VISIT_METHOD(SpirvDebugTypeArray)
   DEFINE_VISIT_METHOD(SpirvDebugTypeVector)

--- a/tools/clang/include/clang/SPIRV/SpirvVisitor.h
+++ b/tools/clang/include/clang/SPIRV/SpirvVisitor.h
@@ -130,6 +130,8 @@ public:
   DEFINE_VISIT_METHOD(SpirvDebugTypeFunction)
   DEFINE_VISIT_METHOD(SpirvDebugTypeComposite)
   DEFINE_VISIT_METHOD(SpirvDebugTypeMember)
+  DEFINE_VISIT_METHOD(SpirvDebugTypeTemplate)
+  DEFINE_VISIT_METHOD(SpirvDebugTypeTemplateParameter)
 
 #undef DEFINE_VISIT_METHOD
 

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -24,8 +24,18 @@ DebugTypeVisitor::lowerToDebugTypeComposite(const StructType *type) {
   // DebugTypeComposite is already lowered by LowerTypeVisitor,
   // but it is not completely lowered.
   // We have to update member information including offset and size.
-  auto *instr =
-      dyn_cast<SpirvDebugTypeComposite>(spvContext.getDebugTypeComposite(type));
+  auto *instr = dyn_cast<SpirvDebugTypeComposite>(spvContext.getDebugType(type));
+  SpirvDebugType *actualType = nullptr;
+  if (instr) {
+    auto *tempType = instr->getTypeTemplate();
+    if (tempType) {
+      auto &tempParams = tempType->getParams();
+      for (auto &t : tempParams) {
+        t->setActualType(dyn_cast<SpirvDebugType>(lowerToDebugType(t->getSpirvType())));
+      }
+    }
+  }
+  // TODO: else emit error!
   assert(instr && "StructType was not lowered by LowerTypeVisitor");
   if (instr->getFullyLowered())
     return instr;

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -24,14 +24,16 @@ DebugTypeVisitor::lowerToDebugTypeComposite(const StructType *type) {
   // DebugTypeComposite is already lowered by LowerTypeVisitor,
   // but it is not completely lowered.
   // We have to update member information including offset and size.
-  auto *instr = dyn_cast<SpirvDebugTypeComposite>(spvContext.getDebugType(type));
+  auto *instr =
+      dyn_cast<SpirvDebugTypeComposite>(spvContext.getDebugType(type));
   SpirvDebugType *actualType = nullptr;
   if (instr) {
     auto *tempType = instr->getTypeTemplate();
     if (tempType) {
       auto &tempParams = tempType->getParams();
       for (auto &t : tempParams) {
-        t->setActualType(dyn_cast<SpirvDebugType>(lowerToDebugType(t->getSpirvType())));
+        t->setActualType(
+            dyn_cast<SpirvDebugType>(lowerToDebugType(t->getSpirvType())));
       }
     }
   }

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -247,7 +247,7 @@ bool DebugTypeVisitor::visit(SpirvModule *module, Phase phase) {
     for (const auto typePair : spvContext.getDebugTypes()) {
       module->addDebugInfo(typePair.second);
     }
-    for (auto *type : spvContext.getMemberTypes()) {
+    for (auto *type : spvContext.getTailDebugTypes()) {
       module->addDebugInfo(type);
     }
   }

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -172,6 +172,18 @@ DebugTypeVisitor::lowerToDebugType(const SpirvType *spirvType) {
                                              vecType->getElementCount());
     break;
   }
+  case SpirvType::TK_Matrix: {
+    // TODO: I temporarily use a DebugTypeArray for a matrix type.
+    // However, when the debug info extension supports matrix type
+    // e.g., DebugTypeMatrix, we must replace DebugTypeArray with
+    // DebugTypeMatrix.
+    auto *matType = dyn_cast<MatrixType>(spirvType);
+    SpirvDebugInstruction *elemDebugType =
+        lowerToDebugType(matType->getElementType());
+    debugType = spvContext.getDebugTypeArray(
+        spirvType, elemDebugType, {matType->numRows(), matType->numCols()});
+    break;
+  }
   case SpirvType::TK_Pointer: {
     debugType = lowerToDebugType(
         dyn_cast<SpirvPointerType>(spirvType)->getPointeeType());

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -152,8 +152,16 @@ DebugTypeVisitor::lowerToDebugType(const SpirvType *spirvType) {
     auto *arrType = dyn_cast<ArrayType>(spirvType);
     SpirvDebugInstruction *elemDebugType =
         lowerToDebugType(arrType->getElementType());
-    debugType = spvContext.getDebugTypeArray(spirvType, elemDebugType,
-                                             {arrType->getElementCount()});
+    if (auto *dbgArrType = dyn_cast<SpirvDebugTypeArray>(elemDebugType)) {
+      auto &counts = dbgArrType->getElementCount();
+      // Note that this is reverse order of dimension. We must iterate the
+      // count array in a reverse order when we actually emit it.
+      counts.push_back(arrType->getElementCount());
+      debugType = dbgArrType;
+    } else {
+      debugType = spvContext.getDebugTypeArray(spirvType, elemDebugType,
+                                               {arrType->getElementCount()});
+    }
     break;
   }
   case SpirvType::TK_Vector: {

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -300,7 +300,14 @@ bool DebugTypeVisitor::visitInstruction(SpirvInstruction *instr) {
       const SpirvType *spirvType = debugInstr->getDebugSpirvType();
       if (spirvType) {
         SpirvDebugInstruction *debugType = lowerToDebugType(spirvType);
-        debugInstr->setDebugType(debugType);
+        if (auto *var = dyn_cast<SpirvDebugGlobalVariable>(debugInstr)) {
+          var->setDebugType(debugType);
+        } else if (auto *var = dyn_cast<SpirvDebugLocalVariable>(debugInstr)) {
+          var->setDebugType(debugType);
+        } else {
+          llvm_unreachable("Debug instruction must be DebugGlobalVariable or "
+                           "DebugLocalVariable");
+        }
       }
     }
     if (auto *debugFunction = dyn_cast<SpirvDebugFunction>(debugInstr)) {
@@ -308,7 +315,7 @@ bool DebugTypeVisitor::visitInstruction(SpirvInstruction *instr) {
           debugFunction->getSpirvFunction()->getFunctionType();
       if (spirvType) {
         SpirvDebugInstruction *debugType = lowerToDebugType(spirvType);
-        debugInstr->setDebugType(debugType);
+        debugFunction->setDebugType(debugType);
       }
     }
   }

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -34,6 +34,8 @@ DebugTypeVisitor::lowerToDebugTypeComposite(const StructType *type) {
       for (auto &t : tempParams) {
         t->setActualType(
             dyn_cast<SpirvDebugType>(lowerToDebugType(t->getSpirvType())));
+        if (!t->getValue())
+          t->setValue(spvBuilder.getOrCreateDebugInfoNone());
       }
     }
   }

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -247,13 +247,16 @@ DebugTypeVisitor::lowerToDebugType(const SpirvType *spirvType) {
     auto *fnType = dyn_cast<FunctionType>(spirvType);
     // Special case: There is no DebugType for void. So if the function return
     // type is void, we set it to nullptr.
-    SpirvDebugInstruction *returnType =
-        isa<VoidType>(fnType->getReturnType())
-            ? nullptr
-            : lowerToDebugType(fnType->getReturnType());
-    llvm::SmallVector<SpirvDebugInstruction *, 4> params;
-    for (const auto *paramType : fnType->getParamTypes())
-      params.push_back(lowerToDebugType(paramType));
+    SpirvDebugType *returnType = nullptr;
+    if (!isa<VoidType>(fnType->getReturnType())) {
+      auto *loweredRetTy = lowerToDebugType(fnType->getReturnType());
+      returnType = dyn_cast<SpirvDebugType>(loweredRetTy);
+      assert(returnType && "Function return type info must be SpirvDebugType");
+    }
+    llvm::SmallVector<SpirvDebugType *, 4> params;
+    for (const auto *paramType : fnType->getParamTypes()) {
+      params.push_back(dyn_cast<SpirvDebugType>(lowerToDebugType(paramType)));
+    }
     // TODO: Add mechanism to properly calculate the flags.
     // The info needed probably resides in clang::FunctionDecl.
     // This info can either be stored in the SpirvFunction class. Or,

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.h
@@ -61,6 +61,11 @@ private:
 
   SpirvDebugInstruction *lowerToDebugTypeComposite(const StructType *);
 
+  // Set the result type of debug instructions to OpTypeVoid.
+  // According to the OpenCL.DebugInfo.100 spec, all debug instructions are
+  // OpExtInst with result type of void.
+  void setDefaultDebugInfo(SpirvDebugInstruction *instr);
+
 private:
   ASTContext &astContext;   /// AST context
   SpirvContext &spvContext; /// SPIR-V context

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.h
@@ -42,6 +42,11 @@ public:
   /// regardless of their polymorphism.
   bool visitInstruction(SpirvInstruction *);
 
+  /// We need special handling for DebugTypeComposite because it is
+  /// lowered by LowerTypeVisitor and it is not completely lowered.
+  /// We have to update member information including offsets and sizes.
+  bool visitInstruction(SpirvDebugTypeComposite *instr);
+
 private:
   /// Emits error to the diagnostic engine associated with this visitor.
   template <unsigned N>

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.h
@@ -42,11 +42,6 @@ public:
   /// regardless of their polymorphism.
   bool visitInstruction(SpirvInstruction *);
 
-  /// We need special handling for DebugTypeComposite because it is
-  /// lowered by LowerTypeVisitor and it is not completely lowered.
-  /// We have to update member information including offsets and sizes.
-  bool visitInstruction(SpirvDebugTypeComposite *instr);
-
 private:
   /// Emits error to the diagnostic engine associated with this visitor.
   template <unsigned N>
@@ -64,7 +59,6 @@ private:
   /// depends on will also be created.
   SpirvDebugInstruction *lowerToDebugType(const SpirvType *);
 
-  SpirvDebugInstruction *lowerToDebugTypeEnum(const StructType *);
   SpirvDebugInstruction *lowerToDebugTypeComposite(const StructType *);
 
 private:

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.h
@@ -59,6 +59,9 @@ private:
   /// depends on will also be created.
   SpirvDebugInstruction *lowerToDebugType(const SpirvType *);
 
+  SpirvDebugInstruction *lowerToDebugTypeEnum(const StructType *);
+  SpirvDebugInstruction *lowerToDebugTypeComposite(const StructType *);
+
 private:
   ASTContext &astContext;   /// AST context
   SpirvContext &spvContext; /// SPIR-V context

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -636,14 +636,15 @@ DeclResultIdMapper::createFnVar(const VarDecl *var,
 
   if (spirvOptions.debugInfoRich) {
     // Add DebugLocalVariable information
-    uint32_t line = astContext.getSourceManager().getPresumedLineNumber(loc);
-    uint32_t column =
-        astContext.getSourceManager().getPresumedColumnNumber(loc);
+    const auto &sm = astContext.getSourceManager();
+    const uint32_t line = sm.getPresumedLineNumber(loc);
+    const uint32_t column = sm.getPresumedColumnNumber(loc);
+    const auto &info =
+        theEmitter.getRichDebugInfo()[sm.getPresumedLoc(loc).getFilename()];
     // TODO: replace this with FlagIsLocal enum.
     uint32_t flags = 1 << 2;
     auto *debugLocalVar = spvBuilder.createDebugLocalVariable(
-        type, name, theEmitter.getRichDebugInfo().source, line, column,
-        theEmitter.getRichDebugInfo().scopeStack.back(), flags);
+        type, name, info.source, line, column, info.scopeStack.back(), flags);
   }
 
   return varInstr;

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -614,8 +614,7 @@ DeclResultIdMapper::createFnParam(const ParmVarDecl *param) {
     auto *debugLocalVar = spvBuilder.createDebugLocalVariable(
         type, name, info->source, line, column, info->scopeStack.back(), flags,
         param->getFunctionScopeIndex());
-
-    // TODO: Add DebugDeclare
+    spvBuilder.createDebugDeclare(debugLocalVar, fnParamInstr);
   }
 
   return fnParamInstr;
@@ -660,8 +659,7 @@ DeclResultIdMapper::createFnVar(const VarDecl *var,
     uint32_t flags = 1 << 2;
     auto *debugLocalVar = spvBuilder.createDebugLocalVariable(
         type, name, info->source, line, column, info->scopeStack.back(), flags);
-
-    // TODO: Add DebugDeclare
+    spvBuilder.createDebugDeclare(debugLocalVar, varInstr);
   }
 
   return varInstr;

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -800,7 +800,7 @@ SpirvVariable *DeclResultIdMapper::createStructOrStructArrayVarOfExplicitLayout(
     // We don't need it here.
     auto varType = declDecl->getType();
     varType.removeLocalConst();
-    HybridStructType::FieldInfo info(varType, declDecl->getName(),
+    HybridStructType::FieldInfo info(varType, declDecl->getName(), nullptr,
                                      declDecl->getAttr<VKOffsetAttr>(),
                                      getPackOffset(declDecl), registerC,
                                      declDecl->hasAttr<HLSLPreciseAttr>());

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -682,6 +682,11 @@ private:
   /// Returns true if the given SPIR-V stage variable has Input storage class.
   inline bool isInputStorageClass(const StageVar &v);
 
+  /// If rich debug info gen is enabled, emit DebugGlobalVariable.
+  void createDebugGlobalVariable(SpirvVariable *var, const QualType &type,
+                                 const SourceLocation &loc,
+                                 const StringRef &name);
+
 private:
   SpirvBuilder &spvBuilder;
   SpirvEmitter &theEmitter;

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1133,8 +1133,7 @@ bool EmitVisitor::visit(SpirvDebugFunction *inst) {
   curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getSource()));
   curInst.push_back(inst->getLine());
   curInst.push_back(inst->getColumn());
-  curInst.push_back(
-      getOrAssignResultId<SpirvInstruction>(inst->getParentScope()));
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getParent()));
   curInst.push_back(linkageNameId);
   curInst.push_back(inst->getFlags());
   curInst.push_back(inst->getScopeLine());
@@ -1209,8 +1208,7 @@ bool EmitVisitor::visit(SpirvDebugLocalVariable *inst) {
   curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getSource()));
   curInst.push_back(inst->getLine());
   curInst.push_back(inst->getColumn());
-  curInst.push_back(
-      getOrAssignResultId<SpirvInstruction>(inst->getParentScope()));
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getParent()));
   curInst.push_back(inst->getFlags());
   if (inst->getArgNumber().hasValue())
     curInst.push_back(inst->getArgNumber().getValue());

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1118,6 +1118,18 @@ bool EmitVisitor::visit(SpirvDebugLexicalBlock *inst) {
   return true;
 }
 
+bool EmitVisitor::visit(SpirvDebugScope *inst) {
+  initInstruction(inst);
+  curInst.push_back(inst->getResultTypeId());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getInstructionSet()));
+  curInst.push_back(inst->getDebugOpcode());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getScope()));
+  finalizeInstruction(&mainBinary);
+  return true;
+}
+
 bool EmitVisitor::visit(SpirvDebugFunction *inst) {
   uint32_t nameId = getOrCreateOpString(inst->getDebugName());
   uint32_t linkageNameId = getOrCreateOpString(inst->getLinkageName());

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1217,6 +1217,35 @@ bool EmitVisitor::visit(SpirvDebugLocalVariable *inst) {
   return true;
 }
 
+bool EmitVisitor::visit(SpirvDebugDeclare *inst) {
+  initInstruction(inst);
+  curInst.push_back(inst->getResultTypeId());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getInstructionSet()));
+  curInst.push_back(inst->getDebugOpcode());
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getDebugLocalVariable()));
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getVariable()));
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getDebugExpression()));
+  finalizeInstruction(&mainBinary);
+  return true;
+}
+
+bool EmitVisitor::visit(SpirvDebugExpression *inst) {
+  initInstruction(inst);
+  curInst.push_back(inst->getResultTypeId());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getInstructionSet()));
+  curInst.push_back(inst->getDebugOpcode());
+  for (const auto &op : inst->getOperations())
+    curInst.push_back(getOrAssignResultId<SpirvInstruction>(op));
+  finalizeInstruction(&richDebugInfo);
+  return true;
+}
+
 // EmitTypeHandler ------
 
 void EmitTypeHandler::initTypeInstruction(spv::Op op) {

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1069,6 +1069,17 @@ bool EmitVisitor::visit(SpirvRayTracingOpNV *inst) {
   return true;
 }
 
+bool EmitVisitor::visit(SpirvDebugInfoNone *inst) {
+  initInstruction(inst);
+  curInst.push_back(inst->getResultTypeId());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getInstructionSet()));
+  curInst.push_back(inst->getDebugOpcode());
+  finalizeInstruction(&richDebugInfo);
+  return true;
+}
+
 bool EmitVisitor::visit(SpirvDebugSource *inst) {
   uint32_t fileId = getOrCreateOpString(inst->getFile());
   uint32_t textId = 0;
@@ -1257,6 +1268,40 @@ bool EmitVisitor::visit(SpirvDebugTypeMember *inst) {
   curInst.push_back(offset);
   curInst.push_back(size);
   curInst.push_back(inst->getDebugFlags());
+  finalizeInstruction(&richDebugInfo);
+  return true;
+}
+
+bool EmitVisitor::visit(SpirvDebugTypeTemplate *inst) {
+  initInstruction(inst);
+  curInst.push_back(inst->getResultTypeId());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getInstructionSet()));
+  curInst.push_back(inst->getDebugOpcode());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getTarget()));
+  for (auto *param : inst->getParams()) {
+    curInst.push_back(getOrAssignResultId<SpirvInstruction>(param));
+  }
+  finalizeInstruction(&richDebugInfo);
+  return true;
+}
+
+bool EmitVisitor::visit(SpirvDebugTypeTemplateParameter *inst) {
+  uint32_t typeNameId = getOrCreateOpString(inst->getDebugName());
+  initInstruction(inst);
+  curInst.push_back(inst->getResultTypeId());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getInstructionSet()));
+  curInst.push_back(inst->getDebugOpcode());
+  curInst.push_back(typeNameId);
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getActualType()));
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getValue()));
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getSource()));
+  curInst.push_back(inst->getLine());
+  curInst.push_back(inst->getColumn());
   finalizeInstruction(&richDebugInfo);
   return true;
 }

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1257,11 +1257,6 @@ bool EmitVisitor::visit(SpirvDebugTypeMember *inst) {
   curInst.push_back(offset);
   curInst.push_back(size);
   curInst.push_back(inst->getDebugFlags());
-  /*
-  if (auto *val = inst->getValue()) {
-    curInst.push_back(getOrAssignResultId<SpirvInstruction>(val));
-  }
-  */
   finalizeInstruction(&richDebugInfo);
   return true;
 }

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1257,9 +1257,11 @@ bool EmitVisitor::visit(SpirvDebugTypeMember *inst) {
   curInst.push_back(offset);
   curInst.push_back(size);
   curInst.push_back(inst->getDebugFlags());
+  /*
   if (auto *val = inst->getValue()) {
     curInst.push_back(getOrAssignResultId<SpirvInstruction>(val));
   }
+  */
   finalizeInstruction(&richDebugInfo);
   return true;
 }

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1167,7 +1167,7 @@ bool EmitVisitor::visit(SpirvDebugFunction *inst) {
 }
 
 bool EmitVisitor::visit(SpirvDebugTypeBasic *inst) {
-  uint32_t typeNameId = getOrCreateOpString(inst->getName());
+  uint32_t typeNameId = getOrCreateOpString(inst->getDebugName());
   initInstruction(inst);
   curInst.push_back(inst->getResultTypeId());
   curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
@@ -1238,7 +1238,7 @@ bool EmitVisitor::visit(SpirvDebugTypeFunction *inst) {
 }
 
 bool EmitVisitor::visit(SpirvDebugTypeComposite *inst) {
-  uint32_t typeNameId = getOrCreateOpString(inst->getName());
+  uint32_t typeNameId = getOrCreateOpString(inst->getDebugName());
   uint32_t linkageNameId = getOrCreateOpString(inst->getLinkageName());
   const auto size = typeHandler.getOrCreateConstantInt(
       llvm::APInt(32, inst->getSizeInBits()), context.getUIntType(32),
@@ -1266,7 +1266,7 @@ bool EmitVisitor::visit(SpirvDebugTypeComposite *inst) {
 }
 
 bool EmitVisitor::visit(SpirvDebugTypeMember *inst) {
-  uint32_t typeNameId = getOrCreateOpString(inst->getName());
+  uint32_t typeNameId = getOrCreateOpString(inst->getDebugName());
   const auto offset = typeHandler.getOrCreateConstantInt(
       llvm::APInt(32, inst->getOffset()), context.getUIntType(32),
       /* isSpecConst */ false);

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1300,6 +1300,33 @@ bool EmitVisitor::visit(SpirvDebugDeclare *inst) {
   return true;
 }
 
+bool EmitVisitor::visit(SpirvDebugGlobalVariable *inst) {
+  uint32_t nameId = getOrCreateOpString(inst->getDebugName());
+  uint32_t linkageNameId = getOrCreateOpString(inst->getLinkageName());
+  initInstruction(inst);
+  curInst.push_back(inst->getResultTypeId());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getInstructionSet()));
+  curInst.push_back(inst->getDebugOpcode());
+  curInst.push_back(nameId);
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getDebugType()));
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getSource()));
+  curInst.push_back(inst->getLine());
+  curInst.push_back(inst->getColumn());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getParent()));
+  curInst.push_back(linkageNameId);
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getVariable()));
+  curInst.push_back(inst->getFlags());
+  if (inst->getStaticMemberDebugDecl().hasValue())
+    curInst.push_back(getOrAssignResultId<SpirvInstruction>(
+        inst->getStaticMemberDebugDecl().getValue()));
+
+  finalizeInstruction(&richDebugInfo);
+  return true;
+}
+
 bool EmitVisitor::visit(SpirvDebugExpression *inst) {
   initInstruction(inst);
   curInst.push_back(inst->getResultTypeId());

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1195,6 +1195,26 @@ bool EmitVisitor::visit(SpirvDebugTypeVector *inst) {
   return true;
 }
 
+bool EmitVisitor::visit(SpirvDebugTypeArray *inst) {
+  initInstruction(inst);
+  curInst.push_back(inst->getResultTypeId());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getInstructionSet()));
+  curInst.push_back(inst->getDebugOpcode());
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getElementType()));
+  for (auto it = inst->getElementCount().rbegin();
+       it != inst->getElementCount().rend(); ++it) {
+    const auto countId = typeHandler.getOrCreateConstantInt(
+        llvm::APInt(32, *it), context.getUIntType(32),
+        /* isSpecConst */ false);
+    curInst.push_back(countId);
+  }
+  finalizeInstruction(&richDebugInfo);
+  return true;
+}
+
 bool EmitVisitor::visit(SpirvDebugTypeFunction *inst) {
   initInstruction(inst);
   curInst.push_back(inst->getResultTypeId());

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1206,6 +1206,64 @@ bool EmitVisitor::visit(SpirvDebugTypeFunction *inst) {
   return true;
 }
 
+bool EmitVisitor::visit(SpirvDebugTypeComposite *inst) {
+  uint32_t typeNameId = getOrCreateOpString(inst->getName());
+  uint32_t linkageNameId = getOrCreateOpString(inst->getLinkageName());
+  const auto size = typeHandler.getOrCreateConstantInt(
+      llvm::APInt(32, inst->getSizeInBits()), context.getUIntType(32),
+      /* isSpecConst */ false);
+  initInstruction(inst);
+  curInst.push_back(inst->getResultTypeId());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getInstructionSet()));
+  curInst.push_back(inst->getDebugOpcode());
+  curInst.push_back(typeNameId);
+  curInst.push_back(inst->getTag());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getSource()));
+  curInst.push_back(inst->getLine());
+  curInst.push_back(inst->getColumn());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getParent()));
+  curInst.push_back(linkageNameId);
+  curInst.push_back(size);
+  curInst.push_back(inst->getDebugFlags());
+  for (auto *member : inst->getMembers()) {
+    curInst.push_back(getOrAssignResultId<SpirvInstruction>(member));
+  }
+  finalizeInstruction(&richDebugInfo);
+  return true;
+}
+
+bool EmitVisitor::visit(SpirvDebugTypeMember *inst) {
+  uint32_t typeNameId = getOrCreateOpString(inst->getName());
+  const auto offset = typeHandler.getOrCreateConstantInt(
+      llvm::APInt(32, inst->getOffset()), context.getUIntType(32),
+      /* isSpecConst */ false);
+  const auto size = typeHandler.getOrCreateConstantInt(
+      llvm::APInt(32, inst->getSizeInBits()), context.getUIntType(32),
+      /* isSpecConst */ false);
+  initInstruction(inst);
+  curInst.push_back(inst->getResultTypeId());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getInstructionSet()));
+  curInst.push_back(inst->getDebugOpcode());
+  curInst.push_back(typeNameId);
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getType()));
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getSource()));
+  curInst.push_back(inst->getLine());
+  curInst.push_back(inst->getColumn());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getParent()));
+  curInst.push_back(offset);
+  curInst.push_back(size);
+  curInst.push_back(inst->getDebugFlags());
+  if (auto *val = inst->getValue()) {
+    curInst.push_back(getOrAssignResultId<SpirvInstruction>(val));
+  }
+  finalizeInstruction(&richDebugInfo);
+  return true;
+}
+
 bool EmitVisitor::visit(SpirvDebugLocalVariable *inst) {
   uint32_t nameId = getOrCreateOpString(inst->getDebugName());
   initInstruction(inst);

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -262,6 +262,7 @@ public:
   bool visit(SpirvDebugFunction *);
   bool visit(SpirvDebugLocalVariable *);
   bool visit(SpirvDebugDeclare *);
+  bool visit(SpirvDebugGlobalVariable *);
   bool visit(SpirvDebugExpression *);
   bool visit(SpirvDebugTypeBasic *);
   bool visit(SpirvDebugTypeVector *);

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -260,6 +260,8 @@ public:
   bool visit(SpirvDebugLexicalBlock *);
   bool visit(SpirvDebugFunction *);
   bool visit(SpirvDebugLocalVariable *);
+  bool visit(SpirvDebugDeclare *);
+  bool visit(SpirvDebugExpression *);
   bool visit(SpirvDebugTypeBasic *);
   bool visit(SpirvDebugTypeVector *);
   bool visit(SpirvDebugTypeFunction *);

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -282,6 +282,10 @@ private:
     return obj->getResultId();
   }
 
+  /// If we already created OpString for str, just return the created one.
+  /// Otherwise, create it, keep it in debugFileIdMap, and return it.
+  uint32_t getOrCreateOpString(llvm::StringRef str);
+
   // Emits an OpLine instruction for the given operation into the given binary
   // section.
   void emitDebugLine(spv::Op op, const SourceLocation &loc,

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -258,6 +258,7 @@ public:
   bool visit(SpirvDebugSource *);
   bool visit(SpirvDebugCompilationUnit *);
   bool visit(SpirvDebugLexicalBlock *);
+  bool visit(SpirvDebugScope *);
   bool visit(SpirvDebugFunction *);
   bool visit(SpirvDebugLocalVariable *);
   bool visit(SpirvDebugDeclare *);

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -267,6 +267,7 @@ public:
   bool visit(SpirvDebugExpression *);
   bool visit(SpirvDebugTypeBasic *);
   bool visit(SpirvDebugTypeVector *);
+  bool visit(SpirvDebugTypeArray *);
   bool visit(SpirvDebugTypeFunction *);
   bool visit(SpirvDebugTypeComposite *);
   bool visit(SpirvDebugTypeMember *);

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -255,6 +255,7 @@ public:
   bool visit(SpirvVectorShuffle *);
   bool visit(SpirvArrayLength *);
   bool visit(SpirvRayTracingOpNV *);
+  bool visit(SpirvDebugInfoNone *);
   bool visit(SpirvDebugSource *);
   bool visit(SpirvDebugCompilationUnit *);
   bool visit(SpirvDebugLexicalBlock *);
@@ -269,6 +270,8 @@ public:
   bool visit(SpirvDebugTypeFunction *);
   bool visit(SpirvDebugTypeComposite *);
   bool visit(SpirvDebugTypeMember *);
+  bool visit(SpirvDebugTypeTemplate *);
+  bool visit(SpirvDebugTypeTemplateParameter *);
 
   // Returns the assembled binary built up in this visitor.
   std::vector<uint32_t> takeBinary();

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -266,6 +266,8 @@ public:
   bool visit(SpirvDebugTypeBasic *);
   bool visit(SpirvDebugTypeVector *);
   bool visit(SpirvDebugTypeFunction *);
+  bool visit(SpirvDebugTypeComposite *);
+  bool visit(SpirvDebugTypeMember *);
 
   // Returns the assembled binary built up in this visitor.
   std::vector<uint32_t> takeBinary();

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -13,6 +13,7 @@
 #include "clang/AST/HlslTypes.h"
 #include "clang/SPIRV/AstTypeProbe.h"
 #include "clang/SPIRV/SpirvFunction.h"
+#include "clang/SPIRV/SpirvModule.h"
 
 namespace {
 /// Returns the :packoffset() annotation on the given decl. Returns nullptr if
@@ -34,6 +35,19 @@ inline uint32_t roundToPow2(uint32_t val, uint32_t pow2) {
 
 namespace clang {
 namespace spirv {
+
+bool LowerTypeVisitor::visit(SpirvModule *module, Phase phase) {
+  if (phase == Phase::Done) {
+    // When the processing for all types is done, we need to take all the
+    // debug composite types in the context and add their SPIR-V instructions
+    // to the SPIR-V module.
+    for (auto typePair : debugTypeComposite) {
+      module->addDebugInfo(typePair.second);
+    }
+  }
+
+  return true;
+}
 
 bool LowerTypeVisitor::visit(SpirvFunction *fn, Phase phase) {
   if (phase == Visitor::Phase::Init) {
@@ -377,8 +391,15 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
     // (ClassTemplateSpecializationDecl is a subclass of CXXRecordDecl, which
     // is then a subclass of RecordDecl.) So we need to check them before
     // checking the general struct type.
-    if (const auto *spvType = lowerResourceType(type, rule, srcLoc))
+    if (const auto *spvType = lowerResourceType(type, rule, srcLoc)) {
+      if (debugExtInstSet &&
+          debugTypeComposite.find(decl) == debugTypeComposite.end()) {
+        llvm::SmallVector<StructType::FieldInfo, 4> fields;
+        debugTypeComposite[decl] =
+            lowerDebugTypeComposite(structType, spvType, fields, true);
+      }
       return spvType;
+    }
 
     // Collect all fields' information.
     llvm::SmallVector<HybridStructType::FieldInfo, 8> fields;
@@ -404,8 +425,15 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
 
     auto loweredFields = populateLayoutInformation(fields, rule);
 
-    return spvContext.getStructType(loweredFields, decl->getName(), false,
-                                    StructInterfaceType::InternalStorage, decl);
+    const auto *spvType =
+        spvContext.getStructType(loweredFields, decl->getName(), false,
+                                 StructInterfaceType::InternalStorage, decl);
+    if (debugExtInstSet &&
+        debugTypeComposite.find(decl) == debugTypeComposite.end()) {
+      debugTypeComposite[decl] =
+          lowerDebugTypeComposite(structType, spvType, loweredFields, false);
+    }
+    return spvType;
   }
 
   // Array type
@@ -856,6 +884,118 @@ LowerTypeVisitor::populateLayoutInformation(
   }
 
   return result;
+}
+
+SpirvDebugTypeComposite *LowerTypeVisitor::lowerDebugTypeComposite(
+    const RecordType *structType, const SpirvType *type,
+    llvm::SmallVector<StructType::FieldInfo, 4> &fields, bool isResourceType) {
+  const auto *decl = structType->getDecl();
+  const SourceLocation &loc = decl->getLocStart();
+  const auto &sm = astContext.getSourceManager();
+  StringRef file = sm.getPresumedLoc(loc).getFilename();
+  uint32_t line = sm.getPresumedLineNumber(loc);
+  uint32_t column = sm.getPresumedColumnNumber(loc);
+  StringRef linkageName = type->getName();
+
+  // TODO: Update linkageName using astContext.createMangleContext().
+  //
+  // Currently, the following code fails because it is not a
+  // FunctionDecl nor VarDecl. I guess we should mangle a RecordDecl
+  // as well.
+  //
+  // std::string s;
+  // llvm::raw_string_ostream stream(s);
+  // mangleCtx->mangleName(decl, stream);
+
+  uint32_t tag = 1;
+  if (decl->isStruct())
+    tag = 1;
+  else if (decl->isClass())
+    tag = 0;
+  else if (decl->isUnion())
+    tag = 2;
+  else
+    assert(!"DebugTypeComposite must be a struct, class, or union.");
+
+  bool isPrivate = decl->isModulePrivate();
+
+  std::string name = type->getName();
+  if (isResourceType)
+    name = "@" + name;
+
+  // TODO: Update parent, size, and flags information correctly.
+  auto &debugInfo = spvContext.getDebugInfo()[file];
+  auto *dbgTyComposite =
+      dyn_cast<SpirvDebugTypeComposite>(spvContext.getDebugTypeComposite(
+          type, name, debugInfo.source, line, column,
+          /* parent */ debugInfo.compilationUnit, linkageName,
+          /* size */ 0,
+          /* flags */ isPrivate ? 2u : 3u, tag));
+
+  dbgTyComposite->setAstResultType(astContext.VoidTy);
+  dbgTyComposite->setResultType(spvContext.getVoidType());
+  dbgTyComposite->setInstructionSet(debugExtInstSet);
+
+  if (isResourceType)
+    return dbgTyComposite;
+
+  // If we already visited this composite type and its members,
+  // we should skip it.
+  auto &members = dbgTyComposite->getMembers();
+  if (!members.empty())
+    return dbgTyComposite;
+
+  uint32_t fieldIdx = 0;
+  for (auto &memberDecl : decl->decls()) {
+    if (const auto *cxxMethodDecl = dyn_cast<CXXMethodDecl>(memberDecl)) {
+      auto *fn = spvContext.findFunctionInfo(cxxMethodDecl);
+      assert(fn && "DebugFunction for method does not exist");
+      members.push_back(fn);
+      continue;
+    }
+
+    // Skip "this" object.
+    if (isa<CXXRecordDecl>(memberDecl)) {
+      ++fieldIdx;
+      continue;
+    }
+
+    assert(isa<FieldDecl>(memberDecl) &&
+           "Decl of member must be CXXMethodDecl, CXXRecordDecl, or FieldDecl");
+
+    const SourceLocation &fieldLoc = memberDecl->getLocStart();
+    const StringRef fieldFile = sm.getPresumedLoc(fieldLoc).getFilename();
+    const uint32_t fieldLine = sm.getPresumedLineNumber(fieldLoc);
+    const uint32_t fieldColumn = sm.getPresumedColumnNumber(fieldLoc);
+
+    const APValue *value = nullptr;
+    if (const auto *varDecl = dyn_cast<VarDecl>(memberDecl)) {
+      if (const auto *val = varDecl->evaluateValue()) {
+        value = val;
+      }
+    }
+
+    uint32_t offset = UINT32_MAX;
+    if (fields[fieldIdx].offset.hasValue())
+      offset = *fields[fieldIdx].offset;
+
+    // TODO: Replace 2u and 3u with valid flags when debug info extension is
+    // placed in SPIRV-Header.
+    auto *debugInstr =
+        dyn_cast<SpirvDebugInstruction>(spvContext.getDebugTypeMember(
+            dyn_cast<FieldDecl>(memberDecl)->getName(), fields[fieldIdx].type,
+            spvContext.getDebugInfo()[fieldFile].source, fieldLine, fieldColumn,
+            dbgTyComposite, memberDecl->isModulePrivate() ? 2u : 3u, offset,
+            value));
+    assert(debugInstr && "We expect SpirvDebugInstruction for DebugTypeMember");
+    debugInstr->setAstResultType(astContext.VoidTy);
+    debugInstr->setResultType(spvContext.getVoidType());
+    debugInstr->setInstructionSet(debugExtInstSet);
+    members.push_back(debugInstr);
+
+    ++fieldIdx;
+  }
+  return dbgTyComposite;
 }
 
 } // namespace spirv

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -421,7 +421,8 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
           auto *tempInfo =
               dyn_cast<SpirvDebugTypeTemplate>(spvContext.getDebugTypeTemplate(
                   spvTypeAndUnderlyingType.first, dbgType));
-          tempInfo->getParams().push_back(dyn_cast<SpirvDebugTypeTemplateParameter>(param));
+          tempInfo->getParams().push_back(
+              dyn_cast<SpirvDebugTypeTemplateParameter>(param));
         }
       }
       return spvTypeAndUnderlyingType.first;

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -999,6 +999,7 @@ SpirvDebugTypeComposite *LowerTypeVisitor::lowerDebugTypeComposite(
     if (const auto *cxxMethodDecl = dyn_cast<CXXMethodDecl>(memberDecl)) {
       auto *fn = spvContext.findFunctionInfo(cxxMethodDecl);
       assert(fn && "DebugFunction for method does not exist");
+      fn->setParent(dbgTyComposite);
       members.push_back(fn);
       continue;
     }

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -29,7 +29,7 @@ public:
         alignmentCalc(astCtx, opts), debugExtInstSet(debugExt) {}
 
   // Visiting different SPIR-V constructs.
-  bool visit(SpirvModule *, Phase);
+  bool visit(SpirvModule *, Phase) { return true; }
   bool visit(SpirvFunction *, Phase);
   bool visit(SpirvBasicBlock *, Phase) { return true; }
 

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -64,8 +64,10 @@ private:
                              SourceLocation);
 
   /// Lowers the given HLSL resource type into its SPIR-V type.
-  const SpirvType *lowerResourceType(QualType type, SpirvLayoutRule rule,
-                                     SourceLocation);
+  ///
+  /// Returns the lowered SpirvType and its underlying SpirvType.
+  std::pair<const SpirvType *, const SpirvType *>
+  lowerResourceType(QualType type, SpirvLayoutRule rule, SourceLocation);
 
   /// For the given sampled type, returns the corresponding image format
   /// that can be used to create an image object.
@@ -93,7 +95,9 @@ private:
 
   SpirvExtInstImport *debugExtInstSet; /// Pointer to
                                        /// OpenCLDebugInfoExtInstSet
-  llvm::DenseMap<const Decl *, SpirvDebugTypeComposite *> debugTypeComposite;
+
+  llvm::SmallSet<const Decl *, 4> visitedRecordDecl; /// A set of already
+                                                     /// visited RecordDecl
 };
 
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -23,12 +23,13 @@ namespace spirv {
 class LowerTypeVisitor : public Visitor {
 public:
   LowerTypeVisitor(ASTContext &astCtx, SpirvContext &spvCtx,
-                   const SpirvCodeGenOptions &opts)
+                   const SpirvCodeGenOptions &opts,
+                   SpirvExtInstImport *debugExt)
       : Visitor(opts, spvCtx), astContext(astCtx), spvContext(spvCtx),
-        alignmentCalc(astCtx, opts) {}
+        alignmentCalc(astCtx, opts), debugExtInstSet(debugExt) {}
 
   // Visiting different SPIR-V constructs.
-  bool visit(SpirvModule *, Phase) { return true; }
+  bool visit(SpirvModule *, Phase);
   bool visit(SpirvFunction *, Phase);
   bool visit(SpirvBasicBlock *, Phase) { return true; }
 
@@ -80,10 +81,19 @@ private:
   populateLayoutInformation(llvm::ArrayRef<HybridStructType::FieldInfo> fields,
                             SpirvLayoutRule rule);
 
+  /// Generate rich debug info for composite type.
+  SpirvDebugTypeComposite *lowerDebugTypeComposite(
+      const RecordType *structType, const SpirvType *spirvType,
+      llvm::SmallVector<StructType::FieldInfo, 4> &fields, bool isResourceType);
+
 private:
   ASTContext &astContext;                /// AST context
   SpirvContext &spvContext;              /// SPIR-V context
   AlignmentSizeCalculator alignmentCalc; /// alignment calculator
+
+  SpirvExtInstImport *debugExtInstSet; /// Pointer to
+                                       /// OpenCLDebugInfoExtInstSet
+  llvm::DenseMap<const Decl *, SpirvDebugTypeComposite *> debugTypeComposite;
 };
 
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/SpirvBasicBlock.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBasicBlock.cpp
@@ -36,17 +36,27 @@ bool SpirvBasicBlock::invokeVisitor(Visitor *visitor,
     }
     // If a basic block is the first basic block of a function, it should
     // include all the variables of the function.
-    if (!vars.empty())
-      for (auto var = vars.rbegin(); var != vars.rend(); ++var)
+    if (!vars.empty()) {
+      for (auto var = vars.rbegin(); var != vars.rend(); ++var) {
+        auto *decl = (*var)->getDebugDeclare();
+        if (decl && !decl->invokeVisitor(visitor))
+          return false;
         if (!(*var)->invokeVisitor(visitor))
           return false;
+      }
+    }
   } else {
     // If a basic block is the first basic block of a function, it should
     // include all the variables of the function.
-    if (!vars.empty())
-      for (auto *var : vars)
+    if (!vars.empty()) {
+      for (auto *var : vars) {
         if (!var->invokeVisitor(visitor))
           return false;
+        auto *decl = var->getDebugDeclare();
+        if (decl && !decl->invokeVisitor(visitor))
+          return false;
+      }
+    }
 
     for (auto iter = instructions.begin(); iter != instructions.end(); ++iter) {
       if (!iter->instruction->invokeVisitor(visitor))

--- a/tools/clang/lib/SPIRV/SpirvBasicBlock.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBasicBlock.cpp
@@ -15,7 +15,7 @@ namespace spirv {
 
 SpirvBasicBlock::SpirvBasicBlock(llvm::StringRef name)
     : labelId(0), labelName(name), mergeTarget(nullptr),
-      continueTarget(nullptr) {}
+      continueTarget(nullptr), debugScope(nullptr) {}
 
 bool SpirvBasicBlock::hasTerminator() const {
   return !instructions.empty() &&
@@ -26,6 +26,9 @@ bool SpirvBasicBlock::invokeVisitor(Visitor *visitor,
                                     llvm::ArrayRef<SpirvVariable *> vars,
                                     bool reverseOrder) {
   if (!visitor->visit(this, Visitor::Phase::Init))
+    return false;
+
+  if (debugScope && !visitor->visit(debugScope))
     return false;
 
   if (reverseOrder) {

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -812,6 +812,18 @@ SpirvDebugLocalVariable *SpirvBuilder::createDebugLocalVariable(
   return inst;
 }
 
+SpirvDebugGlobalVariable *SpirvBuilder::createDebugGlobalVariable(
+    QualType debugType, llvm::StringRef varName, SpirvDebugSource *src,
+    uint32_t line, uint32_t column, SpirvDebugInstruction *parentScope,
+    llvm::StringRef linkageName, SpirvVariable *var, uint32_t flags,
+    llvm::Optional<SpirvInstruction *> staticMemberDebugType) {
+  auto *inst = new (context) SpirvDebugGlobalVariable(
+      debugType, varName, src, line, column, parentScope, linkageName, var,
+      flags, staticMemberDebugType);
+  module->addDebugInfo(inst);
+  return inst;
+}
+
 SpirvDebugExpression *SpirvBuilder::getOrCreateNullDebugExpression() {
   if (nullDebugExpr)
     return nullDebugExpr;

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -23,7 +23,7 @@ namespace spirv {
 SpirvBuilder::SpirvBuilder(ASTContext &ac, SpirvContext &ctx,
                            const SpirvCodeGenOptions &opt)
     : astContext(ac), context(ctx), module(nullptr), function(nullptr),
-      spirvOptions(opt) {
+      spirvOptions(opt), nullDebugExpr(nullptr) {
   module = new (context) SpirvModule;
 }
 
@@ -802,6 +802,44 @@ SpirvDebugLocalVariable *SpirvBuilder::createDebugLocalVariable(
       debugQualType, varName, src, line, column, parentScope, flags, argNumber);
   module->addDebugInfo(inst);
   return inst;
+}
+
+SpirvDebugExpression *SpirvBuilder::getOrCreateNullDebugExpression() {
+  if (nullDebugExpr)
+    return nullDebugExpr;
+
+  nullDebugExpr = new (context) SpirvDebugExpression();
+  module->addDebugInfo(nullDebugExpr);
+  return nullDebugExpr;
+}
+
+SpirvDebugDeclare *SpirvBuilder::createDebugDeclare(
+    SpirvDebugLocalVariable *dbgVar, SpirvInstruction *var,
+    llvm::Optional<SpirvDebugExpression *> dbgExpr) {
+  if (auto *localVar = dyn_cast<SpirvVariable>(var)) {
+    auto *decl = new (context) SpirvDebugDeclare(
+        dbgVar, var,
+        dbgExpr.hasValue() ? dbgExpr.getValue()
+                           : getOrCreateNullDebugExpression());
+    assert(!localVar->getDebugDeclare() &&
+           "Debug info for local variable already exists!");
+    localVar->setDebugDeclare(decl);
+    return decl;
+  }
+
+  if (auto *param = dyn_cast<SpirvFunctionParameter>(var)) {
+    auto *decl = new (context) SpirvDebugDeclare(
+        dbgVar, var,
+        dbgExpr.hasValue() ? dbgExpr.getValue()
+                           : getOrCreateNullDebugExpression());
+    assert(!param->getDebugDeclare() &&
+           "Debug info for function param already exists!");
+    param->setDebugDeclare(decl);
+    return decl;
+  }
+
+  assert(false && "var must be SpirvVariable or SpirvFunctionParameter!");
+  return nullptr;
 }
 
 SpirvDebugFunction *SpirvBuilder::createDebugFunction(

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -824,6 +824,15 @@ SpirvDebugGlobalVariable *SpirvBuilder::createDebugGlobalVariable(
   return inst;
 }
 
+SpirvDebugInfoNone *SpirvBuilder::getOrCreateDebugInfoNone() {
+  if (debugNone)
+    return debugNone;
+
+  debugNone = new (context) SpirvDebugInfoNone();
+  module->addDebugInfo(debugNone);
+  return debugNone;
+}
+
 SpirvDebugExpression *SpirvBuilder::getOrCreateNullDebugExpression() {
   if (nullDebugExpr)
     return nullDebugExpr;

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1137,7 +1137,9 @@ void SpirvBuilder::setCurrentLexicalScope(SpirvDebugInstruction *inst) {
 std::vector<uint32_t> SpirvBuilder::takeModule() {
   // Run necessary visitor passes first
   LiteralTypeVisitor literalTypeVisitor(astContext, context, spirvOptions);
-  LowerTypeVisitor lowerTypeVisitor(astContext, context, spirvOptions);
+  LowerTypeVisitor lowerTypeVisitor(
+      astContext, context, spirvOptions,
+      spirvOptions.debugInfoRich ? getOpenCLDebugInfoExtInstSet() : nullptr);
   DebugTypeVisitor debugTypeVisitor(astContext, context, spirvOptions, *this);
   CapabilityVisitor capabilityVisitor(astContext, context, spirvOptions, *this);
   RelaxedPrecisionVisitor relaxedPrecisionVisitor(context, spirvOptions);

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -23,7 +23,8 @@ namespace spirv {
 SpirvBuilder::SpirvBuilder(ASTContext &ac, SpirvContext &ctx,
                            const SpirvCodeGenOptions &opt)
     : astContext(ac), context(ctx), module(nullptr), function(nullptr),
-      spirvOptions(opt), nullDebugExpr(nullptr), currentLexicalScope(nullptr) {
+      spirvOptions(opt), debugNone(nullptr), nullDebugExpr(nullptr),
+      currentLexicalScope(nullptr) {
   module = new (context) SpirvModule;
 }
 

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -23,7 +23,7 @@ namespace spirv {
 SpirvBuilder::SpirvBuilder(ASTContext &ac, SpirvContext &ctx,
                            const SpirvCodeGenOptions &opt)
     : astContext(ac), context(ctx), module(nullptr), function(nullptr),
-      spirvOptions(opt), nullDebugExpr(nullptr) {
+      spirvOptions(opt), nullDebugExpr(nullptr), currentLexicalScope(nullptr) {
   module = new (context) SpirvModule;
 }
 
@@ -92,6 +92,8 @@ SpirvBasicBlock *SpirvBuilder::createBasicBlock(llvm::StringRef name) {
   assert(function && "found detached basic block");
   auto *bb = new (context) SpirvBasicBlock(name);
   basicBlocks.push_back(bb);
+  if (currentLexicalScope)
+    bb->setDebugScope(new (context) SpirvDebugScope(currentLexicalScope));
   return bb;
 }
 
@@ -788,9 +790,15 @@ SpirvDebugLexicalBlock *
 SpirvBuilder::createDebugLexicalBlock(SpirvDebugSource *source, uint32_t line,
                                       uint32_t column,
                                       SpirvDebugInstruction *parent) {
+  assert(insertPoint && "null insert point");
   auto *inst =
       new (context) SpirvDebugLexicalBlock(source, line, column, parent);
   module->addDebugInfo(inst);
+  if (insertPoint->empty()) {
+    insertPoint->setDebugScope(new (context) SpirvDebugScope(inst));
+  } else {
+    insertPoint->addInstruction(new (context) SpirvDebugScope(inst));
+  }
   return inst;
 }
 
@@ -1116,6 +1124,14 @@ SpirvConstant *SpirvBuilder::getConstantNull(QualType type) {
   auto *nullConst = new (context) SpirvConstantNull(type);
   module->addConstant(nullConst);
   return nullConst;
+}
+
+void SpirvBuilder::setCurrentLexicalScope(SpirvDebugInstruction *inst) {
+  assert((isa<SpirvDebugLexicalBlock>(inst) || isa<SpirvDebugFunction>(inst) ||
+          isa<SpirvDebugCompilationUnit>(inst) ||
+          isa<SpirvDebugTypeComposite>(inst)) &&
+         "Given inst is not a lexical scope");
+  currentLexicalScope = inst;
 }
 
 std::vector<uint32_t> SpirvBuilder::takeModule() {

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -182,8 +182,7 @@ SpirvContext::getRuntimeArrayType(const SpirvType *elemType,
 const StructType *
 SpirvContext::getStructType(llvm::ArrayRef<StructType::FieldInfo> fields,
                             llvm::StringRef name, bool isReadOnly,
-                            StructInterfaceType interfaceType,
-                            llvm::Optional<const RecordDecl *> decl) {
+                            StructInterfaceType interfaceType) {
   // We are creating a temporary struct type here for querying whether the
   // same type was already created. It is a little bit costly, but we can
   // avoid allocating directly from the bump pointer allocator, from which
@@ -199,7 +198,7 @@ SpirvContext::getStructType(llvm::ArrayRef<StructType::FieldInfo> fields,
     return *found;
 
   structTypes.push_back(
-      new (this) StructType(fields, name, isReadOnly, interfaceType, decl));
+      new (this) StructType(fields, name, isReadOnly, interfaceType));
 
   return structTypes.back();
 }

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -292,9 +292,8 @@ SpirvDebugInstruction *SpirvContext::getDebugTypeMember(
 
   // NOTE: Do not save it in debugTypes because it would have the same
   // spirvType but it has different parent i.e., type composite. Instead,
-  // we want to keep DebugTypeMember and DebugTypeInheritance in
-  // memberTypes.
-  memberTypes.push_back(debugType);
+  // we want to keep it in tailDebugTypes.
+  tailDebugTypes.push_back(debugType);
   return debugType;
 }
 
@@ -378,6 +377,11 @@ SpirvContext::getDebugTypeTemplate(const SpirvType *spirvType,
       } else {
         auto *debugType = new (this) SpirvDebugTypeTemplate(target);
         composite->setTypeTemplate(debugType);
+
+        // NOTE: Do not save it in debugTypes because it is not
+        // corresponding to a spirvType but it is pointed by a composite
+        // type. Instead, we want to keep it in tailDebugTypes.
+        tailDebugTypes.push_back(debugType);
         return debugType;
       }
     }
@@ -394,6 +398,10 @@ SpirvDebugInstruction *SpirvContext::getDebugTypeTemplateParameter(
 
   auto *debugType = new (this)
       SpirvDebugTypeTemplateParameter(name, type, value, source, line, column);
+  // NOTE: Do not save it in debugTypes because it is not corresponding
+  // to a spirvType but it is pointed by a type template. Instead,
+  // we want to keep it in tailDebugTypes.
+  tailDebugTypes.push_back(debugType);
   return debugType;
 }
 

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -281,23 +281,15 @@ SpirvContext::getDebugTypeBasic(const SpirvType *spirvType,
   return debugType;
 }
 
-SpirvDebugInstruction *
-SpirvContext::getDebugTypeMember(llvm::StringRef name, SpirvDebugType *type,
-                                 SpirvDebugSource *source, uint32_t line,
-                                 uint32_t column, SpirvDebugInstruction *parent,
-                                 uint32_t offset, uint32_t size, uint32_t flags,
-                                 llvm::Optional<SpirvInstruction *> value) {
+SpirvDebugInstruction *SpirvContext::getDebugTypeMember(
+    llvm::StringRef name, const SpirvType *type, SpirvDebugSource *source,
+    uint32_t line, uint32_t column, SpirvDebugInstruction *parent,
+    uint32_t flags, uint32_t offset, const APValue *value) {
   // NOTE: Do not search it in debugTypes because it would have the same
   // spirvType but has different parent i.e., type composite.
 
-  SpirvDebugTypeMember *debugType = nullptr;
-  if (value.hasValue()) {
-    debugType = new (this) SpirvDebugTypeMember(
-        name, type, source, line, column, parent, offset, size, flags, *value);
-  } else {
-    debugType = new (this) SpirvDebugTypeMember(
-        name, type, source, line, column, parent, offset, size, flags);
-  }
+  SpirvDebugTypeMember *debugType = new (this) SpirvDebugTypeMember(
+      name, type, source, line, column, parent, flags, offset, value);
 
   // NOTE: Do not save it in debugTypes because it would have the same
   // spirvType but it has different parent i.e., type composite. Instead,

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -314,6 +314,14 @@ SpirvDebugInstruction *SpirvContext::getDebugTypeComposite(
 }
 
 SpirvDebugInstruction *
+SpirvContext::getDebugTypeComposite(const SpirvType *spirvType) {
+  auto it = debugTypes.find(spirvType);
+  if (it != debugTypes.end())
+    return it->second;
+  return nullptr;
+}
+
+SpirvDebugInstruction *
 SpirvContext::getDebugTypeArray(const SpirvType *spirvType,
                                 SpirvDebugInstruction *elemType,
                                 llvm::ArrayRef<uint32_t> elemCount) {

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -350,9 +350,10 @@ SpirvContext::getDebugTypeVector(const SpirvType *spirvType,
   debugTypes[spirvType] = debugType;
   return debugType;
 }
-SpirvDebugInstruction* SpirvContext::getDebugTypeFunction(
-  const SpirvType* spirvType, uint32_t flags, SpirvDebugInstruction* ret,
-  llvm::ArrayRef<SpirvDebugInstruction*> params) {
+SpirvDebugInstruction *
+SpirvContext::getDebugTypeFunction(const SpirvType *spirvType, uint32_t flags,
+                                   SpirvDebugType *ret,
+                                   llvm::ArrayRef<SpirvDebugType *> params) {
   // Reuse existing debug type if possible.
   if (debugTypes.find(spirvType) != debugTypes.end())
     return debugTypes[spirvType];

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -311,8 +311,7 @@ SpirvDebugInstruction *SpirvContext::getDebugTypeComposite(
   return debugType;
 }
 
-SpirvDebugInstruction *
-SpirvContext::getDebugType(const SpirvType *spirvType) {
+SpirvDebugInstruction *SpirvContext::getDebugType(const SpirvType *spirvType) {
   auto it = debugTypes.find(spirvType);
   if (it != debugTypes.end())
     return it->second;

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -390,7 +390,7 @@ SpirvContext::getDebugTypeTemplate(const SpirvType *spirvType,
 }
 
 SpirvDebugInstruction *SpirvContext::getDebugTypeTemplateParameter(
-    llvm::StringRef name, const SpirvType *type, SpirvConstant *value,
+    llvm::StringRef name, const SpirvType *type, SpirvInstruction *value,
     SpirvDebugSource *source, uint32_t line, uint32_t column) {
   // NOTE: Do not search it in debugTypes because DebugTypeTemplateParameter
   // just represents a debug type that registers the same spirvType for itself.

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -362,5 +362,31 @@ SpirvContext::getDebugTypeFunction(const SpirvType *spirvType, uint32_t flags,
   return debugType;
 }
 
+SpirvDebugInstruction *
+SpirvContext::getDebugTypeTemplate(const SpirvType *spirvType,
+                                   SpirvDebugInstruction *target) {
+  // Reuse existing debug type if possible.
+  if (debugTypes.find(spirvType) != debugTypes.end())
+    return debugTypes[spirvType];
+
+  auto *debugType = new (this) SpirvDebugTypeTemplate(target);
+  debugTypes[spirvType] = debugType;
+  return debugType;
+}
+
+SpirvDebugInstruction *SpirvContext::getDebugTypeTemplateParameter(
+    const SpirvType *spirvType, llvm::StringRef name,
+    SpirvDebugType *actualType, SpirvConstant *value, SpirvDebugSource *source,
+    uint32_t line, uint32_t column) {
+  // Reuse existing debug type if possible.
+  if (debugTypes.find(spirvType) != debugTypes.end())
+    return debugTypes[spirvType];
+
+  auto *debugType = new (this) SpirvDebugTypeTemplateParameter(
+      name, actualType, value, source, line, column);
+  debugTypes[spirvType] = debugType;
+  return debugType;
+}
+
 } // end namespace spirv
 } // end namespace clang

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1111,12 +1111,9 @@ void SpirvEmitter::doFunctionDecl(const FunctionDecl *decl) {
     info = getOrCreateRichDebugInfo(loc);
 
     auto *source = info->source;
-    // TODO: Revisit this. There are some cases that info->scopeStack.back()
-    // is not a parent scope of this function. Consider the case we suddenly
-    // handle a function decl (doFunctionDecl) when we meet a function call.
-    // The function call itself is not a place for this function definition.
-    // Therefore, its parent is not a parent scope of this function definition.
-    auto *parentScope = info->scopeStack.back();
+    // Note that info->scopeStack.back() is a lexical scope of the function
+    // caller.
+    auto *parentScope = info->compilationUnit;
     // TODO: figure out the proper flag based on the function decl.
     // using FlagIsPublic for now.
     uint32_t flags = 3u;
@@ -1129,10 +1126,9 @@ void SpirvEmitter::doFunctionDecl(const FunctionDecl *decl) {
     func->setDebugScope(new (astContext) SpirvDebugScope(debugFunction));
 
     // We want to keep member function info of a structure, but a StructType
-    // was not created yet. SpirvContext holds a map between RecordDecl and
-    // its member function list. When StructType will be created, it will
-    // keep its member function info. It will be used to create
-    // DebugTypeComposite in DebugTypeVisitor.
+    // was not created yet. SpirvContext holds a map between CXXMethodDecl and
+    // its corresponding DebugFunction. When StructType will be created, it
+    // will keep its member function info.
     if (const auto *methodDecl = dyn_cast<CXXMethodDecl>(decl)) {
       spvContext.saveFuntionInfo(methodDecl, debugFunction);
     }

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1134,7 +1134,7 @@ void SpirvEmitter::doFunctionDecl(const FunctionDecl *decl) {
     // keep its member function info. It will be used to create
     // DebugTypeComposite in DebugTypeVisitor.
     if (const auto *methodDecl = dyn_cast<CXXMethodDecl>(decl)) {
-      spvContext.saveFuntionInfo(methodDecl->getParent(), debugFunction);
+      spvContext.saveFuntionInfo(methodDecl, debugFunction);
     }
 
     info->scopeStack.push_back(debugFunction);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -71,9 +71,11 @@ public:
   DiagnosticsEngine &getDiagnosticsEngine() { return diags; }
   CompilerInstance &getCompilerInstance() { return theCompilerInstance; }
   SpirvCodeGenOptions &getSpirvOptions() { return spirvOptions; }
-  llvm::MapVector<llvm::StringRef, RichDebugInfo> &getRichDebugInfo() {
-    return debugInfo;
-  }
+
+  /// \brief If DebugSource and DebugCompilationUnit for loc are already
+  /// created, we just return RichDebugInfo containing it. Otherwise,
+  /// create DebugSource and DebugCompilationUnit for loc and return it.
+  RichDebugInfo *getOrCreateRichDebugInfo(const SourceLocation &loc);
 
   void doDecl(const Decl *decl);
   void doStmt(const Stmt *stmt, llvm::ArrayRef<const Attr *> attrs = {});

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -39,23 +39,6 @@
 namespace clang {
 namespace spirv {
 
-struct RichDebugInfo {
-  RichDebugInfo(SpirvDebugSource *src, SpirvDebugCompilationUnit *cu)
-      : source(src), compilationUnit(cu) {
-    scopeStack.push_back(cu);
-  }
-  RichDebugInfo() : source(nullptr), compilationUnit(nullptr), scopeStack() {}
-
-  // The HLL source code
-  SpirvDebugSource *source;
-
-  // The compilation unit (topmost debug info node)
-  SpirvDebugCompilationUnit *compilationUnit;
-
-  // Stack of lexical scopes
-  std::vector<SpirvDebugInstruction *> scopeStack;
-};
-
 /// SPIR-V emitter class. It consumes the HLSL AST and emits SPIR-V words.
 ///
 /// This class only overrides the HandleTranslationUnit() method; Traversing
@@ -1179,13 +1162,6 @@ private:
 
   /// The <result-id> of the OpString containing the main source file's path.
   SpirvString *mainSourceFile;
-
-  /// File name to rich debug info map. When the main source file
-  /// includes header files, we create an element of debugInfo for
-  /// each file. RichDebugInfo includes DebugSource,
-  /// DebugCompilationUnit and scopeStack which keeps lexical scopes
-  /// recursively.
-  llvm::MapVector<llvm::StringRef, RichDebugInfo> debugInfo;
 };
 
 void SpirvEmitter::doDeclStmt(const DeclStmt *declStmt) {

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -39,6 +39,23 @@
 namespace clang {
 namespace spirv {
 
+struct RichDebugInfo {
+  RichDebugInfo(SpirvDebugSource *src, SpirvDebugCompilationUnit *cu)
+      : source(src), compilationUnit(cu) {
+    scopeStack.push_back(cu);
+  }
+  RichDebugInfo() : source(nullptr), compilationUnit(nullptr), scopeStack() {}
+
+  // The HLL source code
+  SpirvDebugSource *source;
+
+  // The compilation unit (topmost debug info node)
+  SpirvDebugCompilationUnit *compilationUnit;
+
+  // Stack of lexical scopes
+  std::vector<SpirvDebugInstruction *> scopeStack;
+};
+
 /// SPIR-V emitter class. It consumes the HLSL AST and emits SPIR-V words.
 ///
 /// This class only overrides the HandleTranslationUnit() method; Traversing

--- a/tools/clang/lib/SPIRV/SpirvFunction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvFunction.cpp
@@ -22,11 +22,14 @@ SpirvFunction::SpirvFunction(QualType returnType,
     : functionId(0), astReturnType(returnType),
       astParamTypes(paramTypes.begin(), paramTypes.end()), returnType(nullptr),
       fnType(nullptr), relaxedPrecision(false), precise(isPrecise),
-      containsAlias(false), rvalue(false), functionLoc(loc),
-      functionName(name) {}
+      containsAlias(false), rvalue(false), functionLoc(loc), functionName(name),
+      debugScope(nullptr) {}
 
 bool SpirvFunction::invokeVisitor(Visitor *visitor, bool reverseOrder) {
   if (!visitor->visit(this, Visitor::Phase::Init))
+    return false;
+
+  if (debugScope && !visitor->visit(debugScope))
     return false;
 
   for (auto *param : parameters) {

--- a/tools/clang/lib/SPIRV/SpirvFunction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvFunction.cpp
@@ -29,8 +29,19 @@ bool SpirvFunction::invokeVisitor(Visitor *visitor, bool reverseOrder) {
   if (!visitor->visit(this, Visitor::Phase::Init))
     return false;
 
-  for (auto *param : parameters)
-    visitor->visit(param);
+  for (auto *param : parameters) {
+    if (reverseOrder) {
+      auto *decl = param->getDebugDeclare();
+      if (decl)
+        visitor->visit(decl);
+      visitor->visit(param);
+    } else {
+      visitor->visit(param);
+      auto *decl = param->getDebugDeclare();
+      if (decl)
+        visitor->visit(decl);
+    }
+  }
 
   // Collect basic blocks in a human-readable order that satisfies SPIR-V
   // validation rules.

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -91,6 +91,7 @@ DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugExpression)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugDeclare)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugValue)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugLexicalBlock)
+DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugScope)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugTypeBasic)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugTypeArray)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugTypeVector)
@@ -856,6 +857,9 @@ SpirvDebugLexicalBlock::SpirvDebugLexicalBlock(SpirvDebugSource *source_,
                                                SpirvDebugInstruction *parent_)
     : SpirvDebugInstruction(IK_DebugLexicalBlock, /*opcode*/ 21u),
       source(source_), line(line_), column(column_), parent(parent_) {}
+
+SpirvDebugScope::SpirvDebugScope(SpirvDebugInstruction *scope_)
+    : SpirvDebugInstruction(IK_DebugScope, /*opcode*/ 23u), scope(scope_) {}
 
 SpirvDebugTypeBasic::SpirvDebugTypeBasic(llvm::StringRef name_,
                                          SpirvConstant *size_,

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -880,11 +880,12 @@ SpirvDebugTypeFunction::SpirvDebugTypeFunction(
 
 SpirvDebugTypeMember::SpirvDebugTypeMember(
     llvm::StringRef name_, SpirvDebugType *member_, SpirvInstruction *source_,
-    uint32_t line_, uint32_t column_, uint32_t offset_, uint32_t size_,
-    uint32_t flags_, SpirvInstruction *value_)
+    uint32_t line_, uint32_t column_, SpirvDebugInstruction *parent_,
+    uint32_t offset_, uint32_t size_, uint32_t flags_, SpirvInstruction *value_)
     : SpirvDebugType(IK_DebugTypeMember, /*opcode*/ 11u), name(name_),
       member(member_), source(source_), line(line_), column(column_),
-      offset(offset_), size(size_), debugFlags(flags_), value(value_) {}
+      parent(parent_), offset(offset_), size(size_), debugFlags(flags_),
+      value(value_) {}
 
 SpirvDebugTypeComposite::SpirvDebugTypeComposite(
     llvm::StringRef name_, SpirvInstruction *source_, uint32_t line_,

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -263,7 +263,7 @@ SpirvVariable::SpirvVariable(QualType resultType, SourceLocation loc,
                              SpirvInstruction *initializerInst)
     : SpirvInstruction(IK_Variable, spv::Op::OpVariable, resultType, loc),
       initializer(initializerInst), descriptorSet(-1), binding(-1),
-      hlslUserType("") {
+      hlslUserType(""), debugDecl(nullptr) {
   setStorageClass(sc);
   setPrecise(precise);
 }
@@ -272,7 +272,8 @@ SpirvFunctionParameter::SpirvFunctionParameter(QualType resultType,
                                                bool isPrecise,
                                                SourceLocation loc)
     : SpirvInstruction(IK_FunctionParameter, spv::Op::OpFunctionParameter,
-                       resultType, loc) {
+                       resultType, loc),
+      debugDecl(nullptr) {
   setPrecise(isPrecise);
 }
 
@@ -838,7 +839,7 @@ SpirvDebugExpression::SpirvDebugExpression(
       operations(operations_.begin(), operations_.end()) {}
 
 SpirvDebugDeclare::SpirvDebugDeclare(SpirvDebugLocalVariable *debugVar_,
-                                     SpirvVariable *var_,
+                                     SpirvInstruction *var_,
                                      SpirvDebugExpression *expr)
     : SpirvDebugInstruction(IK_DebugDeclare, /*opcode*/ 28u),
       debugVar(debugVar_), var(var_), expression(expr) {}

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -867,12 +867,18 @@ SpirvDebugTypeBasic::SpirvDebugTypeBasic(llvm::StringRef name_,
     : SpirvDebugType(IK_DebugTypeBasic, /*opcode*/ 2u), name(name_),
       size(size_), encoding(encoding_) {}
 
-SpirvDebugTypeArray::SpirvDebugTypeArray(SpirvDebugInstruction *elemType,
+uint32_t SpirvDebugTypeBasic::getSizeInBits() const {
+  auto *size_ = dyn_cast<SpirvConstantInteger>(size);
+  assert(size_ && "Size of DebugTypeBasic must be int type const.");
+  return size_->getValue().getLimitedValue();
+}
+
+SpirvDebugTypeArray::SpirvDebugTypeArray(SpirvDebugType *elemType,
                                          llvm::ArrayRef<uint32_t> elemCount)
     : SpirvDebugType(IK_DebugTypeArray, /*opcode*/ 5u), elementType(elemType),
       elementCount(elemCount.begin(), elemCount.end()) {}
 
-SpirvDebugTypeVector::SpirvDebugTypeVector(SpirvDebugInstruction *elemType,
+SpirvDebugTypeVector::SpirvDebugTypeVector(SpirvDebugType *elemType,
                                            uint32_t elemCount)
     : SpirvDebugType(IK_DebugTypeVector, /*opcode*/ 6u), elementType(elemType),
       elementCount(elemCount) {}
@@ -884,23 +890,22 @@ SpirvDebugTypeFunction::SpirvDebugTypeFunction(
       returnType(ret), paramTypes(params.begin(), params.end()) {}
 
 SpirvDebugTypeMember::SpirvDebugTypeMember(
-    llvm::StringRef name_, SpirvDebugType *member_, SpirvInstruction *source_,
+    llvm::StringRef name_, SpirvDebugType *type_, SpirvDebugSource *source_,
     uint32_t line_, uint32_t column_, SpirvDebugInstruction *parent_,
     uint32_t offset_, uint32_t size_, uint32_t flags_, SpirvInstruction *value_)
     : SpirvDebugType(IK_DebugTypeMember, /*opcode*/ 11u), name(name_),
-      member(member_), source(source_), line(line_), column(column_),
+      type(type_), source(source_), line(line_), column(column_),
       parent(parent_), offset(offset_), size(size_), debugFlags(flags_),
       value(value_) {}
 
 SpirvDebugTypeComposite::SpirvDebugTypeComposite(
-    llvm::StringRef name_, SpirvInstruction *source_, uint32_t line_,
+    llvm::StringRef name_, SpirvDebugSource *source_, uint32_t line_,
     uint32_t column_, SpirvDebugInstruction *parent_,
     llvm::StringRef linkageName_, uint32_t size_, uint32_t flags_,
-    uint32_t tag_, llvm::ArrayRef<SpirvDebugInstruction *> members_)
+    uint32_t tag_)
     : SpirvDebugType(IK_DebugTypeComposite, /*opcode*/ 10u), name(name_),
       source(source_), line(line_), column(column_), parent(parent_),
-      linkageName(linkageName_), size(size_), debugFlags(flags_), tag(tag_),
-      members(members_.begin(), members_.end()) {}
+      linkageName(linkageName_), size(size_), debugFlags(flags_), tag(tag_) {}
 
 } // namespace spirv
 } // namespace clang

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -884,8 +884,8 @@ SpirvDebugTypeVector::SpirvDebugTypeVector(SpirvDebugType *elemType,
       elementCount(elemCount) {}
 
 SpirvDebugTypeFunction::SpirvDebugTypeFunction(
-    uint32_t flags, SpirvDebugInstruction *ret,
-    llvm::ArrayRef<SpirvDebugInstruction *> params)
+    uint32_t flags, SpirvDebugType *ret,
+    llvm::ArrayRef<SpirvDebugType *> params)
     : SpirvDebugType(IK_DebugTypeFunction, /*opcode*/ 8u), debugFlags(flags),
       returnType(ret), paramTypes(params.begin(), params.end()) {}
 

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -98,6 +98,8 @@ DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugTypeVector)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugTypeFunction)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugTypeComposite)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugTypeMember)
+DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugTypeTemplate)
+DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugTypeTemplateParameter)
 
 #undef DEFINE_INVOKE_VISITOR_FOR_CLASS
 
@@ -908,6 +910,18 @@ SpirvDebugTypeComposite::SpirvDebugTypeComposite(
       source(source_), line(line_), column(column_), parent(parent_),
       linkageName(linkageName_), size(size_), debugFlags(flags_), tag(tag_),
       fullyLowered(false) {}
+
+SpirvDebugTypeTemplate::SpirvDebugTypeTemplate(SpirvDebugInstruction *target_)
+    : SpirvDebugType(IK_DebugTypeTemplate, /*opcode*/ 14u), target(target_) {}
+
+SpirvDebugTypeTemplateParameter::SpirvDebugTypeTemplateParameter(
+    llvm::StringRef name, SpirvDebugType *actualType_, SpirvConstant *value_,
+    SpirvDebugSource *source_, uint32_t line_, uint32_t column_)
+    : SpirvDebugType(IK_DebugTypeTemplateParameter, /*opcode*/ 15u),
+      actualType(actualType_), value(value_), source(source_), line(line_),
+      column(column_) {
+  debugName = name;
+}
 
 } // namespace spirv
 } // namespace clang

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -918,8 +918,8 @@ SpirvDebugTypeTemplateParameter::SpirvDebugTypeTemplateParameter(
     llvm::StringRef name, const SpirvType *type, SpirvConstant *value_,
     SpirvDebugSource *source_, uint32_t line_, uint32_t column_)
     : SpirvDebugType(IK_DebugTypeTemplateParameter, /*opcode*/ 15u),
-      spvType(type), actualType(nullptr), value(value_), source(source_), line(line_),
-      column(column_) {
+      spvType(type), actualType(nullptr), value(value_), source(source_),
+      line(line_), column(column_) {
   debugName = name;
 }
 

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -817,15 +817,16 @@ SpirvDebugLocalVariable::SpirvDebugLocalVariable(
 }
 
 SpirvDebugGlobalVariable::SpirvDebugGlobalVariable(
-    llvm::StringRef varName, SpirvDebugSource *src, uint32_t line_,
-    uint32_t column_, SpirvDebugInstruction *parent,
+    QualType debugQualType, llvm::StringRef varName, SpirvDebugSource *src,
+    uint32_t line_, uint32_t column_, SpirvDebugInstruction *parent,
     llvm::StringRef linkageName_, SpirvVariable *var_, uint32_t flags_,
-    llvm::Optional<SpirvInstruction *> staticMemberDebugType_)
+    llvm::Optional<SpirvInstruction *> staticMemberDebugDecl_)
     : SpirvDebugInstruction(IK_DebugGlobalVariable, /*opcode*/ 18u),
       source(src), line(line_), column(column_), parentScope(parent),
       linkageName(linkageName_), var(var_), flags(flags_),
-      staticMemberDebugType(staticMemberDebugType_), debugType(nullptr) {
+      staticMemberDebugDecl(staticMemberDebugDecl_), debugType(nullptr) {
   debugName = varName;
+  setDebugQualType(debugQualType);
 }
 
 SpirvDebugOperation::SpirvDebugOperation(uint32_t operationOpCode_,

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -868,11 +868,13 @@ SpirvDebugLexicalBlock::SpirvDebugLexicalBlock(SpirvDebugSource *source_,
 SpirvDebugScope::SpirvDebugScope(SpirvDebugInstruction *scope_)
     : SpirvDebugInstruction(IK_DebugScope, /*opcode*/ 23u), scope(scope_) {}
 
-SpirvDebugTypeBasic::SpirvDebugTypeBasic(llvm::StringRef name_,
+SpirvDebugTypeBasic::SpirvDebugTypeBasic(llvm::StringRef name,
                                          SpirvConstant *size_,
                                          uint32_t encoding_)
-    : SpirvDebugType(IK_DebugTypeBasic, /*opcode*/ 2u), name(name_),
-      size(size_), encoding(encoding_) {}
+    : SpirvDebugType(IK_DebugTypeBasic, /*opcode*/ 2u), size(size_),
+      encoding(encoding_) {
+  debugName = name;
+}
 
 uint32_t SpirvDebugTypeBasic::getSizeInBits() const {
   auto *size_ = dyn_cast<SpirvConstantInteger>(size);
@@ -897,23 +899,26 @@ SpirvDebugTypeFunction::SpirvDebugTypeFunction(
       returnType(ret), paramTypes(params.begin(), params.end()) {}
 
 SpirvDebugTypeMember::SpirvDebugTypeMember(
-    llvm::StringRef name_, const SpirvType *type_, SpirvDebugSource *source_,
+    llvm::StringRef name, const SpirvType *type_, SpirvDebugSource *source_,
     uint32_t line_, uint32_t column_, SpirvDebugInstruction *parent_,
     uint32_t flags_, uint32_t offset_, const APValue *value_)
-    : SpirvDebugType(IK_DebugTypeMember, /*opcode*/ 11u), name(name_),
-      type(nullptr), source(source_), line(line_), column(column_),
-      parent(parent_), debugFlags(flags_), value(value_), spvType(type_),
-      offset(offset_) {}
+    : SpirvDebugType(IK_DebugTypeMember, /*opcode*/ 11u), type(nullptr),
+      source(source_), line(line_), column(column_), parent(parent_),
+      debugFlags(flags_), value(value_), spvType(type_), offset(offset_) {
+  debugName = name;
+}
 
 SpirvDebugTypeComposite::SpirvDebugTypeComposite(
-    llvm::StringRef name_, SpirvDebugSource *source_, uint32_t line_,
+    llvm::StringRef name, SpirvDebugSource *source_, uint32_t line_,
     uint32_t column_, SpirvDebugInstruction *parent_,
     llvm::StringRef linkageName_, uint32_t size_, uint32_t flags_,
     uint32_t tag_)
-    : SpirvDebugType(IK_DebugTypeComposite, /*opcode*/ 10u), name(name_),
-      source(source_), line(line_), column(column_), parent(parent_),
-      linkageName(linkageName_), size(size_), debugFlags(flags_), tag(tag_),
-      typeTemplate(nullptr), fullyLowered(false) {}
+    : SpirvDebugType(IK_DebugTypeComposite, /*opcode*/ 10u), source(source_),
+      line(line_), column(column_), parent(parent_), linkageName(linkageName_),
+      size(size_), debugFlags(flags_), tag(tag_), typeTemplate(nullptr),
+      fullyLowered(false) {
+  debugName = name;
+}
 
 SpirvDebugTypeTemplate::SpirvDebugTypeTemplate(SpirvDebugInstruction *target_)
     : SpirvDebugType(IK_DebugTypeTemplate, /*opcode*/ 14u), target(target_) {}

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -890,13 +890,13 @@ SpirvDebugTypeFunction::SpirvDebugTypeFunction(
       returnType(ret), paramTypes(params.begin(), params.end()) {}
 
 SpirvDebugTypeMember::SpirvDebugTypeMember(
-    llvm::StringRef name_, SpirvDebugType *type_, SpirvDebugSource *source_,
+    llvm::StringRef name_, const SpirvType *type_, SpirvDebugSource *source_,
     uint32_t line_, uint32_t column_, SpirvDebugInstruction *parent_,
-    uint32_t offset_, uint32_t size_, uint32_t flags_, SpirvInstruction *value_)
+    uint32_t flags_, uint32_t offset_, const APValue *value_)
     : SpirvDebugType(IK_DebugTypeMember, /*opcode*/ 11u), name(name_),
-      type(type_), source(source_), line(line_), column(column_),
-      parent(parent_), offset(offset_), size(size_), debugFlags(flags_),
-      value(value_) {}
+      type(nullptr), source(source_), line(line_), column(column_),
+      parent(parent_), debugFlags(flags_), value(value_), spvType(type_),
+      offset(offset_) {}
 
 SpirvDebugTypeComposite::SpirvDebugTypeComposite(
     llvm::StringRef name_, SpirvDebugSource *source_, uint32_t line_,

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -81,6 +81,7 @@ DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvUnaryOp)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvVectorShuffle)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvArrayLength)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvRayTracingOpNV)
+DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugInfoNone)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugSource)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugCompilationUnit)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugFunction)
@@ -787,6 +788,9 @@ SpirvDebugInstruction::SpirvDebugInstruction(Kind kind, uint32_t opcode)
                        /*SourceLocation*/ {}),
       debugOpcode(opcode), instructionSet(nullptr) {}
 
+SpirvDebugInfoNone::SpirvDebugInfoNone()
+    : SpirvDebugInstruction(IK_DebugInfoNone, /*opcode*/ 0u) {}
+
 SpirvDebugSource::SpirvDebugSource(llvm::StringRef f, llvm::StringRef t)
     : SpirvDebugInstruction(IK_DebugSource, /*opcode*/ 35u), file(f), text(t) {}
 
@@ -915,7 +919,7 @@ SpirvDebugTypeTemplate::SpirvDebugTypeTemplate(SpirvDebugInstruction *target_)
     : SpirvDebugType(IK_DebugTypeTemplate, /*opcode*/ 14u), target(target_) {}
 
 SpirvDebugTypeTemplateParameter::SpirvDebugTypeTemplateParameter(
-    llvm::StringRef name, const SpirvType *type, SpirvConstant *value_,
+    llvm::StringRef name, const SpirvType *type, SpirvInstruction *value_,
     SpirvDebugSource *source_, uint32_t line_, uint32_t column_)
     : SpirvDebugType(IK_DebugTypeTemplateParameter, /*opcode*/ 15u),
       spvType(type), actualType(nullptr), value(value_), source(source_),

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -905,7 +905,8 @@ SpirvDebugTypeComposite::SpirvDebugTypeComposite(
     uint32_t tag_)
     : SpirvDebugType(IK_DebugTypeComposite, /*opcode*/ 10u), name(name_),
       source(source_), line(line_), column(column_), parent(parent_),
-      linkageName(linkageName_), size(size_), debugFlags(flags_), tag(tag_) {}
+      linkageName(linkageName_), size(size_), debugFlags(flags_), tag(tag_),
+      fullyLowered(false) {}
 
 } // namespace spirv
 } // namespace clang

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -909,16 +909,16 @@ SpirvDebugTypeComposite::SpirvDebugTypeComposite(
     : SpirvDebugType(IK_DebugTypeComposite, /*opcode*/ 10u), name(name_),
       source(source_), line(line_), column(column_), parent(parent_),
       linkageName(linkageName_), size(size_), debugFlags(flags_), tag(tag_),
-      fullyLowered(false) {}
+      typeTemplate(nullptr), fullyLowered(false) {}
 
 SpirvDebugTypeTemplate::SpirvDebugTypeTemplate(SpirvDebugInstruction *target_)
     : SpirvDebugType(IK_DebugTypeTemplate, /*opcode*/ 14u), target(target_) {}
 
 SpirvDebugTypeTemplateParameter::SpirvDebugTypeTemplateParameter(
-    llvm::StringRef name, SpirvDebugType *actualType_, SpirvConstant *value_,
+    llvm::StringRef name, const SpirvType *type, SpirvConstant *value_,
     SpirvDebugSource *source_, uint32_t line_, uint32_t column_)
     : SpirvDebugType(IK_DebugTypeTemplateParameter, /*opcode*/ 15u),
-      actualType(actualType_), value(value_), source(source_), line(line_),
+      spvType(type), actualType(nullptr), value(value_), source(source_), line(line_),
       column(column_) {
   debugName = name;
 }

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -783,7 +783,7 @@ SpirvDebugInstruction::SpirvDebugInstruction(Kind kind, uint32_t opcode)
     : SpirvInstruction(kind, spv::Op::OpExtInst,
                        /*result type */ {},
                        /*SourceLocation*/ {}),
-      debugOpcode(opcode), debugType(nullptr), instructionSet(nullptr) {}
+      debugOpcode(opcode), instructionSet(nullptr) {}
 
 SpirvDebugSource::SpirvDebugSource(llvm::StringRef f, llvm::StringRef t)
     : SpirvDebugInstruction(IK_DebugSource, /*opcode*/ 35u), file(f), text(t) {}
@@ -801,7 +801,7 @@ SpirvDebugFunction::SpirvDebugFunction(
     uint32_t bodyLine, SpirvFunction *func)
     : SpirvDebugInstruction(IK_DebugFunction, /*opcode*/ 20u), source(src),
       fnLine(fline), fnColumn(fcol), parentScope(parent), linkageName(linkName),
-      flags(flags_), scopeLine(bodyLine), fn(func) {
+      flags(flags_), scopeLine(bodyLine), fn(func), debugType(nullptr) {
   debugName = name;
 }
 
@@ -811,7 +811,7 @@ SpirvDebugLocalVariable::SpirvDebugLocalVariable(
     uint32_t flags_, llvm::Optional<uint32_t> argNumber_)
     : SpirvDebugInstruction(IK_DebugLocalVariable, /*opcode*/ 26u), source(src),
       line(lineNumber), column(colNumber), parentScope(parent), flags(flags_),
-      argNumber(argNumber_) {
+      argNumber(argNumber_), debugType(nullptr) {
   debugName = varName;
   setDebugQualType(debugQualType_);
 }
@@ -824,7 +824,7 @@ SpirvDebugGlobalVariable::SpirvDebugGlobalVariable(
     : SpirvDebugInstruction(IK_DebugGlobalVariable, /*opcode*/ 18u),
       source(src), line(line_), column(column_), parentScope(parent),
       linkageName(linkageName_), var(var_), flags(flags_),
-      staticMemberDebugType(staticMemberDebugType_) {
+      staticMemberDebugType(staticMemberDebugType_), debugType(nullptr) {
   debugName = varName;
 }
 

--- a/tools/clang/lib/SPIRV/SpirvModule.cpp
+++ b/tools/clang/lib/SPIRV/SpirvModule.cpp
@@ -39,9 +39,10 @@ void addDebugInfoToMap(
 SpirvModule::SpirvModule()
     : capabilities({}), extensions({}), extInstSets({}), memoryModel(nullptr),
       entryPoints({}), executionModes({}), moduleProcesses({}), decorations({}),
-      constants({}), variables({}), functions({}), debugOp({}), debugExpr({}),
-      debugSources({}), debugCompUnits({}), debugTypes({}), debugVariables({}),
-      debugLexicalScopes({}), debugInfo({}) {}
+      constants({}), variables({}), functions({}), debugNone(nullptr),
+      debugOp({}), debugExpr({}), debugSources({}), debugCompUnits({}),
+      debugTypes({}), debugVariables({}), debugLexicalScopes({}),
+      debugInfo({}) {}
 
 bool SpirvModule::invokeVisitorDebugLexicalScope(Visitor *visitor,
                                                  SpirvDebugInstruction *scope,
@@ -171,9 +172,15 @@ bool SpirvModule::invokeVisitorDebugInfo(Visitor *visitor, bool reverseOrder) {
       if (!debugInstruction->invokeVisitor(visitor))
         return false;
     }
+
+    if (debugNone)
+      debugNone->invokeVisitor(visitor);
   }
   // Traverse the regular order of a SPIR-V debug info.
   else {
+    if (debugNone)
+      debugNone->invokeVisitor(visitor);
+
     for (auto *opInfo : debugOp)
       if (!opInfo->invokeVisitor(visitor))
         return false;

--- a/tools/clang/lib/SPIRV/SpirvModule.cpp
+++ b/tools/clang/lib/SPIRV/SpirvModule.cpp
@@ -13,11 +13,191 @@
 
 namespace clang {
 namespace spirv {
+namespace {
+
+template <class T>
+void addDebugInfoToMap(
+    llvm::DenseMap<SpirvDebugInstruction *, std::vector<T *>> &map, T *info,
+    SpirvDebugInstruction *alt) {
+  auto *parent = info->getParent();
+  if (!parent)
+    parent = alt;
+
+  auto it = map.find(parent);
+  if (it != map.end()) {
+    it->second.push_back(info);
+    return;
+  }
+
+  std::vector<T *> vec;
+  vec.push_back(info);
+  map[parent] = vec;
+}
+
+} // end namespace
 
 SpirvModule::SpirvModule()
     : capabilities({}), extensions({}), extInstSets({}), memoryModel(nullptr),
       entryPoints({}), executionModes({}), moduleProcesses({}), decorations({}),
-      constants({}), variables({}), functions({}), debugInfo({}) {}
+      constants({}), variables({}), functions({}), debugOp({}), debugExpr({}),
+      debugSources({}), debugCompUnits({}), debugTypes({}), debugVariables({}),
+      debugLexicalScopes({}), debugInfo({}) {}
+
+bool SpirvModule::invokeVisitorDebugLexicalScope(Visitor *visitor,
+                                                 SpirvDebugInstruction *scope,
+                                                 bool reverseOrder) {
+  if (reverseOrder) {
+    {
+      auto it = debugLexicalScopes.find(scope);
+      if (it != debugLexicalScopes.end()) {
+        auto &children = it->second;
+        for (auto iter = children.rbegin(); iter != children.rend(); ++iter) {
+          if (!invokeVisitorDebugLexicalScope(visitor, *iter, reverseOrder))
+            return false;
+        }
+      }
+    }
+
+    {
+      auto it = debugVariables.find(scope);
+      if (it != debugVariables.end()) {
+        auto &varVec = it->second;
+        for (auto iter = varVec.rbegin(); iter != varVec.rend(); ++iter) {
+          auto *var = *iter;
+          if (!var->invokeVisitor(visitor))
+            return false;
+        }
+      }
+    }
+
+    {
+      auto it = debugTypes.find(scope);
+      if (it != debugTypes.end()) {
+        auto &typeVec = it->second;
+        for (auto iter = typeVec.rbegin(); iter != typeVec.rend(); ++iter) {
+          auto *type = *iter;
+          if (isa<SpirvDebugTypeComposite>(type)) {
+            if (!invokeVisitorDebugLexicalScope(visitor, type, reverseOrder))
+              return false;
+          } else {
+            if (!type->invokeVisitor(visitor))
+              return false;
+          }
+        }
+      }
+    }
+
+    if (!scope->invokeVisitor(visitor))
+      return false;
+  }
+  // Traverse the regular order of a SPIR-V debug info for lexical scope.
+  else {
+    if (!scope->invokeVisitor(visitor))
+      return false;
+
+    {
+      auto it = debugTypes.find(scope);
+      if (it != debugTypes.end()) {
+        auto &typeVec = it->second;
+        for (auto *type : typeVec) {
+          if (isa<SpirvDebugTypeComposite>(type)) {
+            if (!invokeVisitorDebugLexicalScope(visitor, type, reverseOrder))
+              return false;
+          } else {
+            if (!type->invokeVisitor(visitor))
+              return false;
+          }
+        }
+      }
+    }
+
+    {
+      auto it = debugVariables.find(scope);
+      if (it != debugVariables.end()) {
+        auto &varVec = it->second;
+        for (auto *var : varVec) {
+          if (!var->invokeVisitor(visitor))
+            return false;
+        }
+      }
+    }
+
+    {
+      auto it = debugLexicalScopes.find(scope);
+      if (it != debugLexicalScopes.end()) {
+        auto &children = it->second;
+        for (auto *child : children) {
+          if (!invokeVisitorDebugLexicalScope(visitor, child, reverseOrder))
+            return false;
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
+bool SpirvModule::invokeVisitorDebugInfo(Visitor *visitor, bool reverseOrder) {
+  if (reverseOrder) {
+    for (auto iter = debugInfo.rbegin(); iter != debugInfo.rend(); ++iter) {
+      auto *debugInstruction = *iter;
+      if (!debugInstruction->invokeVisitor(visitor))
+        return false;
+    }
+
+    for (auto iter = debugCompUnits.rbegin(); iter != debugCompUnits.rend();
+         ++iter) {
+      auto *debugInstruction = *iter;
+      if (!invokeVisitorDebugLexicalScope(visitor, debugInstruction,
+                                          reverseOrder))
+        return false;
+    }
+
+    for (auto iter = debugSources.rbegin(); iter != debugSources.rend();
+         ++iter) {
+      auto *debugInstruction = *iter;
+      if (!debugInstruction->invokeVisitor(visitor))
+        return false;
+    }
+
+    for (auto iter = debugExpr.rbegin(); iter != debugExpr.rend(); ++iter) {
+      auto *debugInstruction = *iter;
+      if (!debugInstruction->invokeVisitor(visitor))
+        return false;
+    }
+
+    for (auto iter = debugOp.rbegin(); iter != debugOp.rend(); ++iter) {
+      auto *debugInstruction = *iter;
+      if (!debugInstruction->invokeVisitor(visitor))
+        return false;
+    }
+  }
+  // Traverse the regular order of a SPIR-V debug info.
+  else {
+    for (auto *opInfo : debugOp)
+      if (!opInfo->invokeVisitor(visitor))
+        return false;
+
+    for (auto *exprInfo : debugExpr)
+      if (!exprInfo->invokeVisitor(visitor))
+        return false;
+
+    for (auto *srcInfo : debugSources)
+      if (!srcInfo->invokeVisitor(visitor))
+        return false;
+
+    for (auto *cuInfo : debugCompUnits) {
+      if (!invokeVisitorDebugLexicalScope(visitor, cuInfo, reverseOrder))
+        return false;
+    }
+
+    for (auto *debugInstruction : debugInfo)
+      if (!debugInstruction->invokeVisitor(visitor))
+        return false;
+  }
+
+  return true;
+}
 
 bool SpirvModule::invokeVisitor(Visitor *visitor, bool reverseOrder) {
   // Note: It is debatable whether reverse order of visiting the module should
@@ -40,11 +220,8 @@ bool SpirvModule::invokeVisitor(Visitor *visitor, bool reverseOrder) {
         return false;
     }
 
-    for (auto iter = debugInfo.rbegin(); iter != debugInfo.rend(); ++iter) {
-      auto *debugInstruction = *iter;
-      if (!debugInstruction->invokeVisitor(visitor))
-        return false;
-    }
+    if (!invokeVisitorDebugInfo(visitor, reverseOrder))
+      return false;
 
     for (auto iter = variables.rbegin(); iter != variables.rend(); ++iter) {
       auto *var = *iter;
@@ -73,9 +250,8 @@ bool SpirvModule::invokeVisitor(Visitor *visitor, bool reverseOrder) {
         return false;
     }
 
-    if (!debugSources.empty())
-      for (auto iter = debugSources.rbegin(); iter != debugSources.rend();
-           ++iter) {
+    if (!sources.empty())
+      for (auto iter = sources.rbegin(); iter != sources.rend(); ++iter) {
         auto *source = *iter;
         if (!source->invokeVisitor(visitor))
           return false;
@@ -144,8 +320,8 @@ bool SpirvModule::invokeVisitor(Visitor *visitor, bool reverseOrder) {
       if (!execMode->invokeVisitor(visitor))
         return false;
 
-    if (!debugSources.empty())
-      for (auto *source : debugSources)
+    if (!sources.empty())
+      for (auto *source : sources)
         if (!source->invokeVisitor(visitor))
           return false;
 
@@ -165,9 +341,8 @@ bool SpirvModule::invokeVisitor(Visitor *visitor, bool reverseOrder) {
       if (!var->invokeVisitor(visitor))
         return false;
 
-    for (auto debugInstruction : debugInfo)
-      if (!debugInstruction->invokeVisitor(visitor))
-        return false;
+    if (!invokeVisitorDebugInfo(visitor, reverseOrder))
+      return false;
 
     for (auto fn : functions)
       if (!fn->invokeVisitor(visitor, reverseOrder))
@@ -244,9 +419,58 @@ void SpirvModule::addConstant(SpirvConstant *constant) {
   constants.push_back(constant);
 }
 
-void SpirvModule::addDebugSource(SpirvSource *src) {
+void SpirvModule::addSource(SpirvSource *src) {
   assert(src);
-  debugSources.push_back(src);
+  sources.push_back(src);
+}
+
+void SpirvModule::addDebugInfo(SpirvDebugOperation *info) {
+  assert(info);
+  debugOp.push_back(info);
+}
+
+void SpirvModule::addDebugInfo(SpirvDebugExpression *info) {
+  assert(info);
+  debugExpr.push_back(info);
+}
+
+void SpirvModule::addDebugInfo(SpirvDebugSource *info) {
+  assert(info);
+  debugSources.push_back(info);
+}
+
+void SpirvModule::addDebugInfo(SpirvDebugCompilationUnit *info) {
+  assert(info);
+  debugCompUnits.push_back(info);
+}
+
+void SpirvModule::addDebugInfo(SpirvDebugType *type) {
+  assert(type);
+  addDebugInfoToMap<SpirvDebugType>(debugTypes, type, debugCompUnits[0]);
+}
+
+void SpirvModule::addDebugInfo(SpirvDebugGlobalVariable *info) {
+  assert(info);
+  addDebugInfoToMap<SpirvDebugInstruction>(debugVariables, info,
+                                           debugCompUnits[0]);
+}
+
+void SpirvModule::addDebugInfo(SpirvDebugFunction *info) {
+  assert(info);
+  addDebugInfoToMap<SpirvDebugInstruction>(debugLexicalScopes, info,
+                                           debugCompUnits[0]);
+}
+
+void SpirvModule::addDebugInfo(SpirvDebugLocalVariable *info) {
+  assert(info);
+  addDebugInfoToMap<SpirvDebugInstruction>(debugVariables, info,
+                                           debugCompUnits[0]);
+}
+
+void SpirvModule::addDebugInfo(SpirvDebugLexicalBlock *info) {
+  assert(info);
+  addDebugInfoToMap<SpirvDebugInstruction>(debugLexicalScopes, info,
+                                           debugCompUnits[0]);
 }
 
 void SpirvModule::addDebugInfo(SpirvDebugInstruction *info) {

--- a/tools/clang/lib/SPIRV/SpirvModule.cpp
+++ b/tools/clang/lib/SPIRV/SpirvModule.cpp
@@ -18,10 +18,10 @@ namespace {
 template <class T>
 void addDebugInfoToMap(
     llvm::DenseMap<SpirvDebugInstruction *, std::vector<T *>> &map, T *info,
-    SpirvDebugInstruction *alt) {
+    SpirvDebugInstruction *altParent) {
   auto *parent = info->getParent();
   if (!parent)
-    parent = alt;
+    parent = altParent;
 
   auto it = map.find(parent);
   if (it != map.end()) {

--- a/tools/clang/lib/SPIRV/SpirvType.cpp
+++ b/tools/clang/lib/SPIRV/SpirvType.cpp
@@ -169,9 +169,15 @@ bool RuntimeArrayType::operator==(const RuntimeArrayType &that) const {
 
 StructType::StructType(llvm::ArrayRef<StructType::FieldInfo> fieldsVec,
                        llvm::StringRef name, bool isReadOnly,
-                       StructInterfaceType iface)
+                       StructInterfaceType iface,
+                       llvm::Optional<const RecordDecl *> decl_)
     : SpirvType(TK_Struct, name), fields(fieldsVec.begin(), fieldsVec.end()),
-      readOnly(isReadOnly), interfaceType(iface) {}
+      readOnly(isReadOnly), interfaceType(iface) {
+  if (decl_.hasValue())
+    decl = *decl_;
+  else
+    decl = nullptr;
+}
 
 bool StructType::FieldInfo::
 operator==(const StructType::FieldInfo &that) const {

--- a/tools/clang/lib/SPIRV/SpirvType.cpp
+++ b/tools/clang/lib/SPIRV/SpirvType.cpp
@@ -169,15 +169,9 @@ bool RuntimeArrayType::operator==(const RuntimeArrayType &that) const {
 
 StructType::StructType(llvm::ArrayRef<StructType::FieldInfo> fieldsVec,
                        llvm::StringRef name, bool isReadOnly,
-                       StructInterfaceType iface,
-                       llvm::Optional<const RecordDecl *> decl_)
+                       StructInterfaceType iface)
     : SpirvType(TK_Struct, name), fields(fieldsVec.begin(), fieldsVec.end()),
-      readOnly(isReadOnly), interfaceType(iface) {
-  if (decl_.hasValue())
-    decl = *decl_;
-  else
-    decl = nullptr;
-}
+      readOnly(isReadOnly), interfaceType(iface) {}
 
 bool StructType::FieldInfo::
 operator==(const StructType::FieldInfo &that) const {

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debugdeclare.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debugdeclare.hlsl
@@ -1,0 +1,34 @@
+// Run: %dxc -T ps_6_0 -E main -fspv-debug=rich
+
+// TODO: FlagIsPublic is shown as FlagIsProtected|FlagIsPrivate.
+
+// CHECK:             [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
+
+// CHECK: [[color:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 28 20 {{%\d+}} FlagIsLocal 0
+// CHECK: [[condition:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 30 8 {{%\d+}} FlagIsLocal
+
+// CHECK: [[x:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 23 14 {{%\d+}} FlagIsLocal 0
+// CHECK: [[y:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 23 23 {{%\d+}} FlagIsLocal 1
+
+// CHECK:        %color = OpFunctionParameter
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugDeclare [[color]] %color
+// CHECK:      %condition = OpVariable
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugDeclare [[condition]] %condition
+
+// CHECK:            %x = OpFunctionParameter
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugDeclare [[x]] %x
+// CHECK:            %y = OpFunctionParameter
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugDeclare [[y]] %y
+
+void foo(int x, float y)
+{
+  x = x + y;
+}
+
+float4 main(float4 color : COLOR) : SV_TARGET
+{
+  bool condition = false;
+  foo(1, color.x);
+  return color;
+}
+

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debuglexicalblock.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debuglexicalblock.hlsl
@@ -4,26 +4,27 @@
 // CHECK:   [[debugSource:%\d+]] = OpExtInst %void [[debugSet]] DebugSource {{%\d+}} {{%\d+}}
 // CHECK:      [[compUnit:%\d+]] = OpExtInst %void [[debugSet]] DebugCompilationUnit 1 4 [[debugSource]] HLSL
 float4 main(float4 color : COLOR) : SV_TARGET
-// CHECK: [[mainFnLexBlock:%\d+]] = OpExtInst %void [[debugSet]] DebugLexicalBlock [[debugSource]] 8 1 [[compUnit]]
+// CHECK:          [[main:%\d+]] = OpExtInst %void [[debugSet]] DebugFunction {{%\d+}} {{%\d+}} [[debugSource]] 6 1 [[compUnit]] {{%\d+}} FlagIsProtected|FlagIsPrivate 9 %src_main
+// CHECK: [[mainFnLexBlock:%\d+]] = OpExtInst %void [[debugSet]] DebugLexicalBlock [[debugSource]] 9 1 [[main]]
 {
   float4 c = 0.xxxx;
-  // CHECK: [[forLoopLexBlock:%\d+]] = OpExtInst %void [[debugSet]] DebugLexicalBlock [[debugSource]] 11 12 [[mainFnLexBlock]]
+  // CHECK: [[forLoopLexBlock:%\d+]] = OpExtInst %void [[debugSet]] DebugLexicalBlock [[debugSource]] 12 12 [[mainFnLexBlock]]
   for (;;) {
     float4 a = 0.xxxx;
     float4 b = 1.xxxx;
     c = c + a + b;
   }
   while (c.x)
-  // CHECK: [[whileLoopLexBlock:%\d+]] = OpExtInst %void [[debugSet]] DebugLexicalBlock [[debugSource]] 18 3 [[mainFnLexBlock]]
+  // CHECK: [[whileLoopLexBlock:%\d+]] = OpExtInst %void [[debugSet]] DebugLexicalBlock [[debugSource]] 19 3 [[mainFnLexBlock]]
   {
     float4 a = 0.xxxx;
     float4 b = 1.xxxx;
     c = c + a + b;
 
-    // CHECK: [[ifStmtLexBlock:%\d+]] = OpExtInst %void [[debugSet]] DebugLexicalBlock [[debugSource]] 24 20 [[whileLoopLexBlock]]
+    // CHECK: [[ifStmtLexBlock:%\d+]] = OpExtInst %void [[debugSet]] DebugLexicalBlock [[debugSource]] 25 20 [[whileLoopLexBlock]]
     if (bool(c.x)) {
       c = c + c;
-      // CHECK: [[tempLexBlock:%\d+]] = OpExtInst %void [[debugSet]] DebugLexicalBlock [[debugSource]] 27 7 [[ifStmtLexBlock]]
+      // CHECK: [[tempLexBlock:%\d+]] = OpExtInst %void [[debugSet]] DebugLexicalBlock [[debugSource]] 28 7 [[ifStmtLexBlock]]
       {
         c = c + c;
       }

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debugscope.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debugscope.hlsl
@@ -1,0 +1,68 @@
+// Run: %dxc -T ps_6_0 -E main -fspv-debug=rich
+
+// CHECK:  [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
+// CHECK: [[compUnit:%\d+]] = OpExtInst %void [[set]] DebugCompilationUnit
+// CHECK: [[main:%\d+]] = OpExtInst %void [[set]] DebugFunction
+// CHECK: [[mainFnLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 18 1 [[main]]
+// CHECK: [[forLoopLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 26 12 [[mainFnLexBlock]]
+// CHECK: [[whileLoopLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 41 3 [[mainFnLexBlock]]
+// CHECK: [[ifStmtLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 48 20 [[whileLoopLexBlock]]
+// CHECK: [[tempLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 53 7 [[ifStmtLexBlock]]
+
+// CHECK:         %main = OpFunction
+// CHECK-NEXT: {{%\d+}} = OpLabel
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[compUnit]]
+float4 main(float4 color : COLOR) : SV_TARGET
+// CHECK:     %src_main = OpFunction
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[main]]
+{
+// CHECK:     %bb_entry = OpLabel
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[mainFnLexBlock]]
+
+  float4 c = 0.xxxx;
+
+// CHECK:    %for_check = OpLabel
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[mainFnLexBlock]]
+  for (;;) {
+// CHECK:     %for_body = OpLabel
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[forLoopLexBlock]]
+    float4 a = 0.xxxx;
+    float4 b = 1.xxxx;
+    c = c + a + b;
+// CHECK: %for_continue = OpLabel
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[mainFnLexBlock]]
+  }
+// CHECK:    %for_merge = OpLabel
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[mainFnLexBlock]]
+
+// CHECK:  %while_check = OpLabel
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[mainFnLexBlock]]
+  while (c.x)
+  {
+// CHECK:   %while_body = OpLabel
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[whileLoopLexBlock]]
+    float4 a = 0.xxxx;
+    float4 b = 1.xxxx;
+    c = c + a + b;
+
+    if (bool(c.x)) {
+// CHECK:      %if_true = OpLabel
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[ifStmtLexBlock]]
+      c = c + c;
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[tempLexBlock]]
+      {
+        c = c + c;
+      }
+    }
+// CHECK:     %if_merge = OpLabel
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[whileLoopLexBlock]]
+
+// CHECK:%while_continue = OpLabel
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[mainFnLexBlock]]
+  }
+// CHECK:  %while_merge = OpLabel
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[mainFnLexBlock]]
+
+  return color + c;
+}
+

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debugsource.multiple.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debugsource.multiple.hlsl
@@ -1,0 +1,36 @@
+// Run: %dxc -T ps_6_0 -E main -fspv-debug=rich
+
+// CHECK:      [[debugSet:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
+
+// CHECK: rich.debug.debugsource.multiple.hlsl
+// CHECK: spirv.debug.opline.include-file-2.hlsl
+// CHECK: spirv.debug.opline.include-file-3.hlsl
+// CHECK: spirv.debug.opline.include-file-1.hlsl
+
+// CHECK: {{%\d+}} = OpExtInst %void [[debugSet]] DebugSource {{%\d+}}
+// CHECK: {{%\d+}} = OpExtInst %void [[debugSet]] DebugSource {{%\d+}}
+// CHECK: {{%\d+}} = OpExtInst %void [[debugSet]] DebugSource {{%\d+}}
+
+#include "spirv.debug.opline.include-file-1.hlsl"
+
+int callFunction1() {
+  return function1();
+}
+
+#include "spirv.debug.opline.include-file-2.hlsl"
+
+int callFunction2() {
+  return function2();
+}
+
+#include "spirv.debug.opline.include-file-3.hlsl"
+
+int callFunction3() {
+  CALL_FUNCTION_3;
+}
+
+void main() {
+  callFunction1();
+  callFunction2();
+  callFunction3();
+}

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.function.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.function.hlsl
@@ -4,9 +4,7 @@
 
 // CHECK:             [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 // CHECK:        [[mainName:%\d+]] = OpString "src.main"
-// CHECK: [[mainLinkageName:%\d+]] = OpString "src.main"
 // CHECK:         [[fooName:%\d+]] = OpString "foo"
-// CHECK:  [[fooLinkageName:%\d+]] = OpString "foo"
 // CHECK:          [[source:%\d+]] = OpExtInst %void [[set]] DebugSource
 // CHECK: [[compilationUnit:%\d+]] = OpExtInst %void [[set]] DebugCompilationUnit
 
@@ -14,8 +12,8 @@
 //
 // Check DebugFunction instructions
 //
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[mainName]] [[mainFnType:%\d+]] [[source]] 31 1 [[compilationUnit]] [[mainLinkageName]] FlagIsProtected|FlagIsPrivate 32 %src_main
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[fooName]] [[fooFnType:%\d+]] [[source]] 26 1 [[compilationUnit]] [[fooLinkageName]] FlagIsProtected|FlagIsPrivate 27 %foo
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[mainName]] [[mainFnType:%\d+]] [[source]] 29 1 [[compilationUnit]] [[mainName]] FlagIsProtected|FlagIsPrivate 30 %src_main
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[fooName]] [[fooFnType:%\d+]] [[source]] 24 1 [[compilationUnit]] [[fooName]] FlagIsProtected|FlagIsPrivate 25 %foo
 
 // CHECK:  [[float:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Float
 // CHECK: [[float4:%\d+]] = OpExtInst %void [[set]] DebugTypeVector [[float]] 4

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.function.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.function.hlsl
@@ -9,18 +9,18 @@
 // CHECK: [[compilationUnit:%\d+]] = OpExtInst %void [[set]] DebugCompilationUnit
 
 
-//
-// Check DebugFunction instructions
-//
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[mainName]] [[mainFnType:%\d+]] [[source]] 29 1 [[compilationUnit]] [[mainName]] FlagIsProtected|FlagIsPrivate 30 %src_main
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[fooName]] [[fooFnType:%\d+]] [[source]] 24 1 [[compilationUnit]] [[fooName]] FlagIsProtected|FlagIsPrivate 25 %foo
-
 // CHECK:  [[float:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Float
 // CHECK: [[float4:%\d+]] = OpExtInst %void [[set]] DebugTypeVector [[float]] 4
-// CHECK:  [[mainFnType]] = OpExtInst %void [[set]] DebugTypeFunction FlagIsProtected|FlagIsPrivate [[float4]] [[float4]]
+// CHECK: [[mainFnType:%\d+]] = OpExtInst %void [[set]] DebugTypeFunction FlagIsProtected|FlagIsPrivate [[float4]] [[float4]]
 // CHECK:   [[bool:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Boolean
 // CHECK:    [[int:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Signed
-// CHECK:   [[fooFnType]] = OpExtInst %void [[set]] DebugTypeFunction FlagIsProtected|FlagIsPrivate %void [[int]] [[float]]
+// CHECK: [[fooFnType:%\d+]] = OpExtInst %void [[set]] DebugTypeFunction FlagIsProtected|FlagIsPrivate %void [[int]] [[float]]
+
+// Check DebugFunction instructions
+//
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[mainName]] [[mainFnType]] [[source]] 29 1 [[compilationUnit]] [[mainName]] FlagIsProtected|FlagIsPrivate 30 %src_main
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[fooName]] [[fooFnType]] [[source]] 24 1 [[compilationUnit]] [[fooName]] FlagIsProtected|FlagIsPrivate 25 %foo
+
 void foo(int x, float y)
 {
   x = x + y;

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.function.param.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.function.param.hlsl
@@ -1,0 +1,34 @@
+// Run: %dxc -T ps_6_0 -E main -fspv-debug=rich
+
+// TODO: FlagIsPublic is shown as FlagIsProtected|FlagIsPrivate.
+
+// CHECK:             [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
+// CHECK:        [[mainName:%\d+]] = OpString "src.main"
+// CHECK:           [[color:%\d+]] = OpString "color"
+// CHECK:         [[fooName:%\d+]] = OpString "foo"
+// CHECK:               [[x:%\d+]] = OpString "x"
+// CHECK:               [[y:%\d+]] = OpString "y"
+// CHECK:          [[source:%\d+]] = OpExtInst %void [[set]] DebugSource
+
+// CHECK:  [[float:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Float
+// CHECK: [[float4:%\d+]] = OpExtInst %void [[set]] DebugTypeVector [[float]] 4
+// CHECK:    [[int:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Signed
+
+// CHECK: [[main:%\d+]] = OpExtInst %void [[set]] DebugFunction [[mainName]] {{%\d+}} [[source]] 28 1 {{%\d+}} [[mainName]] FlagIsProtected|FlagIsPrivate 29 %src_main
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[color]] [[float4]] [[source]] 28 20 [[main]] FlagIsLocal 0
+// CHECK: [[foo:%\d+]] = OpExtInst %void [[set]] DebugFunction [[fooName]] {{%\d+}} [[source]] 23 1 {{%\d+}} [[fooName]] FlagIsProtected|FlagIsPrivate 24 %foo
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[x]] [[int]] [[source]] 23 14 [[foo]] FlagIsLocal 0
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[y]] [[float]] [[source]] 23 23 [[foo]] FlagIsLocal 1
+
+void foo(int x, float y)
+{
+  x = x + y;
+}
+
+float4 main(float4 color : COLOR) : SV_TARGET
+{
+  bool condition = false;
+  foo(1, color.x);
+  return color;
+}
+

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.function.parent.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.function.parent.hlsl
@@ -1,0 +1,48 @@
+// Run: %dxc -T ps_6_0 -E main -fspv-debug=rich
+
+// CHECK:      [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
+
+// CHECK: rich.debug.function.parent.hlsl
+// CHECK: spirv.debug.opline.include-file-2.hlsl
+// CHECK: spirv.debug.opline.include-file-3.hlsl
+// CHECK: spirv.debug.opline.include-file-1.hlsl
+
+// CHECK: [[f2:%\d+]] = OpString "function2"
+// CHECK: [[f3:%\d+]] = OpString "function3"
+// CHECK: [[f1:%\d+]] = OpString "function1"
+
+#include "spirv.debug.opline.include-file-1.hlsl"
+
+int callFunction1() {
+  return function1();
+}
+
+#include "spirv.debug.opline.include-file-2.hlsl"
+
+int callFunction2() {
+  return function2();
+}
+
+#include "spirv.debug.opline.include-file-3.hlsl"
+
+int callFunction3() {
+  CALL_FUNCTION_3;
+}
+
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugSource
+// CHECK: [[s2:%\d+]] = OpExtInst %void [[set]] DebugSource
+// CHECK: [[s3:%\d+]] = OpExtInst %void [[set]] DebugSource
+// CHECK: [[s1:%\d+]] = OpExtInst %void [[set]] DebugSource
+
+// CHECK: [[c2:%\d+]] = OpExtInst %void [[set]] DebugCompilationUnit 1 4 [[s2]] HLSL
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[f2]] {{%\d+}} [[s2]] 2 1 [[c2]]
+// CHECK: [[c3:%\d+]] = OpExtInst %void [[set]] DebugCompilationUnit 1 4 [[s3]] HLSL
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[f3]] {{%\d+}} [[s3]] 3 1 [[c3]]
+// CHECK: [[c1:%\d+]] = OpExtInst %void [[set]] DebugCompilationUnit 1 4 [[s1]] HLSL
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[f1]] {{%\d+}} [[s1]] 1 1 [[c1]]
+
+void main() {
+  callFunction1();
+  callFunction2();
+  callFunction3();
+}

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.global-variable.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.global-variable.hlsl
@@ -1,0 +1,36 @@
+// Run: %dxc -T ps_6_2 -E main -fspv-debug=rich -enable-16bit-types
+
+// CHECK:         [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
+// CHECK:    [[varNameC:%\d+]] = OpString "c"
+// CHECK: [[varNameCond:%\d+]] = OpString "cond"
+
+// CHECK:      [[source:%\d+]] = OpExtInst %void [[set]] DebugSource {{%\d+}} {{%\d+}}
+// CHECK: [[compileUnit:%\d+]] = OpExtInst %void [[set]] DebugCompilationUnit 1 4 [[source]] HLSL
+
+// CHECK: [[floatType:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Float
+// CHECK: [[float4Type:%\d+]] = OpExtInst %void [[set]] DebugTypeVector [[floatType]] 4
+// CHECK:  [[boolType:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Boolean
+
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugGlobalVariable [[varNameC]] [[float4Type]] [[source]] 17 15 [[compileUnit]] [[varNameC]] %c FlagIsDefinition
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugGlobalVariable [[varNameCond]] [[boolType]] [[source]] 18 13 [[compileUnit]] [[varNameCond]] %cond FlagIsDefinition
+
+static float4 c;
+static bool cond;
+
+float4 main(float4 color : COLOR) : SV_TARGET {
+  c = 0.xxxx;
+  cond = c.x == 0;
+
+  if (cond) {
+    int a = 2;
+    c = c + c;
+    {
+      uint b = 3;
+      c = c + c;
+    }
+  }
+
+  return color + c;
+}
+
+

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.local-variable.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.local-variable.hlsl
@@ -14,8 +14,9 @@
 // CHECK:  [[boolType:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Boolean
 // CHECK:   [[intType:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Signed
 // CHECK:  [[uintType:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Unsigned
+// CHECK:      [[main:%\d+]] = OpExtInst %void [[set]] DebugFunction {{%\d+}} {{%\d+}} [[source]] 29 1 [[compileUnit]] {{%\d+}} FlagIsProtected|FlagIsPrivate 29 %src_main
 
-// CHECK: [[mainFnLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock [[source]] 29 1 [[compileUnit]]
+// CHECK: [[mainFnLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock [[source]] 29 47 [[main]]
 // CHECK:                {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[varNameC]] [[float4Type]] [[source]] 30 10 [[mainFnLexBlock]] FlagIsLocal
 // CHECK:                {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[varNameCond]] [[boolType]] [[source]] 31 8 [[mainFnLexBlock]] FlagIsLocal
 
@@ -25,8 +26,7 @@
 // CHECK: [[tempLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock [[source]] 37 5 [[ifLexBlock]]
 // CHECK:              {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[varNameB]] [[uintType]] [[source]] 38 12 [[tempLexBlock]] FlagIsLocal
 
-float4 main(float4 color : COLOR) : SV_TARGET
-{
+float4 main(float4 color : COLOR) : SV_TARGET {
   float4 c = 0.xxxx;
   bool cond = c.x == 0;
 

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.local-variable.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.local-variable.hlsl
@@ -6,7 +6,7 @@
 // CHECK:    [[varNameA:%\d+]] = OpString "a"
 // CHECK:    [[varNameB:%\d+]] = OpString "b"
 
-// CHECK:      [[source:%\d+]] = OpExtInst %void [[set]] DebugSource %18 %19
+// CHECK:      [[source:%\d+]] = OpExtInst %void [[set]] DebugSource {{%\d+}} {{%\d+}}
 // CHECK: [[compileUnit:%\d+]] = OpExtInst %void [[set]] DebugCompilationUnit 1 4 [[source]] HLSL
 
 // CHECK: [[mainFnLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock [[source]] 29 1 [[compileUnit]]

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.local-variable.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.local-variable.hlsl
@@ -9,21 +9,21 @@
 // CHECK:      [[source:%\d+]] = OpExtInst %void [[set]] DebugSource {{%\d+}} {{%\d+}}
 // CHECK: [[compileUnit:%\d+]] = OpExtInst %void [[set]] DebugCompilationUnit 1 4 [[source]] HLSL
 
+// CHECK: [[floatType:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Float
+// CHECK: [[float4Type:%\d+]] = OpExtInst %void [[set]] DebugTypeVector [[floatType]] 4
+// CHECK:  [[boolType:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Boolean
+// CHECK:   [[intType:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Signed
+// CHECK:  [[uintType:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Unsigned
+
 // CHECK: [[mainFnLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock [[source]] 29 1 [[compileUnit]]
-// CHECK:                {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[varNameC]] [[float4Type:%\d+]] [[source]] 30 10 [[mainFnLexBlock]] FlagIsLocal
-// CHECK:                {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[varNameCond]] [[boolType:%\d+]] [[source]] 31 8 [[mainFnLexBlock]] FlagIsLocal
+// CHECK:                {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[varNameC]] [[float4Type]] [[source]] 30 10 [[mainFnLexBlock]] FlagIsLocal
+// CHECK:                {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[varNameCond]] [[boolType]] [[source]] 31 8 [[mainFnLexBlock]] FlagIsLocal
 
 // CHECK: [[ifLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock [[source]] 34 13 [[mainFnLexBlock]]
-// CHECK:            {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[varNameA]] [[intType:%\d+]] [[source]] 35 9 [[ifLexBlock]] FlagIsLocal
+// CHECK:            {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[varNameA]] [[intType]] [[source]] 35 9 [[ifLexBlock]] FlagIsLocal
 
 // CHECK: [[tempLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock [[source]] 37 5 [[ifLexBlock]]
-// CHECK:              {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[varNameB]] [[uintType:%\d+]] [[source]] 38 12 [[tempLexBlock]] FlagIsLocal
-
-// CHECK: [[floatType:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Float
-// CHECK:     [[float4Type]] = OpExtInst %void [[set]] DebugTypeVector [[floatType]] 4
-// CHECK:       [[boolType]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Boolean
-// CHECK:        [[intType]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Signed
-// CHECK:       [[uintType]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Unsigned
+// CHECK:              {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[varNameB]] [[uintType]] [[source]] 38 12 [[tempLexBlock]] FlagIsLocal
 
 float4 main(float4 color : COLOR) : SV_TARGET
 {

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.structured-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.structured-buffer.hlsl
@@ -1,0 +1,58 @@
+// Run: %dxc -T ps_6_0 -E main -fspv-reflect
+
+// CHECK: OpExtension "SPV_GOOGLE_hlsl_functionality1"
+
+// CHECK: OpName %type_StructuredBuffer_S "type.StructuredBuffer.S"
+// CHECK: OpName %type_StructuredBuffer_T "type.StructuredBuffer.T"
+
+// CHECK: OpName %type_RWStructuredBuffer_S "type.RWStructuredBuffer.S"
+// CHECK: OpName %type_RWStructuredBuffer_T "type.RWStructuredBuffer.T"
+
+// CHECK: OpDecorateId %mySBuffer3 CounterBuffer %counter_var_mySBuffer3
+// CHECK: OpDecorateId %mySBuffer4 CounterBuffer %counter_var_mySBuffer4
+
+// CHECK: %S = OpTypeStruct %float %v3float %mat2v3float
+// CHECK: %_runtimearr_S = OpTypeRuntimeArray %S
+// CHECK: %type_StructuredBuffer_S = OpTypeStruct %_runtimearr_S
+// CHECK: %_ptr_Uniform_type_StructuredBuffer_S = OpTypePointer Uniform %type_StructuredBuffer_S
+struct S {
+    float  a;
+    float3 b;
+    int2 c;
+};
+
+// CHECK: %T = OpTypeStruct %_arr_float_uint_3 %_arr_v3float_uint_4 %_arr_S_uint_3 %_arr_mat3v2float_uint_4
+// CHECK: %_runtimearr_T = OpTypeRuntimeArray %T
+// CHECK: %type_StructuredBuffer_T = OpTypeStruct %_runtimearr_T
+// CHECK: %_ptr_Uniform_type_StructuredBuffer_T = OpTypePointer Uniform %type_StructuredBuffer_T
+
+// CHECK: %type_RWStructuredBuffer_S = OpTypeStruct %_runtimearr_S
+// CHECK: %_ptr_Uniform_type_RWStructuredBuffer_S = OpTypePointer Uniform %type_RWStructuredBuffer_S
+
+// CHECK: %type_ACSBuffer_counter = OpTypeStruct %int
+// CHECK: %_ptr_Uniform_type_ACSBuffer_counter = OpTypePointer Uniform %type_ACSBuffer_counter
+
+// CHECK: %type_RWStructuredBuffer_T = OpTypeStruct %_runtimearr_T
+// CHECK: %_ptr_Uniform_type_RWStructuredBuffer_T = OpTypePointer Uniform %type_RWStructuredBuffer_T
+struct T {
+    float  a;
+    float3 b;
+    S      c;
+    int2   d;
+};
+
+// CHECK: %mySBuffer1 = OpVariable %_ptr_Uniform_type_StructuredBuffer_S Uniform
+StructuredBuffer<S> mySBuffer1 : register(t1);
+// CHECK: %mySBuffer2 = OpVariable %_ptr_Uniform_type_StructuredBuffer_T Uniform
+StructuredBuffer<T> mySBuffer2 : register(t2);
+
+// CHECK: %mySBuffer3 = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_S Uniform
+// CHECK: %counter_var_mySBuffer3 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
+RWStructuredBuffer<S> mySBuffer3 : register(u3);
+// CHECK: %mySBuffer4 = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_T Uniform
+// CHECK: %counter_var_mySBuffer4 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
+RWStructuredBuffer<T> mySBuffer4 : register(u4);
+
+float4 main() : SV_Target {
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.structured-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.structured-buffer.hlsl
@@ -1,39 +1,11 @@
-// Run: %dxc -T ps_6_0 -E main -fspv-reflect
+// Run: %dxc -T ps_6_0 -E main -fspv-debug=rich
 
-// CHECK: OpExtension "SPV_GOOGLE_hlsl_functionality1"
-
-// CHECK: OpName %type_StructuredBuffer_S "type.StructuredBuffer.S"
-// CHECK: OpName %type_StructuredBuffer_T "type.StructuredBuffer.T"
-
-// CHECK: OpName %type_RWStructuredBuffer_S "type.RWStructuredBuffer.S"
-// CHECK: OpName %type_RWStructuredBuffer_T "type.RWStructuredBuffer.T"
-
-// CHECK: OpDecorateId %mySBuffer3 CounterBuffer %counter_var_mySBuffer3
-// CHECK: OpDecorateId %mySBuffer4 CounterBuffer %counter_var_mySBuffer4
-
-// CHECK: %S = OpTypeStruct %float %v3float %mat2v3float
-// CHECK: %_runtimearr_S = OpTypeRuntimeArray %S
-// CHECK: %type_StructuredBuffer_S = OpTypeStruct %_runtimearr_S
-// CHECK: %_ptr_Uniform_type_StructuredBuffer_S = OpTypePointer Uniform %type_StructuredBuffer_S
 struct S {
     float  a;
     float3 b;
     int2 c;
 };
 
-// CHECK: %T = OpTypeStruct %_arr_float_uint_3 %_arr_v3float_uint_4 %_arr_S_uint_3 %_arr_mat3v2float_uint_4
-// CHECK: %_runtimearr_T = OpTypeRuntimeArray %T
-// CHECK: %type_StructuredBuffer_T = OpTypeStruct %_runtimearr_T
-// CHECK: %_ptr_Uniform_type_StructuredBuffer_T = OpTypePointer Uniform %type_StructuredBuffer_T
-
-// CHECK: %type_RWStructuredBuffer_S = OpTypeStruct %_runtimearr_S
-// CHECK: %_ptr_Uniform_type_RWStructuredBuffer_S = OpTypePointer Uniform %type_RWStructuredBuffer_S
-
-// CHECK: %type_ACSBuffer_counter = OpTypeStruct %int
-// CHECK: %_ptr_Uniform_type_ACSBuffer_counter = OpTypePointer Uniform %type_ACSBuffer_counter
-
-// CHECK: %type_RWStructuredBuffer_T = OpTypeStruct %_runtimearr_T
-// CHECK: %_ptr_Uniform_type_RWStructuredBuffer_T = OpTypePointer Uniform %type_RWStructuredBuffer_T
 struct T {
     float  a;
     float3 b;
@@ -41,17 +13,37 @@ struct T {
     int2   d;
 };
 
-// CHECK: %mySBuffer1 = OpVariable %_ptr_Uniform_type_StructuredBuffer_S Uniform
 StructuredBuffer<S> mySBuffer1 : register(t1);
-// CHECK: %mySBuffer2 = OpVariable %_ptr_Uniform_type_StructuredBuffer_T Uniform
 StructuredBuffer<T> mySBuffer2 : register(t2);
 
-// CHECK: %mySBuffer3 = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_S Uniform
-// CHECK: %counter_var_mySBuffer3 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
 RWStructuredBuffer<S> mySBuffer3 : register(u3);
-// CHECK: %mySBuffer4 = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_T Uniform
-// CHECK: %counter_var_mySBuffer4 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
 RWStructuredBuffer<T> mySBuffer4 : register(u4);
+
+// CHECK: [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
+// CHECK: [[S:%\d+]] = OpString "S"
+// CHECK: [[SB_S:%\d+]] = OpString "@type.StructuredBuffer.S"
+// CHECK: [[T:%\d+]] = OpString "T"
+// CHECK: [[SB_T:%\d+]] = OpString "@type.StructuredBuffer.T"
+// CHECK: [[RW_S:%\d+]] = OpString "@type.RWStructuredBuffer.S"
+// CHECK: [[RW_T:%\d+]] = OpString "@type.RWStructuredBuffer.T"
+// CHECK: [[temp0:%\d+]] = OpString "StructuredBuffer.TemplateParam"
+// CHECK: [[temp1:%\d+]] = OpString "RWStructuredBuffer.TemplateParam"
+
+// CHECK: [[S_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[S]] Structure
+// CHECK: [[SB_S_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[SB_S]] Class
+// CHECK: [[T_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[T]] Structure
+// CHECK: [[SB_T_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[SB_T]] Class
+// CHECK: [[RW_S_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[RW_S]] Class
+// CHECK: [[RW_T_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[RW_T]] Class
+
+// CHECK: [[param0:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[temp0]] [[S_ty]]
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugTypeTemplate [[SB_S_ty]] [[param0]]
+// CHECK: [[param1:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[temp0]] [[T_ty]]
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugTypeTemplate [[SB_T_ty]] [[param1]]
+// CHECK: [[param2:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[temp1]] [[S_ty]]
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugTypeTemplate [[RW_S_ty]] [[param2]]
+// CHECK: [[param3:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[temp1]] [[T_ty]]
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugTypeTemplate [[RW_T_ty]] [[param3]]
 
 float4 main() : SV_Target {
     return 1.0;

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.type.array.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.type.array.hlsl
@@ -1,0 +1,21 @@
+// Run: %dxc -T ps_6_0 -E main -fspv-debug=rich
+
+// CHECK:       [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
+// CHECK:  [[uintName:%\d+]] = OpString "uint"
+// CHECK:   [[intName:%\d+]] = OpString "int"
+// CHECK: [[floatName:%\d+]] = OpString "float"
+// CHECK:           %uint_32 = OpConstant %uint 32
+
+void main() {
+    const uint size = 4 * 3 - 4;
+
+// CHECK:  [[uint:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic [[uintName]] %uint_32 Unsigned
+// CHECK:       {{%\d+}} = OpExtInst %void [[set]] DebugTypeArray [[uint]] %uint_4
+    uint  x[4];
+// CHECK:   [[int:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic [[intName]] %uint_32 Signed
+// CHECK:       {{%\d+}} = OpExtInst %void [[set]] DebugTypeArray [[int]] %uint_8
+    int   y[size];
+// CHECK: [[float:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic [[floatName]] %uint_32 Float
+// CHECK:       {{%\d+}} = OpExtInst %void [[set]] DebugTypeArray [[float]] %uint_8 %uint_4
+    float z[size][4];
+}

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.type.composite.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.type.composite.hlsl
@@ -1,0 +1,39 @@
+// Run: %dxc -T ps_6_0 -E main -fspv-debug=rich
+
+struct foo {
+  int a;
+
+  void func0(float arg) {
+    b.x = arg;
+  }
+
+  float4 b;
+
+  int func1(int arg0, float arg1, bool arg2) {
+    a = arg0;
+    b.y = arg1;
+    if (arg2) return arg0;
+    return b.z;
+  }
+
+  bool c;
+};
+
+// CHECK: [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
+// CHECK: [[foo:%\d+]] = OpString "foo"
+// CHECK: [[a_name:%\d+]] = OpString "a"
+// CHECK: [[b_name:%\d+]] = OpString "b"
+// CHECK: [[c_name:%\d+]] = OpString "c"
+
+// CHECK: OpExtInst %void [[set]] DebugTypeComposite [[foo]] Structure {{%\d+}} 3 1 {{%\d+}} {{%\d+}} %uint_192 FlagIsProtected|FlagIsPrivate [[a:%\d+]] [[b:%\d+]] [[c:%\d+]]
+// CHECK: [[a]] = OpExtInst %void [[set]] DebugTypeMember [[a_name]]
+// CHECK: [[b]] = OpExtInst %void [[set]] DebugTypeMember [[b_name]]
+// CHECK: [[c]] = OpExtInst %void [[set]] DebugTypeMember [[c_name]]
+
+float4 main(float4 color : COLOR) : SV_TARGET {
+  foo a;
+  a.func0(1);
+  a.func1(1, 1, 1);
+
+  return color;
+}

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.type.composite.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.type.composite.hlsl
@@ -27,9 +27,9 @@ struct foo {
 // CHECK: [[b_name:%\d+]] = OpString "b"
 // CHECK: [[c_name:%\d+]] = OpString "c"
 
-// CHECK: OpExtInst %void [[set]] DebugTypeComposite [[foo]] Structure {{%\d+}} 3 1 {{%\d+}} {{%\d+}} %uint_192 FlagIsProtected|FlagIsPrivate [[a:%\d+]] [[f0:%\d+]] [[b:%\d+]] [[f1:%\d+]] [[c:%\d+]]
-// CHECK: [[f0]] = OpExtInst %void [[set]] DebugFunction [[func0]] {{%\d+}} {{%\d+}} 6 3 {{%\d+}} {{%\d+}} FlagIsProtected|FlagIsPrivate 6 %foo_func0
-// CHECK: [[f1]] = OpExtInst %void [[set]] DebugFunction [[func1]] {{%\d+}} {{%\d+}} 12 3 {{%\d+}} {{%\d+}} FlagIsProtected|FlagIsPrivate 12 %foo_func1
+// CHECK: [[parent:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[foo]] Structure {{%\d+}} 3 1 {{%\d+}} {{%\d+}} %uint_192 FlagIsProtected|FlagIsPrivate [[a:%\d+]] [[f0:%\d+]] [[b:%\d+]] [[f1:%\d+]] [[c:%\d+]]
+// CHECK: [[f0]] = OpExtInst %void [[set]] DebugFunction [[func0]] {{%\d+}} {{%\d+}} 6 3 [[parent]] {{%\d+}} FlagIsProtected|FlagIsPrivate 6 %foo_func0
+// CHECK: [[f1]] = OpExtInst %void [[set]] DebugFunction [[func1]] {{%\d+}} {{%\d+}} 12 3 [[parent]] {{%\d+}} FlagIsProtected|FlagIsPrivate 12 %foo_func1
 // CHECK: [[a]] = OpExtInst %void [[set]] DebugTypeMember [[a_name]]
 // CHECK: [[b]] = OpExtInst %void [[set]] DebugTypeMember [[b_name]]
 // CHECK: [[c]] = OpExtInst %void [[set]] DebugTypeMember [[c_name]]

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.type.composite.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.type.composite.hlsl
@@ -22,10 +22,14 @@ struct foo {
 // CHECK: [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 // CHECK: [[foo:%\d+]] = OpString "foo"
 // CHECK: [[a_name:%\d+]] = OpString "a"
+// CHECK: [[func0:%\d+]] = OpString "foo.func0"
+// CHECK: [[func1:%\d+]] = OpString "foo.func1"
 // CHECK: [[b_name:%\d+]] = OpString "b"
 // CHECK: [[c_name:%\d+]] = OpString "c"
 
-// CHECK: OpExtInst %void [[set]] DebugTypeComposite [[foo]] Structure {{%\d+}} 3 1 {{%\d+}} {{%\d+}} %uint_192 FlagIsProtected|FlagIsPrivate [[a:%\d+]] [[b:%\d+]] [[c:%\d+]]
+// CHECK: OpExtInst %void [[set]] DebugTypeComposite [[foo]] Structure {{%\d+}} 3 1 {{%\d+}} {{%\d+}} %uint_192 FlagIsProtected|FlagIsPrivate [[a:%\d+]] [[f0:%\d+]] [[b:%\d+]] [[f1:%\d+]] [[c:%\d+]]
+// CHECK: [[f0]] = OpExtInst %void [[set]] DebugFunction [[func0]] {{%\d+}} {{%\d+}} 6 3 {{%\d+}} {{%\d+}} FlagIsProtected|FlagIsPrivate 6 %foo_func0
+// CHECK: [[f1]] = OpExtInst %void [[set]] DebugFunction [[func1]] {{%\d+}} {{%\d+}} 12 3 {{%\d+}} {{%\d+}} FlagIsProtected|FlagIsPrivate 12 %foo_func1
 // CHECK: [[a]] = OpExtInst %void [[set]] DebugTypeMember [[a_name]]
 // CHECK: [[b]] = OpExtInst %void [[set]] DebugTypeMember [[b_name]]
 // CHECK: [[c]] = OpExtInst %void [[set]] DebugTypeMember [[c_name]]

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.type.matrix.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.type.matrix.hlsl
@@ -1,0 +1,13 @@
+// Run: %dxc -T ps_6_0 -E main -fspv-debug=rich
+
+// NOTE: The current debug info extension (OpenCL.DebugInfo.100
+// Information Extended Instruction Set) does not support a matrix
+// type. To avoid a crash from matrix type, we temporarily emit a
+// debug array type for it. This test checks only that it runs
+// without a crash.
+
+// CHECK: {{%\d+}} = OpExtInst %void {{%\d+}} DebugTypeBasic {{%\d+}} %uint_32 Float
+
+void main() {
+   float3x4 mat;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2213,6 +2213,10 @@ TEST_F(FileTest, RichDebugInfoTypeVector) {
   runFileTest("rich.debug.type.vector.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
+TEST_F(FileTest, RichDebugInfoTypeArray) {
+  runFileTest("rich.debug.type.array.hlsl", Expect::Success,
+              /*runValidation*/ runValidationForRichDebugInfo);
+}
 TEST_F(FileTest, RichDebugInfoTypeFunction) {
   runFileTest("rich.debug.type.function.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2213,6 +2213,10 @@ TEST_F(FileTest, RichDebugInfoTypeVector) {
   runFileTest("rich.debug.type.vector.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
+TEST_F(FileTest, RichDebugInfoTypeMatrix) {
+  runFileTest("rich.debug.type.matrix.hlsl", Expect::Success,
+              /*runValidation*/ runValidationForRichDebugInfo);
+}
 TEST_F(FileTest, RichDebugInfoTypeArray) {
   runFileTest("rich.debug.type.array.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2221,6 +2221,10 @@ TEST_F(FileTest, RichDebugInfoTypeComposite) {
   runFileTest("rich.debug.type.composite.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
+TEST_F(FileTest, RichDebugInfoTypeStructuredBuffer) {
+  runFileTest("rich.debug.structured-buffer.hlsl", Expect::Success,
+              /*runValidation*/ runValidationForRichDebugInfo);
+}
 TEST_F(FileTest, RichDebugInfoLocalVariable) {
   runFileTest("rich.debug.local-variable.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2225,6 +2225,10 @@ TEST_F(FileTest, RichDebugInfoLocalVariable) {
   runFileTest("rich.debug.local-variable.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
+TEST_F(FileTest, RichDebugInfoGlobalVariable) {
+  runFileTest("rich.debug.global-variable.hlsl", Expect::Success,
+              /*runValidation*/ runValidationForRichDebugInfo);
+}
 TEST_F(FileTest, RichDebugInfoFunction) {
   runFileTest("rich.debug.function.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2183,7 +2183,7 @@ TEST_F(FileTest, MeshShadingNVAmplificationError4) {
 // TODO: change |runValidation| parameter back to 'true' once the following bug
 // has been fixed in SPIRV-Tools:
 // https://github.com/KhronosGroup/SPIRV-Tools/issues/3086
-const bool runValidationForRichDebugInfo = false;
+const bool runValidationForRichDebugInfo = true;
 
 TEST_F(FileTest, RichDebugInfoDebugSource) {
   runFileTest("rich.debug.debugsource.hlsl", Expect::Success,

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2223,5 +2223,9 @@ TEST_F(FileTest, RichDebugInfoFunction) {
   runFileTest("rich.debug.function.hlsl", Expect::Success,
               /*runValidation*/ false);
 }
+TEST_F(FileTest, RichDebugInfoDebugSourceMultiple) {
+  runFileTest("rich.debug.debugsource.multiple.hlsl", Expect::Success,
+              /*runValidation*/ false);
+}
 
 } // namespace

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2183,7 +2183,7 @@ TEST_F(FileTest, MeshShadingNVAmplificationError4) {
 // TODO: change |runValidation| parameter back to 'true' once the following bug
 // has been fixed in SPIRV-Tools:
 // https://github.com/KhronosGroup/SPIRV-Tools/issues/3086
-const bool runValidationForRichDebugInfo = true;
+const bool runValidationForRichDebugInfo = false;
 
 TEST_F(FileTest, RichDebugInfoDebugSource) {
   runFileTest("rich.debug.debugsource.hlsl", Expect::Success,

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2223,6 +2223,10 @@ TEST_F(FileTest, RichDebugInfoFunction) {
   runFileTest("rich.debug.function.hlsl", Expect::Success,
               /*runValidation*/ false);
 }
+TEST_F(FileTest, RichDebugInfoFunctionParam) {
+  runFileTest("rich.debug.function.param.hlsl", Expect::Success,
+              /*runValidation*/ false);
+}
 TEST_F(FileTest, RichDebugInfoDebugSourceMultiple) {
   runFileTest("rich.debug.debugsource.multiple.hlsl", Expect::Success,
               /*runValidation*/ false);

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2237,5 +2237,9 @@ TEST_F(FileTest, RichDebugInfoDeclare) {
   runFileTest("rich.debug.debugdeclare.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
+TEST_F(FileTest, RichDebugInfoScope) {
+  runFileTest("rich.debug.debugscope.hlsl", Expect::Success,
+              /*runValidation*/ runValidationForRichDebugInfo);
+}
 
 } // namespace

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2183,53 +2183,59 @@ TEST_F(FileTest, MeshShadingNVAmplificationError4) {
 // TODO: change |runValidation| parameter back to 'true' once the following bug
 // has been fixed in SPIRV-Tools:
 // https://github.com/KhronosGroup/SPIRV-Tools/issues/3086
+const bool runValidationForRichDebugInfo = false;
+
 TEST_F(FileTest, RichDebugInfoDebugSource) {
   runFileTest("rich.debug.debugsource.hlsl", Expect::Success,
-              /*runValidation*/ false);
+              /*runValidation*/ runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoDebugCompilationUnit) {
   runFileTest("rich.debug.debugcompilationunit.hlsl", Expect::Success,
-              /*runValidation*/ false);
+              /*runValidation*/ runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoDebugLexicalBlock) {
   runFileTest("rich.debug.debuglexicalblock.hlsl", Expect::Success,
-              /*runValidation*/ false);
+              /*runValidation*/ runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoTypeBool) {
   runFileTest("rich.debug.type.bool.hlsl", Expect::Success,
-              /*runValidation*/ false);
+              /*runValidation*/ runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoTypeInt) {
   runFileTest("rich.debug.type.int.hlsl", Expect::Success,
-              /*runValidation*/ false);
+              /*runValidation*/ runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoTypeFloat) {
   runFileTest("rich.debug.type.float.hlsl", Expect::Success,
-              /*runValidation*/ false);
+              /*runValidation*/ runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoTypeVector) {
   runFileTest("rich.debug.type.vector.hlsl", Expect::Success,
-              /*runValidation*/ false);
+              /*runValidation*/ runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoTypeFunction) {
   runFileTest("rich.debug.type.function.hlsl", Expect::Success,
-              /*runValidation*/ false);
+              /*runValidation*/ runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoLocalVariable) {
   runFileTest("rich.debug.local-variable.hlsl", Expect::Success,
-              /*runValidation*/ false);
+              /*runValidation*/ runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoFunction) {
   runFileTest("rich.debug.function.hlsl", Expect::Success,
-              /*runValidation*/ false);
+              /*runValidation*/ runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoFunctionParam) {
   runFileTest("rich.debug.function.param.hlsl", Expect::Success,
-              /*runValidation*/ false);
+              /*runValidation*/ runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoDebugSourceMultiple) {
   runFileTest("rich.debug.debugsource.multiple.hlsl", Expect::Success,
-              /*runValidation*/ false);
+              /*runValidation*/ runValidationForRichDebugInfo);
+}
+TEST_F(FileTest, RichDebugInfoDeclare) {
+  runFileTest("rich.debug.debugdeclare.hlsl", Expect::Success,
+              /*runValidation*/ runValidationForRichDebugInfo);
 }
 
 } // namespace

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2217,6 +2217,10 @@ TEST_F(FileTest, RichDebugInfoTypeFunction) {
   runFileTest("rich.debug.type.function.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
+TEST_F(FileTest, RichDebugInfoTypeComposite) {
+  runFileTest("rich.debug.type.composite.hlsl", Expect::Success,
+              /*runValidation*/ runValidationForRichDebugInfo);
+}
 TEST_F(FileTest, RichDebugInfoLocalVariable) {
   runFileTest("rich.debug.local-variable.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2245,6 +2245,10 @@ TEST_F(FileTest, RichDebugInfoFunction) {
   runFileTest("rich.debug.function.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
+TEST_F(FileTest, RichDebugInfoFunctionParent) {
+  runFileTest("rich.debug.function.parent.hlsl", Expect::Success,
+              /*runValidation*/ runValidationForRichDebugInfo);
+}
 TEST_F(FileTest, RichDebugInfoFunctionParam) {
   runFileTest("rich.debug.function.param.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);


### PR DESCRIPTION
Parent of a member function in a struct must be the struct.
Parent of a function must be a lexical scope where the function
is defined, not a lexical scope where the function is called.