### PR TITLE
[spirv] make dumping source optional

### DIFF
--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -806,6 +806,11 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
         opts.SpirvOptions.debugInfoTool = true;
       } else if (v == "rich") {
         opts.SpirvOptions.debugInfoFile = true;
+        opts.SpirvOptions.debugInfoSource = false;
+        opts.SpirvOptions.debugInfoLine = true;
+        opts.SpirvOptions.debugInfoRich = true;
+      } else if (v == "rich-with-source") {
+        opts.SpirvOptions.debugInfoFile = true;
         opts.SpirvOptions.debugInfoSource = true;
         opts.SpirvOptions.debugInfoLine = true;
         opts.SpirvOptions.debugInfoRich = true;

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debugcompilationunit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debugcompilationunit.hlsl
@@ -1,7 +1,7 @@
 // Run: %dxc -T ps_6_0 -E main -fspv-debug=rich
 
 // CHECK:      [[debugSet:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
-// CHECK:   [[debugSource:%\d+]] = OpExtInst %void [[debugSet]] DebugSource {{%\d+}} {{%\d+}}
+// CHECK:   [[debugSource:%\d+]] = OpExtInst %void [[debugSet]] DebugSource
 // CHECK:               {{%\d+}} = OpExtInst %void [[debugSet]] DebugCompilationUnit 1 4 [[debugSource]] HLSL
 
 float4 main(float4 color : COLOR) : SV_TARGET {

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debuglexicalblock.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debuglexicalblock.hlsl
@@ -1,7 +1,7 @@
 // Run: %dxc -T ps_6_0 -E main -fspv-debug=rich
 
 // CHECK:      [[debugSet:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
-// CHECK:   [[debugSource:%\d+]] = OpExtInst %void [[debugSet]] DebugSource {{%\d+}} {{%\d+}}
+// CHECK:   [[debugSource:%\d+]] = OpExtInst %void [[debugSet]] DebugSource
 // CHECK:      [[compUnit:%\d+]] = OpExtInst %void [[debugSet]] DebugCompilationUnit 1 4 [[debugSource]] HLSL
 float4 main(float4 color : COLOR) : SV_TARGET
 // CHECK:          [[main:%\d+]] = OpExtInst %void [[debugSet]] DebugFunction {{%\d+}} {{%\d+}} [[debugSource]] 6 1 [[compUnit]] {{%\d+}} FlagIsProtected|FlagIsPrivate 9 %src_main

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debugsource.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debugsource.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T ps_6_0 -E main -fspv-debug=rich
+// Run: %dxc -T ps_6_0 -E main -fspv-debug=rich-with-source
 
 // CHECK:      [[debugSet:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 // CHECK:               {{%\d+}} = OpExtInst %void [[debugSet]] DebugSource {{%\d+}} {{%\d+}}

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.global-variable.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.global-variable.hlsl
@@ -4,7 +4,7 @@
 // CHECK:    [[varNameC:%\d+]] = OpString "c"
 // CHECK: [[varNameCond:%\d+]] = OpString "cond"
 
-// CHECK:      [[source:%\d+]] = OpExtInst %void [[set]] DebugSource {{%\d+}} {{%\d+}}
+// CHECK:      [[source:%\d+]] = OpExtInst %void [[set]] DebugSource
 // CHECK: [[compileUnit:%\d+]] = OpExtInst %void [[set]] DebugCompilationUnit 1 4 [[source]] HLSL
 
 // CHECK: [[floatType:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Float

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.local-variable.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.local-variable.hlsl
@@ -6,7 +6,7 @@
 // CHECK:    [[varNameA:%\d+]] = OpString "a"
 // CHECK:    [[varNameB:%\d+]] = OpString "b"
 
-// CHECK:      [[source:%\d+]] = OpExtInst %void [[set]] DebugSource {{%\d+}} {{%\d+}}
+// CHECK:      [[source:%\d+]] = OpExtInst %void [[set]] DebugSource
 // CHECK: [[compileUnit:%\d+]] = OpExtInst %void [[set]] DebugCompilationUnit 1 4 [[source]] HLSL
 
 // CHECK: [[floatType:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Float


### PR DESCRIPTION
This commit disables adding the source code in `OpSource` and
`DebugSource` when the debug option is `-fspv-debug=rich`. Instead, it
is enabled when the option is `-fspv-debug=rich-with-source`.