### PR TITLE
[spirv] Fix dynamic cast bug for debug instructions

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -1814,8 +1814,8 @@ public:
 class SpirvDebugInstruction : public SpirvInstruction {
 public:
   static bool classof(const SpirvInstruction *inst) {
-    return inst->getKind() >= IK_DebugCompilationUnit &&
-           inst->getKind() <= IK_DebugTypeMember;
+    return inst->getKind() >= IK_DebugInfoNone &&
+           inst->getKind() <= IK_DebugTypeTemplateParameter;
   }
 
   void setDebugType(SpirvDebugInstruction *type) { debugType = type; }

--- a/tools/clang/unittests/SPIRV/CMakeLists.txt
+++ b/tools/clang/unittests/SPIRV/CMakeLists.txt
@@ -14,6 +14,7 @@ add_clang_unittest(clang-spirv-tests
   SpirvContextTest.cpp
   SpirvTestOptions.cpp
   SpirvTypeTest.cpp
+  SpirvDebugInstructionTest.cpp
   SpirvConstantTest.cpp
   StringTest.cpp
   TestMain.cpp

--- a/tools/clang/unittests/SPIRV/SpirvDebugInstructionTest.cpp
+++ b/tools/clang/unittests/SPIRV/SpirvDebugInstructionTest.cpp
@@ -1,0 +1,52 @@
+//===- unittests/SPIRV/SpirvDebugInstructionTest.cpp - test debug insts --===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===---------------------------------------------------------------------===//
+
+#include "SpirvTestBase.h"
+#include "clang/SPIRV/SpirvBuilder.h"
+#include "clang/SPIRV/SpirvInstruction.h"
+#include "clang/SPIRV/SpirvType.h"
+
+using namespace clang::spirv;
+
+namespace {
+
+class SpirvDebugInstructionTest : public SpirvTestBase {
+public:
+  SpirvDebugInstructionTest() : spirvBuilder(nullptr) {}
+  SpirvBuilder *GetSpirvBuilder();
+
+private:
+  SpirvBuilder *spirvBuilder;
+};
+
+SpirvBuilder *SpirvDebugInstructionTest::GetSpirvBuilder() {
+  if (spirvBuilder != nullptr)
+    return spirvBuilder;
+  SpirvCodeGenOptions opt;
+  spirvBuilder = new (getSpirvContext())
+      SpirvBuilder(getAstContext(), getSpirvContext(), opt);
+  return spirvBuilder;
+}
+
+TEST_F(SpirvDebugInstructionTest, DynamicTypeCheckDebugInfoNone) {
+  SpirvInstruction *i = GetSpirvBuilder()->getOrCreateDebugInfoNone();
+  EXPECT_TRUE(llvm::isa<SpirvDebugInfoNone>(i));
+  EXPECT_TRUE(llvm::isa<SpirvDebugInstruction>(i));
+  EXPECT_TRUE(llvm::isa<SpirvInstruction>(i));
+}
+
+TEST_F(SpirvDebugInstructionTest, DynamicTypeCheckDebugTypeTemplateParameter) {
+  SpirvInstruction *i = getSpirvContext().getDebugTypeTemplateParameter(
+      nullptr, "vtable check", nullptr, nullptr, nullptr, 0, 0);
+  EXPECT_TRUE(llvm::isa<SpirvDebugTypeTemplateParameter>(i));
+  EXPECT_TRUE(llvm::isa<SpirvDebugInstruction>(i));
+  EXPECT_TRUE(llvm::isa<SpirvInstruction>(i));
+}
+
+} // anonymous namespace


### PR DESCRIPTION
When we have a dynamic cast from a SpirvDebugInfoNone instruction to
SpirvDebugInstruction e.g., `SpirvDebugInfoNone x; SpirvDebugInstruction
*y = &x; auto *z = dyn_cast<SpirvDebugInfoNone>(y)`, it returns
`nullptr` without this commit, because
`SpirvDebugInstruction::classof()` does not included `DebugInfoNone`.