### PR TITLE
Fix bit/byte mixup for SpirvDebugTypeMember.offset

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -169,7 +169,7 @@ public:
   getDebugTypeMember(llvm::StringRef name, const SpirvType *type,
                      SpirvDebugSource *source, uint32_t line, uint32_t column,
                      SpirvDebugInstruction *parent, uint32_t flags,
-                     uint32_t offset = UINT32_MAX,
+                     uint32_t offsetInBits = UINT32_MAX,
                      const APValue *value = nullptr);
 
   SpirvDebugInstruction *

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -2381,7 +2381,7 @@ public:
   SpirvDebugTypeMember(llvm::StringRef name, const SpirvType *type,
                        SpirvDebugSource *source, uint32_t line, uint32_t column,
                        SpirvDebugInstruction *parent, uint32_t flags,
-                       uint32_t offset, const APValue *value = nullptr);
+                       uint32_t offsetInBits, const APValue *value = nullptr);
 
   static bool classof(const SpirvInstruction *inst) {
     return inst->getKind() == IK_DebugTypeMember;
@@ -2401,7 +2401,7 @@ public:
   SpirvDebugSource *getSource() const { return source; }
   uint32_t getLine() const { return line; }
   uint32_t getColumn() const { return column; }
-  uint32_t getOffset() const { return offset; }
+  uint32_t getOffsetInBits() const { return offset; }
   uint32_t getDebugFlags() const { return debugFlags; }
   uint32_t getSizeInBits() const override { return size; }
   const APValue *getValue() const { return value; }

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -63,9 +63,9 @@ DebugTypeVisitor::lowerCbufferDebugType(const StructType *type,
 
   auto &members = dbgTyComposite->getMembers();
   for (auto &field : type->getFields()) {
-    uint32_t offset = UINT32_MAX;
+    uint32_t offsetInBits = UINT32_MAX;
     if (field.offset.hasValue())
-      offset = *field.offset;
+      offsetInBits = *field.offset * 8;
 
     // TODO: Replace 2u and 3u with valid flags when debug info extension is
     // placed in SPIRV-Header.
@@ -73,7 +73,7 @@ DebugTypeVisitor::lowerCbufferDebugType(const StructType *type,
         dyn_cast<SpirvDebugInstruction>(spvContext.getDebugTypeMember(
             field.name, field.type, debugInfo->source, line, column,
             dbgTyComposite,
-            /* flags */ 3u, offset, /* value */ nullptr));
+            /* flags */ 3u, offsetInBits, /* value */ nullptr));
     assert(debugInstr);
     setDefaultDebugInfo(debugInstr);
     members.push_back(debugInstr);
@@ -145,12 +145,12 @@ bool DebugTypeVisitor::lowerDebugTypeMember(SpirvDebugTypeMember *debugMember,
   debugMember->setType(memberTy);
 
   uint32_t memberSizeInBits = memberTy->getSizeInBits();
-  uint32_t memberOffset = debugMember->getOffset();
-  if (memberOffset == UINT32_MAX)
-    memberOffset = *offsetInBits;
-  debugMember->updateOffsetAndSize(memberOffset, memberSizeInBits);
+  uint32_t memberOffsetInBits = debugMember->getOffsetInBits();
+  if (memberOffsetInBits == UINT32_MAX)
+    memberOffsetInBits = *offsetInBits;
+  debugMember->updateOffsetAndSize(memberOffsetInBits, memberSizeInBits);
 
-  *offsetInBits = memberOffset + memberSizeInBits;
+  *offsetInBits = memberOffsetInBits + memberSizeInBits;
   if (*sizeInBits < *offsetInBits)
     *sizeInBits = *offsetInBits;
 

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1413,7 +1413,7 @@ bool EmitVisitor::visit(SpirvDebugTypeComposite *inst) {
 bool EmitVisitor::visit(SpirvDebugTypeMember *inst) {
   uint32_t typeNameId = getOrCreateOpStringId(inst->getDebugName());
   const auto offset = typeHandler.getOrCreateConstantInt(
-      llvm::APInt(32, inst->getOffset()), context.getUIntType(32),
+      llvm::APInt(32, inst->getOffsetInBits()), context.getUIntType(32),
       /* isSpecConst */ false);
   const auto size = typeHandler.getOrCreateConstantInt(
       llvm::APInt(32, inst->getSizeInBits()), context.getUIntType(32),

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -1067,9 +1067,9 @@ SpirvDebugTypeComposite *LowerTypeVisitor::lowerDebugTypeComposite(
       }
     }
 
-    uint32_t offset = UINT32_MAX;
+    uint32_t offsetInBits = UINT32_MAX;
     if (fields[fieldIdx].offset.hasValue())
-      offset = *fields[fieldIdx].offset;
+      offsetInBits = *fields[fieldIdx].offset * 8;
 
     RichDebugInfo *fieldDebugInfo = debugInfo;
     file = sm.getPresumedLoc(fieldLoc).getFilename();
@@ -1082,7 +1082,7 @@ SpirvDebugTypeComposite *LowerTypeVisitor::lowerDebugTypeComposite(
         dyn_cast<SpirvDebugInstruction>(spvContext.getDebugTypeMember(
             dyn_cast<FieldDecl>(memberDecl)->getName(), fields[fieldIdx].type,
             fieldDebugInfo->source, fieldLine, fieldColumn, dbgTyComposite,
-            memberDecl->isModulePrivate() ? 2u : 3u, offset, value));
+            memberDecl->isModulePrivate() ? 2u : 3u, offsetInBits, value));
     assert(debugInstr && "We expect SpirvDebugInstruction for DebugTypeMember");
     debugInstr->setAstResultType(astContext.VoidTy);
     debugInstr->setResultType(spvContext.getVoidType());

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -283,12 +283,12 @@ SpirvContext::getDebugTypeBasic(const SpirvType *spirvType,
 SpirvDebugInstruction *SpirvContext::getDebugTypeMember(
     llvm::StringRef name, const SpirvType *type, SpirvDebugSource *source,
     uint32_t line, uint32_t column, SpirvDebugInstruction *parent,
-    uint32_t flags, uint32_t offset, const APValue *value) {
+    uint32_t flags, uint32_t offsetInBits, const APValue *value) {
   // NOTE: Do not search it in debugTypes because it would have the same
   // spirvType but has different parent i.e., type composite.
 
   SpirvDebugTypeMember *debugType = new (this) SpirvDebugTypeMember(
-      name, type, source, line, column, parent, flags, offset, value);
+      name, type, source, line, column, parent, flags, offsetInBits, value);
 
   // NOTE: Do not save it in debugTypes because it would have the same
   // spirvType but it has different parent i.e., type composite. Instead,

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -912,10 +912,10 @@ SpirvDebugTypeFunction::SpirvDebugTypeFunction(
 SpirvDebugTypeMember::SpirvDebugTypeMember(
     llvm::StringRef name, const SpirvType *type_, SpirvDebugSource *source_,
     uint32_t line_, uint32_t column_, SpirvDebugInstruction *parent_,
-    uint32_t flags_, uint32_t offset_, const APValue *value_)
+    uint32_t flags_, uint32_t offsetInBits_, const APValue *value_)
     : SpirvDebugType(IK_DebugTypeMember, /*opcode*/ 11u), type(nullptr),
       source(source_), line(line_), column(column_), parent(parent_),
-      debugFlags(flags_), value(value_), spvType(type_), offset(offset_) {
+      debugFlags(flags_), value(value_), spvType(type_), offset(offsetInBits_) {
   debugName = name;
 }
 

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.cbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.cbuffer.hlsl
@@ -1,38 +1,38 @@
 // Run: %dxc -T vs_6_0 -E main -fspv-debug=rich
 
 struct S {
-    float  f1;
-    float3 f2;
+    float  f1;  // Size: 32,  Offset: [ 0 -  32]
+    float3 f2;  // Size: 96,  Offset: [32 - 128]
 };
 
 cbuffer MyCbuffer : register(b1) {
-    bool     a;
-    int      b;
-    uint2    c;
-    float3x4 d;
-    S        s;
-    float    t[4];
+    bool     a;    // Size:  32, Offset: [  0 -  32]
+    int      b;    // Size:  32, Offset: [ 32 -  64]
+    uint2    c;    // Size:  64, Offset: [ 64 - 128]
+    float3x4 d;    // Size: 384, Offset: [128 - 512]
+    S        s;    // Size: 128, Offset: [640 - 768]
+    float    t[4]; // Size: 128, Offset: [768 - 896]
 };
 
 cbuffer AnotherCBuffer : register(b2) {
-    float3 m;
-    float4 n;
+    float3 m;  // Size:  96, Offset: [ 0  -  96]
+    float4 n;  // Size: 128, Offset: [128 - 256]
 }
 
-// CHECK: [[AnotherCBuffer:%\d+]] = OpExtInst %void [[ext:%\d+]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 0 0 {{%\d+}} {{%\d+}} %uint_144 FlagIsProtected|FlagIsPrivate [[m:%\d+]] [[n:%\d+]]
-// CHECK: [[n]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[AnotherCBuffer]] %uint_16 %uint_128
+// CHECK: [[AnotherCBuffer:%\d+]] = OpExtInst %void [[ext:%\d+]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 0 0 {{%\d+}} {{%\d+}} %uint_256 FlagIsProtected|FlagIsPrivate [[m:%\d+]] [[n:%\d+]]
+// CHECK: [[n]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[AnotherCBuffer]] %uint_128 %uint_128
 // CHECK: [[m]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[AnotherCBuffer]] %uint_0 %uint_96
 
-// CHECK: [[MyCbuffer:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 0 0 {{%\d+}} {{%\d+}} %uint_400 FlagIsProtected|FlagIsPrivate [[a:%\d+]] [[b:%\d+]] [[c:%\d+]] [[d:%\d+]] [[s:%\d+]] [[t:%\d+]]
-// CHECK: [[t]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_96 %uint_128
+// CHECK: [[MyCbuffer:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 0 0 {{%\d+}} {{%\d+}} %uint_896 FlagIsProtected|FlagIsPrivate [[a:%\d+]] [[b:%\d+]] [[c:%\d+]] [[d:%\d+]] [[s:%\d+]] [[t:%\d+]]
+// CHECK: [[t]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_768 %uint_128
 
-// CHECK: [[S:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 3 1 {{%\d+}} {{%\d+}} %uint_100 FlagIsProtected|FlagIsPrivate [[f1:%\d+]] [[f2:%\d+]]
-// CHECK: [[s]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} [[S]] {{%\d+}} 0 0 [[MyCbuffer]] %uint_80 %uint_100
-// CHECK: [[d]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_16 %uint_384
-// CHECK: [[c]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_8 %uint_64
-// CHECK: [[b]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_4 %uint_32
+// CHECK: [[S:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 3 1 {{%\d+}} {{%\d+}} %uint_128 FlagIsProtected|FlagIsPrivate [[f1:%\d+]] [[f2:%\d+]]
+// CHECK: [[s]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} [[S]] {{%\d+}} 0 0 [[MyCbuffer]] %uint_640 %uint_128
+// CHECK: [[d]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_128 %uint_384
+// CHECK: [[c]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_64 %uint_64
+// CHECK: [[b]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_32 %uint_32
 // CHECK: [[a]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_0 %uint_32
-// CHECK: [[f2]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 5 5 [[S]] %uint_4 %uint_96
+// CHECK: [[f2]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 5 5 [[S]] %uint_32 %uint_96
 // CHECK: [[f1]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 4 5 [[S]] %uint_0 %uint_32
 
 // CHECK: {{%\d+}} = OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} {{%\d+}} {{%\d+}} 17 9 {{%\d+}} {{%\d+}} %AnotherCBuffer


### PR DESCRIPTION
Rename `offset` variables to `offsetInBits` to try avoiding this sort of mistake in the future.