### PR TITLE
[spirv] reduce number of emitted OpLine

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvFunction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvFunction.h
@@ -99,6 +99,9 @@ public:
   SpirvDebugScope *getDebugScope() const { return debugScope; }
   void setDebugScope(SpirvDebugScope *scope) { debugScope = scope; }
 
+  bool isEntryFunctionWrapper() const { return isWrapperOfEntry; }
+  void setEntryFunctionWrapper() { isWrapperOfEntry = true; }
+
   /// Returns true if this is a member function of a struct or class.
   bool isMemberFunction() const {
     if (parameters.empty())
@@ -142,7 +145,10 @@ private:
   /// Basic blocks inside this function.
   std::vector<SpirvBasicBlock *> basicBlocks;
 
-  /// DebugScope that groups all instructions in this basic block.
+  /// True if it is a wrapper function for an entry point function.
+  bool isWrapperOfEntry;
+
+  /// DebugScope that groups all instructions in this function.
   SpirvDebugScope *debugScope;
 };
 

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -136,7 +136,11 @@ void EmitVisitor::emitDebugNameForInstruction(uint32_t resultId,
 
 void EmitVisitor::emitDebugLine(spv::Op op, const SourceLocation &loc,
                                 std::vector<uint32_t> *section) {
-  assert(section);
+  // Technically entry function wrappers do not exist in HLSL. They
+  // are just created by DXC. We do not want to emit line information
+  // for their instructions.
+  if (inEntryFunctionWrapper)
+    return;
 
   // Based on SPIR-V spec, OpSelectionMerge must immediately precede either an
   // OpBranchConditional or OpSwitch instruction. Similarly OpLoopMerge must
@@ -150,6 +154,13 @@ void EmitVisitor::emitDebugLine(spv::Op op, const SourceLocation &loc,
     lastOpWasMergeInst = true;
 
   if (!isOpLineLegalForOp(op))
+    return;
+
+  // DebugGlobalVariable and DebugLocalVariable of OpenCL.DebugInfo.100 already
+  // has the line and the column information. We do not want to emit OpLine
+  // for global variables and local variables. Instead, we want to emit OpLine
+  // for their initialization if exists.
+  if (op == spv::Op::OpVariable)
     return;
 
   if (!spvOptions.debugInfoLine)
@@ -174,6 +185,8 @@ void EmitVisitor::emitDebugLine(spv::Op op, const SourceLocation &loc,
 
   if (line == debugLine && column == debugColumn)
     return;
+
+  assert(section);
 
   // We must update these two values to emit the next Opline.
   debugLine = line;
@@ -280,6 +293,9 @@ bool EmitVisitor::visit(SpirvFunction *fn, Phase phase) {
     const uint32_t returnTypeId = typeHandler.emitType(fn->getReturnType());
     const uint32_t functionTypeId = typeHandler.emitType(fn->getFunctionType());
 
+    if (fn->isEntryFunctionWrapper())
+      inEntryFunctionWrapper = true;
+
     // Emit OpFunction
     initInstruction(spv::Op::OpFunction, fn->getSourceLocation());
     curInst.push_back(returnTypeId);
@@ -301,6 +317,7 @@ bool EmitVisitor::visit(SpirvFunction *fn, Phase phase) {
     // Emit OpFunctionEnd
     initInstruction(spv::Op::OpFunctionEnd, /* SourceLocation */ {});
     finalizeInstruction(&mainBinary);
+    inEntryFunctionWrapper = false;
   }
 
   return true;
@@ -1131,6 +1148,12 @@ bool EmitVisitor::visit(SpirvDebugLexicalBlock *inst) {
 }
 
 bool EmitVisitor::visit(SpirvDebugScope *inst) {
+  // Technically entry function wrappers do not exist in HLSL. They
+  // are just created by DXC. We do not want to emit DebugScope for
+  // it.
+  if (inEntryFunctionWrapper)
+    return true;
+
   initInstruction(inst);
   curInst.push_back(inst->getResultTypeId());
   curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -193,7 +193,7 @@ public:
                     &typeConstantBinary,
                     [this]() -> uint32_t { return takeNextId(); }),
         debugMainFileId(0), debugLine(0), debugColumn(0),
-        lastOpWasMergeInst(false) {}
+        lastOpWasMergeInst(false), inEntryFunctionWrapper(false) {}
 
   // Visit different SPIR-V constructs for emitting.
   bool visit(SpirvModule *, Phase phase);
@@ -379,6 +379,8 @@ private:
   uint32_t debugColumn;
   // True if the last emitted instruction was OpSelectionMerge or OpLoopMerge.
   bool lastOpWasMergeInst;
+  // True if currently it enters an entry function wrapper.
+  bool inEntryFunctionWrapper;
 };
 
 } // namespace spirv

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1433,6 +1433,9 @@ void SpirvEmitter::doVarDecl(const VarDecl *decl) {
     // not have local storage, it should be file scope variable.
     const bool isFileScopeVar = !decl->hasLocalStorage();
 
+    // TODO: if no initializer exists, just emit DebugDeclare for OpVariable.
+    // If initializer exists and use OpStore, emit DebugDeclare for OpStore.
+    // If OpFunctionParameter exists, emit DebugValue for OpFunctionParameter.
     if (isFileScopeVar)
       var = declIdMapper.createFileVar(decl, llvm::None);
     else
@@ -10720,6 +10723,10 @@ bool SpirvEmitter::emitEntryFunctionWrapper(const FunctionDecl *decl,
   entryFunction =
       spvBuilder.beginFunction(astContext.VoidTy, /* param QualTypes */ {},
                                decl->getLocStart(), decl->getName());
+
+  // Specify that entryFunction is an entry function wrapper.
+  entryFunction->setEntryFunctionWrapper();
+
   // Note this should happen before using declIdMapper for other tasks.
   declIdMapper.setEntryFunction(entryFunction);
 

--- a/tools/clang/lib/SPIRV/SpirvFunction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvFunction.cpp
@@ -23,7 +23,7 @@ SpirvFunction::SpirvFunction(QualType returnType,
       astParamTypes(paramTypes.begin(), paramTypes.end()), returnType(nullptr),
       fnType(nullptr), relaxedPrecision(false), precise(isPrecise),
       containsAlias(false), rvalue(false), functionLoc(loc), functionName(name),
-      debugScope(nullptr) {}
+      isWrapperOfEntry(false), debugScope(nullptr) {}
 
 bool SpirvFunction::invokeVisitor(Visitor *visitor, bool reverseOrder) {
   if (!visitor->visit(this, Visitor::Phase::Init))

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debugscope.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debugscope.hlsl
@@ -3,15 +3,12 @@
 // CHECK:  [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 // CHECK: [[compUnit:%\d+]] = OpExtInst %void [[set]] DebugCompilationUnit
 // CHECK: [[main:%\d+]] = OpExtInst %void [[set]] DebugFunction
-// CHECK: [[mainFnLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 18 1 [[main]]
-// CHECK: [[forLoopLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 26 12 [[mainFnLexBlock]]
-// CHECK: [[whileLoopLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 41 3 [[mainFnLexBlock]]
-// CHECK: [[ifStmtLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 48 20 [[whileLoopLexBlock]]
-// CHECK: [[tempLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 53 7 [[ifStmtLexBlock]]
+// CHECK: [[mainFnLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 15 1 [[main]]
+// CHECK: [[forLoopLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 23 12 [[mainFnLexBlock]]
+// CHECK: [[whileLoopLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 38 3 [[mainFnLexBlock]]
+// CHECK: [[ifStmtLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 45 20 [[whileLoopLexBlock]]
+// CHECK: [[tempLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 50 7 [[ifStmtLexBlock]]
 
-// CHECK:         %main = OpFunction
-// CHECK-NEXT: {{%\d+}} = OpLabel
-// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[compUnit]]
 float4 main(float4 color : COLOR) : SV_TARGET
 // CHECK:     %src_main = OpFunction
 // CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[main]]

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.o3.option.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.o3.option.hlsl
@@ -11,7 +11,8 @@ struct VSOUT {
   float4 color : COLOR;
 };
 
-// CHECK:      OpLine [[file]] 15 1
+// TODO: After correctly propagate the line information in spirv-opt,
+//       add checking OpLine instructions.
 VSOUT main(float4 pos   : POSITION,
            float4 color : COLOR)
 {

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.entry.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.entry.hlsl
@@ -3,39 +3,16 @@
 // CHECK:      [[file:%\d+]] = OpString
 // CHECK-SAME: spirv.debug.opline.entry.hlsl
 
-// CHECK:                          OpLine [[file]] 29 1
-// CHECK-NEXT:             %main = OpFunction %void None %16
-// CHECK-NEXT:          {{%\d+}} = OpLabel
-// CHECK-NEXT:                     OpLine [[file]] 29 20
-// CHECK-NEXT:      %param_var_a = OpVariable %_ptr_Function_v2float Function
-// CHECK-NEXT:                     OpLine [[file]] 30 20
-// CHECK-NEXT:      %param_var_b = OpVariable %_ptr_Function_v3float Function
-// CHECK-NEXT:                     OpLine [[file]] 31 20
-// CHECK-NEXT:      %param_var_c = OpVariable %_ptr_Function_v4float Function
-// CHECK-NEXT:                     OpLine [[file]] 29 20
-// CHECK-NEXT: [[texcoord:%\d+]] = OpLoad %v2float %in_var_TEXCOORD0
-// CHECK-NEXT:                     OpStore %param_var_a [[texcoord]]
-// CHECK-NEXT:                     OpLine [[file]] 30 20
-// CHECK-NEXT:   [[normal:%\d+]] = OpLoad %v3float %in_var_NORMAL
-// CHECK-NEXT:                     OpStore %param_var_b [[normal]]
-// CHECK-NEXT:                     OpLine [[file]] 31 20
-// CHECK-NEXT:    [[color:%\d+]] = OpLoad %v4float %in_var_COLOR
-// CHECK-NEXT:                     OpStore %param_var_c [[color]]
-// CHECK-NEXT:                     OpLine [[file]] 29 1
-// CHECK-NEXT:   [[result:%\d+]] = OpFunctionCall %v4float %src_main %param_var_a %param_var_b %param_var_c
-// CHECK-NEXT:                     OpLine [[file]] 31 33
-// CHECK-NEXT:                     OpStore %out_var_SV_Target [[result]]
-// CHECK-NEXT:                     OpReturn
 float4 main(float2 a : TEXCOORD0,
             float3 b : NORMAL,
             float4 c : COLOR) : SV_Target {
-// CHECK:                  OpLine [[file]] 29 1
-// CHECK-NEXT: %src_main = OpFunction %v4float None %29
-// CHECK-NEXT:             OpLine [[file]] 29 20
+// CHECK:                  OpLine [[file]] 6 1
+// CHECK-NEXT: %src_main = OpFunction %v4float None
+// CHECK-NEXT:             OpLine [[file]] 6 20
 // CHECK-NEXT:        %a = OpFunctionParameter %_ptr_Function_v2float
-// CHECK-NEXT:             OpLine [[file]] 30 20
+// CHECK-NEXT:             OpLine [[file]] 7 20
 // CHECK-NEXT:        %b = OpFunctionParameter %_ptr_Function_v3float
-// CHECK-NEXT:             OpLine [[file]] 31 20
+// CHECK-NEXT:             OpLine [[file]] 8 20
 // CHECK-NEXT:        %c = OpFunctionParameter %_ptr_Function_v4float
   float4 d = float4(a, b.xy + c.zw);
   return d;

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.function.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.function.hlsl
@@ -5,13 +5,11 @@
 
 void foo(in float4 a, out float3 b);
 
-// CHECK:              OpLine [[file]] 30 1
-// CHECK-NEXT: %main = OpFunction %void None
+// CHECK:                  OpLine [[file]] 28 1
+// CHECK-NEXT: %src_main = OpFunction %void None
 
 void bar(int a, in float b, inout bool2 c, const float3 d, out uint4 e) {
 }
-
-float4 getV4f(float x, int y, bool z);
 
 struct R {
   int a;
@@ -31,102 +29,41 @@ void main() {
   float4 v4f;
   float3 v3f;
 
-// CHECK:                     OpLine [[file]] 36 7
-// CHECK-NEXT: %param_var_a = OpVariable %_ptr_Function_v4float Function
   foo(v4f, v3f);
-// CHECK:                     OpLine [[file]] 39 14
-// CHECK-NEXT: %param_var_x = OpVariable %_ptr_Function_float Function
-  foo(getV4f(v4f.x,
-// CHECK:                     OpLine [[file]] 46 21
-// CHECK-NEXT: %param_var_x_0 = OpVariable %_ptr_Function_float Function
-// CHECK-NEXT:                OpLine [[file]] 46 28
-// CHECK-NEXT: %param_var_y = OpVariable %_ptr_Function_int Function
-// CHECK-NEXT:                OpLine [[file]] 46 35
-// CHECK-NEXT: %param_var_z = OpVariable %_ptr_Function_bool Function
-             getV4f(v4f.y, v4f.z, v4f.w).z,
-// CHECK:                     OpLine [[file]] 46 14
-// CHECK-NEXT: %param_var_y_0 = OpVariable %_ptr_Function_int Function
-// CHECK-NEXT:                OpLine [[file]] 51 14
-// CHECK-NEXT: %param_var_z_0 = OpVariable %_ptr_Function_bool Function
-             v3f.y),
-      v3f);
-// CHECK-NEXT:                OpLine [[file]] 39 7
-// CHECK-NEXT: %param_var_a_0 = OpVariable %_ptr_Function_v4float Function
-
   r[0].incr();
-  decr(r[0],
-// CHECK-NEXT:                OpLine [[file]] 62 13
-// CHECK-NEXT: %param_var_i = OpVariable %_ptr_Function_uint Function
-// CHECK-NEXT:                OpLine [[file]] 62 8
-// CHECK-NEXT: %param_var_b = OpVariable %_ptr_Function_R_0 Function
-       getR(1),
-       r[2],
-// CHECK-NEXT:                OpLine [[file]] 68 13
-// CHECK-NEXT: %param_var_i_0 = OpVariable %_ptr_Function_uint Function
-// CHECK-NEXT:                OpLine [[file]] 68 8
-// CHECK-NEXT: %param_var_d = OpVariable %_ptr_Function_R_0 Function
-       getR(3),
-// CHECK-NEXT:                OpLine [[file]] 73 13
-// CHECK-NEXT: %param_var_i_1 = OpVariable %_ptr_Function_uint Function
-// CHECK-NEXT:                OpLine [[file]] 73 8
-// CHECK-NEXT: %param_var_e = OpVariable %_ptr_Function_R_0 Function
-       getR(4));
+  decr(r[0], getR(1), r[2], getR(3), getR(4));
 
   rwsb[0].incr();
-
-  decr(rwsb[1],
-// CHECK-NEXT:                OpLine [[file]] 80 8
-// CHECK-NEXT: %param_var_b_0 = OpVariable %_ptr_Function_R_0 Function
-       rwsb[2],
-       rwsb[3],
-// CHECK-NEXT:                OpLine [[file]] 84 8
-// CHECK-NEXT: %param_var_d_0 = OpVariable %_ptr_Function_R_0 Function
-       rwsb[4],
-// CHECK-NEXT:                OpLine [[file]] 87 8
-// CHECK-NEXT: %param_var_e_0 = OpVariable %_ptr_Function_R_0 Function
-       rwsb[5]);
 }
 
-// CHECK:             OpLine [[file]] 96 1
+// CHECK:             OpLine [[file]] 45 1
 // CHECK-NEXT: %foo = OpFunction %void None
-// CHECK-NEXT:        OpLine [[file]] 96 20
+// CHECK-NEXT:        OpLine [[file]] 45 20
 // CHECK-NEXT:   %a = OpFunctionParameter %_ptr_Function_v4float
-// CHECK-NEXT:        OpLine [[file]] 96 34
+// CHECK-NEXT:        OpLine [[file]] 45 34
 // CHECK-NEXT:   %b = OpFunctionParameter %_ptr_Function_v3float
 void foo(in float4 a, out float3 b) {
   a = b.xxzz;
   b = a.yzw;
-// CHECK:                     OpLine [[file]] 103 7
-// CHECK-NEXT: %param_var_a_1 = OpVariable %_ptr_Function_int Function
-// CHECK-NEXT:                OpLine [[file]] 103 12
-// CHECK-NEXT: %param_var_b_1 = OpVariable %_ptr_Function_float Function
   bar(a.x, b.y, a.yz, b, a);
 }
 
-// CHECK:                     OpLine [[file]] 112 1
-// CHECK-NEXT:      %getV4f = OpFunction %v4float None
-// CHECK-NEXT:                OpLine [[file]] 112 21
-// CHECK-NEXT:           %x = OpFunctionParameter %_ptr_Function_float
-// CHECK-NEXT:                OpLine [[file]] 112 28
-// CHECK-NEXT:           %y = OpFunctionParameter %_ptr_Function_int
-float4 getV4f(float x, int y, bool z) { return float4(x, y, z, z); }
-
-// CHECK:                     OpLine [[file]] 117 1
+// CHECK:                     OpLine [[file]] 54 1
 // CHECK-NEXT:      %R_incr = OpFunction %void None
 // CHECK-NEXT:  %param_this = OpFunctionParameter %_ptr_Function_R_0
 void R::incr() { ++a; }
 
-// CHECK:                     OpLine [[file]] 123 1
+// CHECK:                     OpLine [[file]] 60 1
 // CHECK-NEXT:        %getR = OpFunction %R_0 None
-// CHECK-NEXT:                OpLine [[file]] 123 13
+// CHECK-NEXT:                OpLine [[file]] 60 13
 // CHECK-NEXT:           %i = OpFunctionParameter %_ptr_Function_uint
 R getR(uint i) { return r[i]; }
 
-// CHECK:                     OpLine [[file]] 131 1
+// CHECK:                     OpLine [[file]] 68 1
 // CHECK-NEXT:        %decr = OpFunction %void None
-// CHECK-NEXT:                OpLine [[file]] 131 19
+// CHECK-NEXT:                OpLine [[file]] 68 19
 // CHECK-NEXT:         %a_0 = OpFunctionParameter %_ptr_Function_R_0
-// CHECK-NEXT:                OpLine [[file]] 131 27
+// CHECK-NEXT:                OpLine [[file]] 68 27
 // CHECK-NEXT:         %b_0 = OpFunctionParameter %_ptr_Function_R_0
 void decr(inout R a, in R b, out R c, R d, const R e) { a.a--; }
 

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.include.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.include.hlsl
@@ -2,19 +2,15 @@
 
 // CHECK:      [[main:%\d+]] = OpString
 // CHECK-SAME: spirv.debug.opline.include.hlsl
+// CHECK:      [[file1:%\d+]] = OpString
+// CHECK-SAME: spirv.debug.opline.include-file-1.hlsl
 // CHECK:      [[file2:%\d+]] = OpString
 // CHECK-SAME: spirv.debug.opline.include-file-2.hlsl
 // CHECK:      [[file3:%\d+]] = OpString
 // CHECK-SAME: spirv.debug.opline.include-file-3.hlsl
-// CHECK:      [[file1:%\d+]] = OpString
-// CHECK-SAME: spirv.debug.opline.include-file-1.hlsl
 
-// CHECK:              OpLine [[file2]] 1 12
-// CHECK-NEXT:    %a = OpVariable %_ptr_Private_int Private
-// CHECK:              OpLine [[file3]] 1 17
-// CHECK-NEXT:    %b = OpVariable %_ptr_Workgroup_int Workgroup
-// CHECK:              OpLine [[main]] 65 1
-// CHECK-NEXT: %main = OpFunction %void None
+// CHECK:                  OpLine [[main]] 61 1
+// CHECK-NEXT: %src_main = OpFunction %void None
 
 #include "spirv.debug.opline.include-file-1.hlsl"
 
@@ -63,7 +59,7 @@ int callFunction3() {
 }
 
 void main() {
-// CHECK:      OpLine [[main]] 68 3
+// CHECK:      OpLine [[main]] 64 3
 // CHECK-NEXT: OpFunctionCall %int %callFunction1
   callFunction1();
 
@@ -81,34 +77,34 @@ void main() {
   // line
   // in
   // OpSource.
-// CHECK:      OpLine [[main]] 86 3
+// CHECK:      OpLine [[main]] 82 3
 // CHECK-NEXT: OpFunctionCall %int %callFunction2
   callFunction2();
 
-// CHECK:      OpLine [[main]] 90 3
+// CHECK:      OpLine [[main]] 86 3
 // CHECK-NEXT: OpFunctionCall %int %callFunction3
   callFunction3();
 }
 
-// CHECK:      OpLine [[main]] 21 1
+// CHECK:      OpLine [[main]] 17 1
 // CHECK-NEXT: %callFunction1 = OpFunction %int None
-// CHECK:      OpLine [[main]] 22 10
+// CHECK:      OpLine [[main]] 18 10
 // CHECK-NEXT: OpFunctionCall %int %function1
-// CHECK:      OpLine [[main]] 22 3
+// CHECK:      OpLine [[main]] 18 3
 // CHECK-NEXT: OpReturnValue
 
-// CHECK:      OpLine [[main]] 27 1
+// CHECK:      OpLine [[main]] 23 1
 // CHECK-NEXT: %callFunction2 = OpFunction %int None
-// CHECK:      OpLine [[main]] 42 10
+// CHECK:      OpLine [[main]] 38 10
 // CHECK-NEXT: OpFunctionCall %int %function2
-// CHECK:      OpLine [[main]] 42 3
+// CHECK:      OpLine [[main]] 38 3
 // CHECK-NEXT: OpReturnValue
 
-// CHECK:      OpLine [[main]] 47 1
+// CHECK:      OpLine [[main]] 43 1
 // CHECK-NEXT: %callFunction3 = OpFunction %int None
-// CHECK:      OpLine [[main]] 62 10
+// CHECK:      OpLine [[main]] 58 10
 // CHECK-NEXT: OpFunctionCall %int %function3
-// CHECK:      OpLine [[main]] 62 3
+// CHECK:      OpLine [[main]] 58 3
 // CHECK-NEXT: OpReturnValue
 
 // CHECK:      OpLine [[file1]] 1 1

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.variables.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.variables.hlsl
@@ -3,93 +3,35 @@
 // CHECK:      [[file:%\d+]] = OpString
 // CHECK-SAME: spirv.debug.opline.variables.hlsl
 
-struct S {
-  float4 f;
-};
-
-// CHECK:                        OpLine [[file]] 12 32
-// CHECK-NEXT: %consume_v2bool = OpVariable %_ptr_Uniform_type_ConsumeStructuredBuffer_v2bool Uniform
-ConsumeStructuredBuffer<bool2> consume_v2bool;
-
-// CHECK:                        OpLine [[file]] 16 32
-// CHECK-NEXT: %append_v2float = OpVariable %_ptr_Uniform_type_AppendStructuredBuffer_v2float Uniform
-AppendStructuredBuffer<float2> append_v2float;
-
-// CHECK:                       OpLine [[file]] 20 19
-// CHECK-NEXT: %byte_addr_buf = OpVariable %_ptr_Uniform_type_ByteAddressBuffer Uniform
-ByteAddressBuffer byte_addr_buf;
-
-// CHECK:                    OpLine [[file]] 24 19
-// CHECK-NEXT: %rw_texture = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
-RWTexture2D<int3> rw_texture;
-
-// TODO(jaebaek): Check DeclResultIdMapper::create.*Var()
-//                we must emit "OpLine .." here.
-TextureBuffer<S> texture_buf;
-
-// CHECK:             OpLine [[file]] 32 14
-// CHECK-NEXT: %sam = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
-SamplerState sam;
-
-// CHECK:                     OpLine [[file]] 36 19
-// CHECK-NEXT: %float_array = OpVariable %_ptr_Workgroup__arr_float_uint_10 Workgroup
-groupshared float float_array[10];
-
-// CHECK:                     OpLine [[file]] 40 12
-// CHECK-NEXT:   %int_array = OpVariable %_ptr_Private__arr_int_uint_10 Private
-static int int_array[10];
-
-// "static" variables in functions must be defined first.
-// CHECK:                     OpLine [[file]] 61 16
-// CHECK-NEXT:           %c = OpVariable %_ptr_Private_v3bool Private
-// CHECK-NEXT: %init_done_c = OpVariable %_ptr_Private_bool Private %false
-
-bool3 test_function_variables() {
-// CHECK:                     OpLine [[file]] 50 9
-// CHECK-NEXT:         %a_0 = OpVariable %_ptr_Function_v3bool Function
-  bool3 a;
-
-// CHECK-NEXT:                OpLine [[file]] 54 22
-// CHECK-NEXT:         %b_0 = OpVariable %_ptr_Function_mat2v3float Function
-  row_major float2x3 b;
-
-// CHECK:                      OpLine [[file]] 61 20
-// CHECK-NEXT: [[init:%\d+]] = OpLoad %bool %init_done_c
-// CHECK-NEXT:                 OpSelectionMerge %if_init_done None
-// CHECK-NEXT:                 OpBranchConditional [[init]] %if_init_done %if_init_todo
-// CHECK-NEXT: %if_init_todo = OpLabel
-  static bool3 c = bool3(true, consume_v2bool.Consume());
-
-// CHECK:      %if_init_done = OpLabel
-
-  c = a && c;
-  return c;
+float test_function_variables() {
+// CHECK:                 OpLine [[file]] 9 22
+// CHECK-NEXT: {{%\d+}} = OpLoad %bool %init_done_foo
+  static float foo = 2.f;
+  return foo;
 }
 
-// CHECK:                     OpLine [[file]] 75 1
+// CHECK:                     OpLine [[file]] 19 1
 // CHECK-NEXT: %test_function_param = OpFunction %v2float None
-// CHECK-NEXT:                OpLine [[file]] 75 35
-// CHECK-NEXT:         %a_1 = OpFunctionParameter %_ptr_Function_v2float
-// CHECK-NEXT:                OpLine [[file]] 75 50
-// CHECK-NEXT:         %b_1 = OpFunctionParameter %_ptr_Function_v3bool
+// CHECK-NEXT:                OpLine [[file]] 19 35
+// CHECK-NEXT:           %a = OpFunctionParameter %_ptr_Function_v2float
+// CHECK-NEXT:                OpLine [[file]] 19 50
+// CHECK-NEXT:           %b = OpFunctionParameter %_ptr_Function_v3bool
 float2 test_function_param(float2 a, inout bool3 b,
-// CHECK-NEXT:                OpLine [[file]] 80 38
-// CHECK-NEXT:         %c_1 = OpFunctionParameter %_ptr_Function_int
-// CHECK-NEXT:                OpLine [[file]] 80 52
-// CHECK-NEXT:         %d_0 = OpFunctionParameter %_ptr_Function_v3float
-                           const int c, out float3 d,
-// CHECK-NEXT:                OpLine [[file]] 83 33
-// CHECK-NEXT:           %e = OpFunctionParameter %_ptr_Function_bool
-                           bool e) {
-// CHECK:                     OpLine [[file]] 86 9
-// CHECK-NEXT:           %f = OpVariable %_ptr_Function__arr_float_uint_2 Function
-  float f[2];
-  return a + d.xy + float2(f);
+// CHECK-NEXT:                OpLine [[file]] 24 38
+// CHECK-NEXT:           %c = OpFunctionParameter %_ptr_Function_int
+// CHECK-NEXT:                OpLine [[file]] 24 52
+// CHECK-NEXT:           %d = OpFunctionParameter %_ptr_Function_v3float
+                           const int c, out float3 d) {
+// CHECK:      OpLine [[file]] 27 9
+// CHECK-NEXT: OpStore %f
+  float f = a.x;
+  return a + d.xy + float2(f, a.y);
 }
 
 void main() {
-  bool a;
-  bool3 b = test_function_variables();
-  float3 c;
-  float2 d = test_function_param(float2(1, 0), b, 13, c, a);
+  float bar = test_function_variables();
+
+  bool3 param_b;
+  float3 param_d;
+  test_function_param(float2(1, 0), param_b, 13, param_d);
 }


### PR DESCRIPTION
Since the HLSL code does not contain the code for the wrapper of entry
function, we should not emit `OpLine` instructions for its instructions.
In addition, we do not emit `OpLine` instructions for variables because
a unit of STEP-IN command of SwiftShader debugger is `OpLine` and the
`OpLine` for variables lets the debugger stop in weird locations. Since
`DebugGlobalVariable` and `DebugLocalVariable` instructions of
OpenCL.DebugInfo.100 have both the line and the column information, we
do not need to emit `OpLine` instructions for them.