### PR TITLE
Temporary commit to show a bug

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/structured-buffer.counter.pointer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/structured-buffer.counter.pointer.hlsl
@@ -1,0 +1,29 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct S {
+    float  a;
+    float3 b;
+    int2 c;
+};
+
+struct T {
+    float  a;
+    float3 b;
+    S      c;
+    int2   d;
+};
+
+StructuredBuffer<S> mySBuffer1 : register(t1);
+StructuredBuffer<T> mySBuffer2 : register(t2);
+
+RWStructuredBuffer<S> mySBuffer3 : register(u3);
+RWStructuredBuffer<T> mySBuffer4 : register(u4);
+
+void foo(RWStructuredBuffer<S> inputBuffer) {
+  inputBuffer[0].a = 0;
+}
+
+float4 main() : SV_Target {
+    foo(mySBuffer3);
+    return 1.0;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2279,6 +2279,11 @@ TEST_F(FileTest, CompatibilityWithVk1p1) {
   runFileTest("sm6.wave.builtin.no-dup.vulkan1.2.hlsl");
 }
 
+TEST_F(FileTest, StructuredBufferCounterPointer) {
+  runFileTest("rich.debug.structured-buffer.hlsl", Expect::Success,
+              /*runValidation*/ true);
+}
+
 // Tests for Rich Debug Information
 // TODO: change |runValidation| parameter back to 'true' once the following bug
 // has been fixed in SPIRV-Tools:


### PR DESCRIPTION
I found a bug for a `StructuredBuffer`.
See tools/clang/test/CodeGenSPIRV/structured-buffer.counter.pointer.hlsl which is not related to debug info.
It has a validation error saying
```
In Logical addressing, variables may not allocate a pointer type
  %counter_var_inputBuffer = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
```

When I previously tested it with spv-val, it worked fine without validation error.
I guess the error came from one of recent DXC commits.
Do you have any idea?