### PR TITLE
[spirv] Generate debug info for cbuffer

### DIFF
--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.h
@@ -66,6 +66,9 @@ private:
   // OpExtInst with result type of void.
   void setDefaultDebugInfo(SpirvDebugInstruction *instr);
 
+  SpirvDebugTypeComposite *prepareDebugTypeComposite(const StructType *type,
+                                                     const SourceLocation &loc);
+
 private:
   ASTContext &astContext;   /// AST context
   SpirvContext &spvContext; /// SPIR-V context

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.h
@@ -59,15 +59,32 @@ private:
   /// depends on will also be created.
   SpirvDebugInstruction *lowerToDebugType(const SpirvType *);
 
+  /// Lowers DebugTypeComposite.
   SpirvDebugInstruction *lowerToDebugTypeComposite(const SpirvType *);
 
-  // Set the result type of debug instructions to OpTypeVoid.
-  // According to the OpenCL.DebugInfo.100 spec, all debug instructions are
-  // OpExtInst with result type of void.
+  /// Lowers DebugTypeComposite for cbuffer.
+  SpirvDebugTypeComposite *lowerCbufferDebugType(const StructType *type,
+                                                 const SourceLocation &loc);
+
+  /// Lowers DebugTypeTemplate for HLSL resource type. Returns false if
+  /// there is an error.
+  bool lowerDebugTypeTemplate(SpirvDebugTypeComposite *instr);
+
+  /// Lowers DebugTypeFunction for member function of a composite type.
+  /// Returns false if there is an error.
+  bool lowerDebugTypeFunctionForMemberFunction(SpirvDebugInstruction *instr);
+
+  /// Lowers debug type for DebugTypeMember of a composite type. Returns
+  /// false if there is an error.
+  bool lowerDebugTypeMember(SpirvDebugTypeMember *debugMember,
+                            uint32_t *sizeInBits, uint32_t *offsetInBits);
+
+  /// Set the result type of debug instructions to OpTypeVoid.
+  /// According to the OpenCL.DebugInfo.100 spec, all debug instructions are
+  /// OpExtInst with result type of void.
   void setDefaultDebugInfo(SpirvDebugInstruction *instr);
 
-  SpirvDebugTypeComposite *prepareDebugTypeComposite(const StructType *type,
-                                                     const SourceLocation &loc);
+  SpirvDebugInfoNone *getDebugInfoNone();
 
 private:
   ASTContext &astContext;   /// AST context

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -895,16 +895,6 @@ SpirvVariable *DeclResultIdMapper::createCTBuffer(const HLSLBufferDecl *decl) {
       decl->getAttr<VKBindingAttr>(), decl->getAttr<VKCounterBindingAttr>());
 
   if (spirvOptions.debugInfoRich) {
-    llvm::SmallVector<HybridStructType::FieldInfo, 4> fields;
-    for (const auto *subDecl : decl->decls()) {
-      if (shouldSkipInStructLayout(subDecl))
-        continue;
-
-      const auto *varDecl = cast<VarDecl>(subDecl);
-      assert(varDecl && "Sub-Decls of HLSLBufferDecl must be VarDecls");
-
-      fields.emplace_back(varDecl->getType(), varDecl->getName());
-    }
     createDebugGlobalVariable(bufferVar, QualType(), decl->getLocation(),
                               decl->getName());
   }

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -87,19 +87,6 @@ bool LowerTypeVisitor::visitInstruction(SpirvInstruction *instr) {
           lowerType(debugQualType, instr->getLayoutRule(),
                     /*isRowMajor*/ llvm::None, instr->getSourceLocation());
       debugInstruction->setDebugSpirvType(spirvType);
-    } else if (auto *debugGlobalVar =
-                   dyn_cast<SpirvDebugGlobalVariable>(instr)) {
-      auto *varType = debugGlobalVar->getVariable()->getResultType();
-      assert(varType &&
-             "Global variable must be visited before any debug instruction");
-      auto *ptrType = dyn_cast<SpirvPointerType>(varType);
-      assert(ptrType && "OpVariable must have a pointer type");
-      auto *actualType = ptrType->getPointeeType();
-      debugGlobalVar->setDebugSpirvType(actualType);
-      if (auto *structType = dyn_cast<StructType>(actualType)) {
-        lowerDebugTypeCompositeFromSpirvType(structType, false,
-                                             instr->getSourceLocation());
-      }
     }
   }
 
@@ -983,66 +970,6 @@ LowerTypeVisitor::generateFunctionInfo(const CXXMethodDecl *decl,
                          funcName, flags, scopeLine, nullptr);
   fn->setFunctionType(fnType);
   return fn;
-}
-
-SpirvDebugTypeComposite *LowerTypeVisitor::lowerDebugTypeCompositeFromSpirvType(
-    const StructType *type, bool isResourceType, const SourceLocation &loc) {
-  const auto &sm = astContext.getSourceManager();
-  uint32_t line = sm.getPresumedLineNumber(loc);
-  uint32_t column = sm.getPresumedColumnNumber(loc);
-  StringRef linkageName = type->getName();
-  llvm::ArrayRef<StructType::FieldInfo> fields = type->getFields();
-
-  // TODO: Update linkageName using astContext.createMangleContext().
-  std::string name = type->getName();
-  if (isResourceType)
-    name = "@" + name;
-
-  // TODO: Update parent, size, flags, and tag information correctly.
-  RichDebugInfo *debugInfo = &spvContext.getDebugInfo().begin()->second;
-  const char *file = sm.getPresumedLoc(loc).getFilename();
-  if (file)
-    debugInfo = &spvContext.getDebugInfo()[file];
-  auto *dbgTyComposite =
-      dyn_cast<SpirvDebugTypeComposite>(spvContext.getDebugTypeComposite(
-          type, name, debugInfo->source, line, column,
-          /* parent */ debugInfo->compilationUnit, linkageName,
-          /* size */ 0, /* flags */ 3u, /* tag */ 1u));
-
-  // If we already visited this composite type and its members,
-  // we should skip it.
-  auto &members = dbgTyComposite->getMembers();
-  if (!members.empty())
-    return dbgTyComposite;
-
-  dbgTyComposite->setAstResultType(astContext.VoidTy);
-  dbgTyComposite->setResultType(spvContext.getVoidType());
-  dbgTyComposite->setInstructionSet(debugExtInstSet);
-
-  if (isResourceType) {
-    dbgTyComposite->setDebugInfoNone(spvBuilder.getOrCreateDebugInfoNone());
-    return dbgTyComposite;
-  }
-
-  for (auto &field : fields) {
-    uint32_t offset = UINT32_MAX;
-    if (field.offset.hasValue())
-      offset = *field.offset;
-
-    // TODO: Replace 2u and 3u with valid flags when debug info extension is
-    // placed in SPIRV-Header.
-    auto *debugInstr =
-        dyn_cast<SpirvDebugInstruction>(spvContext.getDebugTypeMember(
-            field.name, field.type, debugInfo->source, line, column,
-            dbgTyComposite,
-            /* flags */ 3u, offset, /* value */ nullptr));
-    assert(debugInstr && "We expect SpirvDebugInstruction for DebugTypeMember");
-    debugInstr->setAstResultType(astContext.VoidTy);
-    debugInstr->setResultType(spvContext.getVoidType());
-    debugInstr->setInstructionSet(debugExtInstSet);
-    members.push_back(debugInstr);
-  }
-  return dbgTyComposite;
 }
 
 SpirvDebugTypeComposite *LowerTypeVisitor::lowerDebugTypeComposite(

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -99,11 +99,6 @@ private:
       const RecordType *structType, const SpirvType *spirvType,
       llvm::SmallVector<StructType::FieldInfo, 4> &fields, bool isResourceType);
 
-  /// Generate rich debug info of a composite type from a SpirvType
-  /// (StructType).
-  SpirvDebugTypeComposite *lowerDebugTypeCompositeFromSpirvType(
-      const StructType *type, bool isResourceType, const SourceLocation &loc);
-
 private:
   ASTContext &astContext;                /// AST context
   SpirvContext &spvContext;              /// SPIR-V context

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -98,6 +98,10 @@ private:
   SpirvDebugTypeComposite *lowerDebugTypeComposite(
       const RecordType *structType, const SpirvType *spirvType,
       llvm::SmallVector<StructType::FieldInfo, 4> &fields, bool isResourceType);
+  SpirvDebugTypeComposite *
+  lowerDebugTypeComposite(const SpirvType *type,
+                          llvm::ArrayRef<StructType::FieldInfo> fields,
+                          bool isResourceType, const SourceLocation &loc);
 
 private:
   ASTContext &astContext;                /// AST context

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -94,14 +94,15 @@ private:
   populateLayoutInformation(llvm::ArrayRef<HybridStructType::FieldInfo> fields,
                             SpirvLayoutRule rule);
 
-  /// Generate rich debug info for composite type.
+  /// Generate rich debug info of a composite type from a QualType (RecordType).
   SpirvDebugTypeComposite *lowerDebugTypeComposite(
       const RecordType *structType, const SpirvType *spirvType,
       llvm::SmallVector<StructType::FieldInfo, 4> &fields, bool isResourceType);
-  SpirvDebugTypeComposite *
-  lowerDebugTypeComposite(const SpirvType *type,
-                          llvm::ArrayRef<StructType::FieldInfo> fields,
-                          bool isResourceType, const SourceLocation &loc);
+
+  /// Generate rich debug info of a composite type from a SpirvType
+  /// (StructType).
+  SpirvDebugTypeComposite *lowerDebugTypeCompositeFromSpirvType(
+      const StructType *type, bool isResourceType, const SourceLocation &loc);
 
 private:
   ASTContext &astContext;                /// AST context

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -792,7 +792,8 @@ SpirvDebugInstruction::SpirvDebugInstruction(Kind kind, uint32_t opcode)
     : SpirvInstruction(kind, spv::Op::OpExtInst,
                        /*result type */ {},
                        /*SourceLocation*/ {}),
-      debugOpcode(opcode), debugType(nullptr), instructionSet(nullptr) {}
+      debugOpcode(opcode), debugSpirvType(nullptr), debugType(nullptr),
+      instructionSet(nullptr) {}
 
 SpirvDebugInfoNone::SpirvDebugInfoNone()
     : SpirvDebugInstruction(IK_DebugInfoNone, /*opcode*/ 0u) {}

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.cbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.cbuffer.hlsl
@@ -1,21 +1,5 @@
 // Run: %dxc -T vs_6_0 -E main -fspv-debug=rich
 
-// CHECK:      OpName %type_MyCbuffer "type.MyCbuffer"
-// CHECK-NEXT: OpMemberName %type_MyCbuffer 0 "a"
-// CHECK-NEXT: OpMemberName %type_MyCbuffer 1 "b"
-// CHECK-NEXT: OpMemberName %type_MyCbuffer 2 "c"
-// CHECK-NEXT: OpMemberName %type_MyCbuffer 3 "d"
-// CHECK-NEXT: OpMemberName %type_MyCbuffer 4 "s"
-// CHECK-NEXT: OpMemberName %type_MyCbuffer 5 "t"
-
-// CHECK:      OpName %MyCbuffer "MyCbuffer"
-
-// CHECK:      OpName %type_AnotherCBuffer "type.AnotherCBuffer"
-// CHECK-NEXT: OpMemberName %type_AnotherCBuffer 0 "m"
-// CHECK-NEXT: OpMemberName %type_AnotherCBuffer 1 "n"
-
-// CHECK:      OpName %AnotherCBuffer "AnotherCBuffer"
-
 struct S {
     float  f1;
     float3 f2;
@@ -35,15 +19,15 @@ cbuffer AnotherCBuffer : register(b2) {
     float4 n;
 }
 
-// CHECK: [[S:%\d+]] = OpExtInst %void [[ext:%\d+]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 19 1 {{%\d+}} {{%\d+}} %uint_100 FlagIsProtected|FlagIsPrivate [[f1:%\d+]] [[f2:%\d+]]
+// CHECK: [[S:%\d+]] = OpExtInst %void [[ext:%\d+]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 3 1 {{%\d+}} {{%\d+}} %uint_100 FlagIsProtected|FlagIsPrivate [[f1:%\d+]] [[f2:%\d+]]
 // CHECK: [[MyCbuffer:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 0 0 {{%\d+}} {{%\d+}} %uint_400 FlagIsProtected|FlagIsPrivate [[a:%\d+]] [[b:%\d+]] [[c:%\d+]] [[d:%\d+]] [[s:%\d+]] [[t:%\d+]]
 // CHECK: [[AnotherCBuffer:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 0 0 {{%\d+}} {{%\d+}} %uint_144 FlagIsProtected|FlagIsPrivate [[m:%\d+]] [[n:%\d+]]
 
-// CHECK: {{%\d+}} = OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} {{%\d+}} {{%\d+}} 24 9 {{%\d+}} {{%\d+}} %MyCbuffer
-// CHECK: {{%\d+}} = OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} {{%\d+}} {{%\d+}} 33 9 {{%\d+}} {{%\d+}} %AnotherCBuffer
+// CHECK: {{%\d+}} = OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} {{%\d+}} {{%\d+}} 8 9 {{%\d+}} {{%\d+}} %MyCbuffer
+// CHECK: {{%\d+}} = OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} {{%\d+}} {{%\d+}} 17 9 {{%\d+}} {{%\d+}} %AnotherCBuffer
 
-// CHECK: [[f1]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 20 5 [[S]] %uint_0 %uint_32
-// CHECK: [[f2]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 21 5 [[S]] %uint_4 %uint_96
+// CHECK: [[f1]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 4 5 [[S]] %uint_0 %uint_32
+// CHECK: [[f2]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 5 5 [[S]] %uint_4 %uint_96
 // CHECK: [[a]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_0 %uint_32
 // CHECK: [[b]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_4 %uint_32
 // CHECK: [[c]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_8 %uint_64

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.cbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.cbuffer.hlsl
@@ -1,0 +1,58 @@
+// Run: %dxc -T vs_6_0 -E main -fspv-debug=rich
+
+// CHECK:      OpName %type_MyCbuffer "type.MyCbuffer"
+// CHECK-NEXT: OpMemberName %type_MyCbuffer 0 "a"
+// CHECK-NEXT: OpMemberName %type_MyCbuffer 1 "b"
+// CHECK-NEXT: OpMemberName %type_MyCbuffer 2 "c"
+// CHECK-NEXT: OpMemberName %type_MyCbuffer 3 "d"
+// CHECK-NEXT: OpMemberName %type_MyCbuffer 4 "s"
+// CHECK-NEXT: OpMemberName %type_MyCbuffer 5 "t"
+
+// CHECK:      OpName %MyCbuffer "MyCbuffer"
+
+// CHECK:      OpName %type_AnotherCBuffer "type.AnotherCBuffer"
+// CHECK-NEXT: OpMemberName %type_AnotherCBuffer 0 "m"
+// CHECK-NEXT: OpMemberName %type_AnotherCBuffer 1 "n"
+
+// CHECK:      OpName %AnotherCBuffer "AnotherCBuffer"
+
+struct S {
+    float  f1;
+    float3 f2;
+};
+
+cbuffer MyCbuffer : register(b1) {
+    bool     a;
+    int      b;
+    uint2    c;
+    float3x4 d;
+    S        s;
+    float    t[4];
+};
+
+cbuffer AnotherCBuffer : register(b2) {
+    float3 m;
+    float4 n;
+}
+
+// CHECK: [[S:%\d+]] = OpExtInst %void [[ext:%\d+]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 19 1 {{%\d+}} {{%\d+}} %uint_100 FlagIsProtected|FlagIsPrivate [[f1:%\d+]] [[f2:%\d+]]
+// CHECK: [[MyCbuffer:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 0 0 {{%\d+}} {{%\d+}} %uint_400 FlagIsProtected|FlagIsPrivate [[a:%\d+]] [[b:%\d+]] [[c:%\d+]] [[d:%\d+]] [[s:%\d+]] [[t:%\d+]]
+// CHECK: [[AnotherCBuffer:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 0 0 {{%\d+}} {{%\d+}} %uint_144 FlagIsProtected|FlagIsPrivate [[m:%\d+]] [[n:%\d+]]
+
+// CHECK: {{%\d+}} = OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} {{%\d+}} {{%\d+}} 24 9 {{%\d+}} {{%\d+}} %MyCbuffer
+// CHECK: {{%\d+}} = OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} {{%\d+}} {{%\d+}} 33 9 {{%\d+}} {{%\d+}} %AnotherCBuffer
+
+// CHECK: [[f1]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 20 5 [[S]] %uint_0 %uint_32
+// CHECK: [[f2]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 21 5 [[S]] %uint_4 %uint_96
+// CHECK: [[a]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_0 %uint_32
+// CHECK: [[b]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_4 %uint_32
+// CHECK: [[c]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_8 %uint_64
+// CHECK: [[d]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_16 %uint_384
+// CHECK: [[s]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} [[S]] {{%\d+}} 0 0 [[MyCbuffer]] %uint_80 %uint_100
+// CHECK: [[t]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_96 %uint_128
+// CHECK: [[m]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[AnotherCBuffer]] %uint_0 %uint_96
+// CHECK: [[n]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[AnotherCBuffer]] %uint_16 %uint_128
+
+float  main() : A {
+  return t[0] + m[0];
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2393,5 +2393,9 @@ TEST_F(FileTest, RichDebugInfoTypeSampler) {
   runFileTest("rich.debug.sampler.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
+TEST_F(FileTest, RichDebugInfoCbuffer) {
+  runFileTest("rich.debug.cbuffer.hlsl", Expect::Success,
+              /*runValidation*/ runValidationForRichDebugInfo);
+}
 
 } // namespace


### PR DESCRIPTION
This commit generates a `DebugGlobalVariable` instruction for a cbuffer
and creates a `DebugTypeComposite` for its type similar to struct/class.
Essentially we consider a cbuffer is a composite type global variable.