### PR TITLE
[spirv] Add DebugDeclare for variables without init

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1477,8 +1477,7 @@ void SpirvEmitter::doVarDecl(const VarDecl *decl) {
       auto *debugLocalVar = spvBuilder.createDebugLocalVariable(
           decl->getType(), decl->getName(), info->source, line, column,
           info->scopeStack.back(), flags);
-      if (decl->getInit() != nullptr)
-        spvBuilder.createDebugDeclare(debugLocalVar, var);
+      spvBuilder.createDebugDeclare(debugLocalVar, var);
     }
 
     // Variables that are not externally visible and of opaque types should

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debugdeclare.without.init.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debugdeclare.without.init.hlsl
@@ -1,0 +1,30 @@
+// Run: %dxc -T ps_6_0 -E main -fspv-debug=rich
+
+// CHECK:      %i = OpFunctionParameter %_ptr_Function_PS_INPUT
+// CHECK-NEXT: DebugDeclare {{%\d+}} %i
+// CHECK:      %ps_output = OpVariable %_ptr_Function_PS_OUTPUT Function
+// CHECK:      %c = OpVariable %_ptr_Function_v4float Function
+// CHECK:      DebugDeclare {{%\d+}} %ps_output
+// CHECK:      DebugDeclare {{%\d+}} %c
+
+Texture2D g_tColor;
+
+SamplerState g_sAniso;
+
+struct PS_INPUT {
+  float2 vTextureCoords2 : TEXCOORD2;
+  float2 vTextureCoords3 : TEXCOORD3;
+};
+
+struct PS_OUTPUT {
+  float4 vColor : SV_Target0;
+};
+
+PS_OUTPUT main(PS_INPUT i) {
+  PS_OUTPUT ps_output;
+  float4 c;
+  c = g_tColor.Sample(g_sAniso, i.vTextureCoords2.xy);
+  c += g_tColor.Sample(g_sAniso, i.vTextureCoords3.xy);
+  ps_output.vColor = c;
+  return ps_output;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2408,6 +2408,10 @@ TEST_F(FileTest, RichDebugInfoDeclare) {
   runFileTest("rich.debug.debugdeclare.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
+TEST_F(FileTest, RichDebugInfoDeclareWithoutInit) {
+  runFileTest("rich.debug.debugdeclare.without.init.hlsl", Expect::Success,
+              /*runValidation*/ runValidationForRichDebugInfo);
+}
 TEST_F(FileTest, RichDebugInfoScope) {
   runFileTest("rich.debug.debugscope.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);


### PR DESCRIPTION
Even when a local variable does not have the initialization, we have to
map its storage e.g., OpVariable to its DebugLocalVariable.