### PR TITLE
[spirv] fix sorting DebugTypeTemplateParam bug

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/rich.debug.rwtexture.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.rwtexture.hlsl
@@ -5,20 +5,20 @@
 //CHECK: [[name_3d:%\d+]] = OpString "@type.3d.image"
 //CHECK: [[name_1d:%\d+]] = OpString "@type.1d.image"
 
-//CHECK: [[tem_p6:%\d+]] = OpExtInst %void [[ext:%\d+]] DebugTypeTemplateParameter
-//CHECK: [[2daf:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_2d_arr]] Class [[src:%\d+]] 0 0 [[cu:%\d+]] {{%\d+}} [[info_none:%\d+]]
+//CHECK: [[2daf:%\d+]] = OpExtInst %void [[ext:%\d+]] DebugTypeComposite [[name_2d_arr]] Class [[src:%\d+]] 0 0 [[cu:%\d+]] {{%\d+}} [[info_none:%\d+]]
+//CHECK: [[tem_p6:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
 //CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[2daf]] [[tem_p6]]
 
-//CHECK: [[tem_p3:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
 //CHECK: [[1dai:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_1d_arr]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
+//CHECK: [[tem_p3:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
 //CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[1dai]] [[tem_p3]]
 
-//CHECK: [[tem_p2:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
 //CHECK: [[3df:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_3d]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
+//CHECK: [[tem_p2:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
 //CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[3df]] [[tem_p2]]
 
-//CHECK: [[tem_p0:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
 //CHECK: [[1di:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_1d]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
+//CHECK: [[tem_p0:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
 //CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[1di]] [[tem_p0]]
 
 //CHECK: OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} [[2daf]] [[src]] {{\d+}} {{\d+}} [[cu]] {{%\d+}} %t8

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.sort.type.template.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.sort.type.template.hlsl
@@ -1,0 +1,13 @@
+// Run: %dxc -T ps_6_0 -E main -fspv-debug=rich
+
+// CHECK: [[dbg_info_none:%\d+]] = OpExtInst %void [[ext:%\d+]] DebugInfoNone
+// CHECK: [[ty:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite {{%\d+}} Class {{%\d+}} 0 0 {{%\d+}} {{%\d+}} [[dbg_info_none]]
+// CHECK: [[param:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter {{%\d+}} {{%\d+}} [[dbg_info_none]]
+// CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[ty]] [[param]]
+
+Texture2D<float4> tex : register(t0);
+
+float4 main(float4 pos : SV_Position) : SV_Target0
+{
+  return tex.Load(int3(pos.xy, 0));
+}

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.structured-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.structured-buffer.hlsl
@@ -22,32 +22,32 @@ RWStructuredBuffer<T> mySBuffer4 : register(u4);
 // CHECK: [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 // CHECK: [[T:%\d+]] = OpString "T"
 // CHECK: [[S:%\d+]] = OpString "S"
-// CHECK: [[temp1:%\d+]] = OpString "RWStructuredBuffer.TemplateParam"
 // CHECK: [[RW_T:%\d+]] = OpString "@type.RWStructuredBuffer.T"
+// CHECK: [[temp1:%\d+]] = OpString "RWStructuredBuffer.TemplateParam"
 // CHECK: [[RW_S:%\d+]] = OpString "@type.RWStructuredBuffer.S"
-// CHECK: [[temp0:%\d+]] = OpString "StructuredBuffer.TemplateParam"
 // CHECK: [[SB_T:%\d+]] = OpString "@type.StructuredBuffer.T"
+// CHECK: [[temp0:%\d+]] = OpString "StructuredBuffer.TemplateParam"
 // CHECK: [[SB_S:%\d+]] = OpString "@type.StructuredBuffer.S"
 // CHECK: [[inputBuffer:%\d+]] = OpString "inputBuffer"
 
 // CHECK: [[T_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[T]] Structure
 // CHECK: [[S_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[S]] Structure
 
-// CHECK: [[param3:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[temp1]] [[T_ty]]
 // CHECK: [[none:%\d+]] = OpExtInst %void [[set]] DebugInfoNone
 // CHECK: [[RW_T_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[RW_T]] Class {{%\d+}} 0 0 {{%\d+}} {{%\d+}} [[none]]
+// CHECK: [[param3:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[temp1]] [[T_ty]]
 // CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugTypeTemplate [[RW_T_ty]] [[param3]]
 
-// CHECK: [[param2:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[temp1]] [[S_ty]]
 // CHECK: [[RW_S_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[RW_S]] Class {{%\d+}} 0 0 {{%\d+}} {{%\d+}} [[none]]
+// CHECK: [[param2:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[temp1]] [[S_ty]]
 // CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugTypeTemplate [[RW_S_ty]] [[param2]]
 
-// CHECK: [[param1:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[temp0]] [[T_ty]]
 // CHECK: [[SB_T_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[SB_T]] Class {{%\d+}} 0 0 {{%\d+}} {{%\d+}} [[none]]
+// CHECK: [[param1:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[temp0]] [[T_ty]]
 // CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugTypeTemplate [[SB_T_ty]] [[param1]]
 
-// CHECK: [[param0:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[temp0]] [[S_ty]]
 // CHECK: [[SB_S_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[SB_S]] Class {{%\d+}} 0 0 {{%\d+}} {{%\d+}} [[none]]
+// CHECK: [[param0:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[temp0]] [[S_ty]]
 // CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugTypeTemplate [[SB_S_ty]] [[param0]]
 
 // CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[inputBuffer]] [[RW_S_ty]]

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.texture.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.texture.hlsl
@@ -4,21 +4,21 @@
 //CHECK: [[name_2d:%\d+]] = OpString "@type.2d.image"
 //CHECK: [[name_cb_arr:%\d+]] = OpString "@type.cube.image.array"
 
-//CHECK: [[tem_p3:%\d+]] = OpExtInst %void [[ext:%\d+]] DebugTypeTemplateParameter
-//CHECK: [[info_none:%\d+]] = OpExtInst %void [[ext]] DebugInfoNone
+//CHECK: [[info_none:%\d+]] = OpExtInst %void [[ext:%\d+]] DebugInfoNone
 //CHECK: [[t3_ty:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_2d_arr]] Class [[src:%\d+]] 0 0 [[cu:%\d+]] {{%\d+}} [[info_none]]
+//CHECK: [[tem_p3:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
 //CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[t3_ty]] [[tem_p3]]
 
-//CHECK: [[tem_p2:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
 //CHECK: [[t2_ty:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_2d]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
+//CHECK: [[tem_p2:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
 //CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[t2_ty]] [[tem_p2]]
 
-//CHECK: [[tem_p1:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
 //CHECK: [[t1_ty:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_cb_arr]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
+//CHECK: [[tem_p1:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
 //CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[t1_ty]] [[tem_p1]]
 
-//CHECK: [[tem_p0:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
 //CHECK: [[t0_ty:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_2d]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
+//CHECK: [[tem_p0:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
 //CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[t0_ty]] [[tem_p0]]
 
 //CHECK: OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} [[t3_ty]] [[src]] {{\d+}} {{\d+}} [[cu]] {{%\d+}} %t3

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2306,7 +2306,7 @@ TEST_F(FileTest, CompatibilityWithVk1p1) {
 // TODO: change |runValidation| parameter back to 'true' once the following bug
 // has been fixed in SPIRV-Tools:
 // https://github.com/KhronosGroup/SPIRV-Tools/issues/3086
-const bool runValidationForRichDebugInfo = false;
+const bool runValidationForRichDebugInfo = true;
 
 TEST_F(FileTest, RichDebugInfoDebugSource) {
   runFileTest("rich.debug.debugsource.hlsl", Expect::Success,
@@ -2374,7 +2374,7 @@ TEST_F(FileTest, RichDebugInfoTypeCompositeBeforeFunction) {
 }
 TEST_F(FileTest, RichDebugInfoTypeStructuredBuffer) {
   runFileTest("rich.debug.structured-buffer.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+              /*runValidation*/ false);
 }
 TEST_F(FileTest, RichDebugInfoLocalVariable) {
   runFileTest("rich.debug.local-variable.hlsl", Expect::Success,
@@ -2426,6 +2426,10 @@ TEST_F(FileTest, RichDebugInfoTypeSampler) {
 }
 TEST_F(FileTest, RichDebugInfoCbuffer) {
   runFileTest("rich.debug.cbuffer.hlsl", Expect::Success,
+              /*runValidation*/ runValidationForRichDebugInfo);
+}
+TEST_F(FileTest, RichDebugSortTypeTemplate) {
+  runFileTest("rich.debug.sort.type.template.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
 


### PR DESCRIPTION
We emit DebugInfoNone for Value operand of DebugTypeTemplateParam
when DebugTypeTemplateParam is used for a type, not a value. Previously,
we did not consider the case in SortDebugInfoVisitor.

Fixes #311