### PR TITLE
[spirv] refactoring debug type generation

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -471,13 +471,12 @@ public:
       SpirvDebugLocalVariable *dbgVar, SpirvInstruction *var,
       llvm::Optional<SpirvDebugExpression *> dbgExpr = llvm::None);
 
-  SpirvDebugFunction *createDebugFunction(llvm::StringRef name,
-                                          SpirvDebugSource *src,
-                                          uint32_t fnLine, uint32_t fnColumn,
-                                          SpirvDebugInstruction *parentScope,
-                                          llvm::StringRef linkageName,
-                                          uint32_t flags, uint32_t scopeLine,
-                                          SpirvFunction *fn);
+  SpirvDebugFunction *
+  createDebugFunction(const FunctionDecl *decl, llvm::StringRef name,
+                      SpirvDebugSource *src, uint32_t fnLine, uint32_t fnColumn,
+                      SpirvDebugInstruction *parentScope,
+                      llvm::StringRef linkageName, uint32_t flags,
+                      uint32_t scopeLine, SpirvFunction *fn);
 
   /// \brief Create SPIR-V instructions for KHR RayQuery ops
   SpirvInstruction *

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -172,12 +172,13 @@ public:
                      uint32_t offsetInBits = UINT32_MAX,
                      const APValue *value = nullptr);
 
-  SpirvDebugInstruction *
-  getDebugTypeComposite(const SpirvType *spirvType, llvm::StringRef name,
-                        SpirvDebugSource *source, uint32_t line,
-                        uint32_t column, SpirvDebugInstruction *parent,
-                        llvm::StringRef linkageName, uint32_t size,
-                        uint32_t flags, uint32_t tag);
+  SpirvDebugTypeComposite *getDebugTypeComposite(const SpirvType *spirvType,
+                                                 llvm::StringRef name,
+                                                 SpirvDebugSource *source,
+                                                 uint32_t line, uint32_t column,
+                                                 SpirvDebugInstruction *parent,
+                                                 llvm::StringRef linkageName,
+                                                 uint32_t flags, uint32_t tag);
 
   SpirvDebugInstruction *getDebugType(const SpirvType *spirvType);
 

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -195,13 +195,21 @@ public:
                        SpirvDebugType *ret,
                        llvm::ArrayRef<SpirvDebugType *> params);
 
-  SpirvDebugInstruction *getDebugTypeTemplate(const SpirvType *spirvType,
-                                              SpirvDebugInstruction *target);
+  SpirvDebugTypeTemplate *createDebugTypeTemplate(
+      const TemplateSpecializationType *templateType,
+      SpirvDebugInstruction *target,
+      const llvm::SmallVector<SpirvDebugTypeTemplateParameter *, 2> &params);
 
-  SpirvDebugInstruction *getDebugTypeTemplateParameter(
-      const SpirvType *parentType, llvm::StringRef name, const SpirvType *type,
-      SpirvInstruction *value, SpirvDebugSource *source, uint32_t line,
-      uint32_t column);
+  SpirvDebugTypeTemplate *
+  getDebugTypeTemplate(const TemplateSpecializationType *templateType);
+
+  SpirvDebugTypeTemplateParameter *createDebugTypeTemplateParameter(
+      const TemplateArgument *templateArg, llvm::StringRef name,
+      const SpirvType *type, SpirvInstruction *value, SpirvDebugSource *source,
+      uint32_t line, uint32_t column);
+
+  SpirvDebugTypeTemplateParameter *
+  getDebugTypeTemplateParameter(const TemplateArgument *templateArg);
 
   llvm::MapVector<const SpirvType *, SpirvDebugType *> &getDebugTypes() {
     return debugTypes;
@@ -428,6 +436,12 @@ private:
   // The purpose is not to generate several DebugType* instructions for the same
   // type if the type is used for several variables.
   llvm::MapVector<const SpirvType *, SpirvDebugType *> debugTypes;
+
+  // Mapping from QualType type to debug type instruction for templates.
+  llvm::MapVector<const TemplateSpecializationType *, SpirvDebugTypeTemplate *>
+      typeTemplates;
+  llvm::MapVector<const TemplateArgument *, SpirvDebugTypeTemplateParameter *>
+      typeTemplateParams;
 
   // Mapping from SPIR-V type to QualType for a record type.
   llvm::DenseMap<const SpirvType *, const RecordType *> spvTypeToRecordType;

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -166,7 +166,8 @@ public:
                                     uint32_t encoding);
 
   SpirvDebugType *getDebugTypeMember(llvm::StringRef name, SpirvDebugType *type,
-                                     SpirvDebugSource *source,
+                                     SpirvDebugSource *source, uint32_t line,
+                                     uint32_t column,
                                      SpirvDebugInstruction *parent,
                                      uint32_t flags,
                                      uint32_t offsetInBits = UINT32_MAX,
@@ -353,6 +354,18 @@ public:
     return it->second;
   }
 
+  /// Function to add/get the mapping from a FunctionDecl to its DebugFunction.
+  void addDeclToDebugFunction(const FunctionDecl *decl,
+                              SpirvDebugFunction *fn) {
+    declToDebugFunction[decl] = fn;
+  }
+  SpirvDebugFunction *getDebugFunctionForDecl(const FunctionDecl *decl) {
+    auto it = declToDebugFunction.find(decl);
+    if (it == declToDebugFunction.end())
+      return nullptr;
+    return it->second;
+  }
+
 private:
   /// \brief The allocator used to create SPIR-V entity objects.
   ///
@@ -424,10 +437,12 @@ private:
   llvm::DenseMap<const TemplateArgument *, SpirvDebugTypeTemplateParameter *>
       typeTemplateParams;
 
-  // Mapping from SPIR-V type to QualType for a record type.
-  llvm::DenseMap<const SpirvType *, const RecordType *> spvTypeToRecordType;
   // Mapping from SPIR-V type to Decl for a struct type.
   llvm::DenseMap<const SpirvType *, const DeclContext *> spvTypeToDecl;
+
+  // Mapping from FunctionDecl to SPIR-V debug function.
+  llvm::DenseMap<const FunctionDecl *, SpirvDebugFunction *>
+      declToDebugFunction;
 
   // Mapping from CXXMethodDecl (member method of struct or class) to its
   // function info.

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -160,17 +160,16 @@ public:
   // === DebugTypes ===
 
   // TODO: Replace uint32_t with an enum for encoding.
-  SpirvDebugInstruction *getDebugTypeBasic(const SpirvType *spirvType,
-                                           llvm::StringRef name,
-                                           SpirvConstant *size,
-                                           uint32_t encoding);
+  SpirvDebugType *getDebugTypeBasic(const SpirvType *spirvType,
+                                    llvm::StringRef name, SpirvConstant *size,
+                                    uint32_t encoding);
 
-  SpirvDebugInstruction *
-  getDebugTypeMember(llvm::StringRef name, const SpirvType *type,
-                     SpirvDebugSource *source, uint32_t line, uint32_t column,
-                     SpirvDebugInstruction *parent, uint32_t flags,
-                     uint32_t offsetInBits = UINT32_MAX,
-                     const APValue *value = nullptr);
+  SpirvDebugType *getDebugTypeMember(llvm::StringRef name, SpirvDebugType *type,
+                                     SpirvDebugSource *source,
+                                     SpirvDebugInstruction *parent,
+                                     uint32_t flags,
+                                     uint32_t offsetInBits = UINT32_MAX,
+                                     const APValue *value = nullptr);
 
   SpirvDebugTypeComposite *getDebugTypeComposite(const SpirvType *spirvType,
                                                  llvm::StringRef name,
@@ -180,32 +179,31 @@ public:
                                                  llvm::StringRef linkageName,
                                                  uint32_t flags, uint32_t tag);
 
-  SpirvDebugInstruction *getDebugType(const SpirvType *spirvType);
+  SpirvDebugType *getDebugType(const SpirvType *spirvType);
 
-  SpirvDebugInstruction *getDebugTypeArray(const SpirvType *spirvType,
-                                           SpirvDebugInstruction *elemType,
-                                           llvm::ArrayRef<uint32_t> elemCount);
+  SpirvDebugType *getDebugTypeArray(const SpirvType *spirvType,
+                                    SpirvDebugInstruction *elemType,
+                                    llvm::ArrayRef<uint32_t> elemCount);
 
-  SpirvDebugInstruction *getDebugTypeVector(const SpirvType *spirvType,
-                                            SpirvDebugInstruction *elemType,
-                                            uint32_t elemCount);
+  SpirvDebugType *getDebugTypeVector(const SpirvType *spirvType,
+                                     SpirvDebugInstruction *elemType,
+                                     uint32_t elemCount);
 
-  SpirvDebugInstruction *
-  getDebugTypeFunction(const SpirvType *spirvType, uint32_t flags,
-                       SpirvDebugType *ret,
-                       llvm::ArrayRef<SpirvDebugType *> params);
+  SpirvDebugType *getDebugTypeFunction(const SpirvType *spirvType,
+                                       uint32_t flags, SpirvDebugType *ret,
+                                       llvm::ArrayRef<SpirvDebugType *> params);
 
   SpirvDebugTypeTemplate *createDebugTypeTemplate(
-      const TemplateSpecializationType *templateType,
+      const ClassTemplateSpecializationDecl *templateType,
       SpirvDebugInstruction *target,
       const llvm::SmallVector<SpirvDebugTypeTemplateParameter *, 2> &params);
 
   SpirvDebugTypeTemplate *
-  getDebugTypeTemplate(const TemplateSpecializationType *templateType);
+  getDebugTypeTemplate(const ClassTemplateSpecializationDecl *templateType);
 
   SpirvDebugTypeTemplateParameter *createDebugTypeTemplateParameter(
       const TemplateArgument *templateArg, llvm::StringRef name,
-      const SpirvType *type, SpirvInstruction *value, SpirvDebugSource *source,
+      SpirvDebugType *type, SpirvInstruction *value, SpirvDebugSource *source,
       uint32_t line, uint32_t column);
 
   SpirvDebugTypeTemplateParameter *
@@ -348,19 +346,6 @@ public:
     return currentLexicalScope;
   }
 
-  /// Function to add/get the mapping from a SPIR-V type to its QualType for
-  /// a record type.
-  void addSpirvTypeToRecordType(const SpirvType *spvTy,
-                                const RecordType *recordTy) {
-    spvTypeToRecordType[spvTy] = recordTy;
-  }
-  const RecordType *getRecordType(const SpirvType *spvTy) {
-    auto it = spvTypeToRecordType.find(spvTy);
-    if (it == spvTypeToRecordType.end())
-      return nullptr;
-    return it->second;
-  }
-
   /// Function to add/get the mapping from a SPIR-V type to its Decl for
   /// a struct type.
   void addSpirvTypeToDecl(const SpirvType *spvTy, const DeclContext *decl) {
@@ -438,7 +423,8 @@ private:
   llvm::MapVector<const SpirvType *, SpirvDebugType *> debugTypes;
 
   // Mapping from QualType type to debug type instruction for templates.
-  llvm::MapVector<const TemplateSpecializationType *, SpirvDebugTypeTemplate *>
+  llvm::MapVector<const ClassTemplateSpecializationDecl *,
+                  SpirvDebugTypeTemplate *>
       typeTemplates;
   llvm::MapVector<const TemplateArgument *, SpirvDebugTypeTemplateParameter *>
       typeTemplateParams;

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -169,9 +169,8 @@ public:
                                      SpirvDebugSource *source, uint32_t line,
                                      uint32_t column,
                                      SpirvDebugInstruction *parent,
-                                     uint32_t flags,
-                                     uint32_t offsetInBits = UINT32_MAX,
-                                     const APValue *value = nullptr);
+                                     uint32_t flags, uint32_t offsetInBits,
+                                     uint32_t sizeInBits, const APValue *value);
 
   SpirvDebugTypeComposite *getDebugTypeComposite(const SpirvType *spirvType,
                                                  llvm::StringRef name,

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -340,7 +340,7 @@ public:
   }
 
   /// Function to add/get the mapping from a SPIR-V type to its QualType for
-  /// a type of a resource.
+  /// a record type.
   void addSpirvTypeToRecordType(const SpirvType *spvTy,
                                 const RecordType *recordTy) {
     spvTypeToRecordType[spvTy] = recordTy;
@@ -348,6 +348,18 @@ public:
   const RecordType *getRecordType(const SpirvType *spvTy) {
     auto it = spvTypeToRecordType.find(spvTy);
     if (it == spvTypeToRecordType.end())
+      return nullptr;
+    return it->second;
+  }
+
+  /// Function to add/get the mapping from a SPIR-V type to its Decl for
+  /// a struct type.
+  void addSpirvTypeToDecl(const SpirvType *spvTy, const DeclContext *decl) {
+    spvTypeToDecl[spvTy] = decl;
+  }
+  const DeclContext *getDeclForSpirvType(const SpirvType *spvTy) {
+    auto it = spvTypeToDecl.find(spvTy);
+    if (it == spvTypeToDecl.end())
       return nullptr;
     return it->second;
   }
@@ -416,8 +428,10 @@ private:
   // type if the type is used for several variables.
   llvm::MapVector<const SpirvType *, SpirvDebugType *> debugTypes;
 
-  // Mapping from SPIR-V type to QualType for a resource type.
+  // Mapping from SPIR-V type to QualType for a record type.
   llvm::DenseMap<const SpirvType *, const RecordType *> spvTypeToRecordType;
+  // Mapping from SPIR-V type to Decl for a struct type.
+  llvm::DenseMap<const SpirvType *, const DeclContext *> spvTypeToDecl;
 
   // Keep DebugTypeMember, DebugTypeInheritance, DebugTypeTemplate,
   // and DebugTypeTemplateParameter.

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -339,6 +339,19 @@ public:
     return currentLexicalScope;
   }
 
+  /// Function to add/get the mapping from a SPIR-V type to its QualType for
+  /// a type of a resource.
+  void addSpirvTypeToRecordType(const SpirvType *spvTy,
+                                const RecordType *recordTy) {
+    spvTypeToRecordType[spvTy] = recordTy;
+  }
+  const RecordType *getRecordType(const SpirvType *spvTy) {
+    auto it = spvTypeToRecordType.find(spvTy);
+    if (it == spvTypeToRecordType.end())
+      return nullptr;
+    return it->second;
+  }
+
 private:
   /// \brief The allocator used to create SPIR-V entity objects.
   ///
@@ -402,6 +415,9 @@ private:
   // The purpose is not to generate several DebugType* instructions for the same
   // type if the type is used for several variables.
   llvm::MapVector<const SpirvType *, SpirvDebugType *> debugTypes;
+
+  // Mapping from SPIR-V type to QualType for a resource type.
+  llvm::DenseMap<const SpirvType *, const RecordType *> spvTypeToRecordType;
 
   // Keep DebugTypeMember, DebugTypeInheritance, DebugTypeTemplate,
   // and DebugTypeTemplateParameter.

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -2496,7 +2496,9 @@ public:
   void setSizeInBits(uint32_t size_) { size = size_; }
   uint32_t getSizeInBits() const override { return size; }
 
-  void markOpaqueType(SpirvDebugInfoNone *none) {
+  void markAsOpaqueType(SpirvDebugInfoNone *none) {
+    // If it was already marked as a opaque type, just return. For example,
+    // `debugName` can be "@@Texture2D" if we call this method twice.
     if (debugNone == none && !debugName.empty() && debugName[0] == '@')
       return;
     debugName = std::string("@") + debugName;

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -2446,8 +2446,6 @@ public:
 
   SpirvDebugInstruction *getParentScope() const override { return parent; }
 
-  void setType(SpirvDebugType *type_) { type = type_; }
-  SpirvDebugType *getType() const { return type; }
   SpirvDebugSource *getSource() const { return source; }
   uint32_t getLine() const { return line; }
   uint32_t getColumn() const { return column; }
@@ -2459,7 +2457,6 @@ public:
   const SpirvType *getSpirvType() const { return spvType; }
 
 private:
-  SpirvDebugType *type;     //< The type of the current member
   SpirvDebugSource *source; //< DebugSource containing this type
   uint32_t line;            //< Line number
   uint32_t column;          //< Column number
@@ -2488,8 +2485,8 @@ public:
   SpirvDebugTypeComposite(llvm::StringRef name, SpirvDebugSource *source,
                           uint32_t line, uint32_t column,
                           SpirvDebugInstruction *parent,
-                          llvm::StringRef linkageName, uint32_t size,
-                          uint32_t flags, uint32_t tag);
+                          llvm::StringRef linkageName, uint32_t flags,
+                          uint32_t tag);
 
   static bool classof(const SpirvInstruction *inst) {
     return inst->getKind() == IK_DebugTypeComposite;
@@ -2513,9 +2510,6 @@ public:
 
   void setTypeTemplate(SpirvDebugTypeTemplate *t) { typeTemplate = t; }
   SpirvDebugTypeTemplate *getTypeTemplate() const { return typeTemplate; }
-
-  void setFullyLowered() { fullyLowered = true; }
-  bool getFullyLowered() const { return fullyLowered; }
 
   void setDebugInfoNone(SpirvDebugInfoNone *none) { debugNone = none; }
   SpirvDebugInfoNone *getDebugInfoNone() const { return debugNone; }
@@ -2554,11 +2548,6 @@ private:
   // the limitation of single value for the map. Instead, we keep it
   // here.
   SpirvDebugTypeTemplate *typeTemplate;
-
-  // It is first lowered by LowerTypeVisitor and then lowered by
-  // DebugTypeVisitor. We set fullyLowered true after it is lowered
-  // by DebugTypeVisitor.
-  bool fullyLowered;
 
   // When it is DebugTypeComposite for HLSL resource type i.e., opaque
   // type, we must put DebugInfoNone for Size operand.

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -2429,7 +2429,7 @@ public:
                        SpirvDebugSource *source, uint32_t line_,
                        uint32_t column_, SpirvDebugInstruction *parent,
                        uint32_t flags, uint32_t offsetInBits,
-                       const APValue *value = nullptr);
+                       uint32_t sizeInBits, const APValue *value = nullptr);
 
   static bool classof(const SpirvInstruction *inst) {
     return inst->getKind() == IK_DebugTypeMember;
@@ -2442,9 +2442,9 @@ public:
   SpirvDebugSource *getSource() const { return source; }
   uint32_t getLine() const { return line; }
   uint32_t getColumn() const { return column; }
-  uint32_t getOffsetInBits() const { return offset; }
+  uint32_t getOffsetInBits() const { return offsetInBits; }
   uint32_t getDebugFlags() const { return debugFlags; }
-  uint32_t getSizeInBits() const override { return size; }
+  uint32_t getSizeInBits() const override { return sizeInBits; }
   const APValue *getValue() const { return value; }
 
 private:
@@ -2454,8 +2454,8 @@ private:
 
   SpirvDebugInstruction *parent; //< The parent DebugTypeComposite
 
-  uint32_t offset; //< Offset (in bits) of this member in the struct
-  uint32_t size;   //< Size (in bits) of this member in the struct
+  uint32_t offsetInBits; //< Offset (in bits) of this member in the struct
+  uint32_t sizeInBits;   //< Size (in bits) of this member in the struct
   // TODO: Replace uint32_t with enum in the SPIRV-Headers once it is
   // available.
   uint32_t debugFlags;

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -2497,6 +2497,8 @@ public:
   uint32_t getSizeInBits() const override { return size; }
 
   void markOpaqueType(SpirvDebugInfoNone *none) {
+    if (debugNone == none && !debugName.empty() && debugName[0] == '@')
+      return;
     debugName = std::string("@") + debugName;
     debugNone = none;
   }

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -2426,17 +2426,13 @@ private:
 class SpirvDebugTypeMember : public SpirvDebugType {
 public:
   SpirvDebugTypeMember(llvm::StringRef name, SpirvDebugType *type,
-                       SpirvDebugSource *source, SpirvDebugInstruction *parent,
+                       SpirvDebugSource *source, uint32_t line_,
+                       uint32_t column_, SpirvDebugInstruction *parent,
                        uint32_t flags, uint32_t offsetInBits,
                        const APValue *value = nullptr);
 
   static bool classof(const SpirvInstruction *inst) {
     return inst->getKind() == IK_DebugTypeMember;
-  }
-
-  void SetLineAndColumn(uint32_t line_, uint32_t column_) {
-    line = line_;
-    column = column_;
   }
 
   bool invokeVisitor(Visitor *v) override;

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -2382,22 +2382,20 @@ public:
   uint32_t getLine() const { return line; }
   uint32_t getColumn() const { return column; }
 
-  const SpirvType *getSpirvType() const { return spvType; }
-
 private:
   SpirvDebugType *actualType; //< Type for type param
   SpirvInstruction *value;    //< Value. It must be null for type.
   SpirvDebugSource *source;   //< DebugSource containing this type
   uint32_t line;              //< Line number
   uint32_t column;            //< Column number
-
-  const SpirvType *spvType;
 };
 
 /// Represents debug information for a template type.
 class SpirvDebugTypeTemplate : public SpirvDebugType {
 public:
-  SpirvDebugTypeTemplate(SpirvDebugInstruction *target);
+  SpirvDebugTypeTemplate(
+      SpirvDebugInstruction *target,
+      const llvm::SmallVector<SpirvDebugTypeTemplateParameter *, 2> &params);
 
   static bool classof(const SpirvInstruction *inst) {
     return inst->getKind() == IK_DebugTypeTemplate;
@@ -2405,7 +2403,7 @@ public:
 
   bool invokeVisitor(Visitor *v) override;
 
-  llvm::SmallVector<SpirvDebugTypeTemplateParameter *, 2> &getParams() {
+  llvm::SmallVector<SpirvDebugTypeTemplateParameter *, 2> getParams() {
     return params;
   }
   SpirvDebugInstruction *getTarget() const { return target; }
@@ -2508,9 +2506,6 @@ public:
   void setSizeInBits(uint32_t size_) { size = size_; }
   uint32_t getSizeInBits() const override { return size; }
 
-  void setTypeTemplate(SpirvDebugTypeTemplate *t) { typeTemplate = t; }
-  SpirvDebugTypeTemplate *getTypeTemplate() const { return typeTemplate; }
-
   void setDebugInfoNone(SpirvDebugInfoNone *none) { debugNone = none; }
   SpirvDebugInfoNone *getDebugInfoNone() const { return debugNone; }
 
@@ -2539,15 +2534,6 @@ private:
   // DebugTypeInheritance. Since DebugFunction may be a member, we cannot use a
   // vector of SpirvDebugType.
   llvm::SmallVector<SpirvDebugInstruction *, 4> members;
-
-  // Optional pointer to keep the template type information of a HLSL
-  // resource type. A HLSL resource needs both DebugTypeComposite and
-  // DebugTypeTemplate. Typically, we keep all debug type information
-  // in SpirvContext::debugTypes including DebugTypeComposite, but we
-  // cannot keep DebugTypeTemplate for a HLSL resource in it because of
-  // the limitation of single value for the map. Instead, we keep it
-  // here.
-  SpirvDebugTypeTemplate *typeTemplate;
 
   // When it is DebugTypeComposite for HLSL resource type i.e., opaque
   // type, we must put DebugInfoNone for Size operand.

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -2451,10 +2451,7 @@ public:
   uint32_t getSizeInBits() const override { return size; }
   const APValue *getValue() const { return value; }
 
-  SpirvDebugType *getType() const { return type; }
-
 private:
-  SpirvDebugType *type;     //< Debug type of this member
   SpirvDebugSource *source; //< DebugSource
   uint32_t line;            //< Line number
   uint32_t column;          //< Column number

--- a/tools/clang/include/clang/SPIRV/SpirvType.h
+++ b/tools/clang/include/clang/SPIRV/SpirvType.h
@@ -294,7 +294,7 @@ public:
               llvm::Optional<uint32_t> matrixStride_ = llvm::None,
               llvm::Optional<bool> isRowMajor_ = llvm::None,
               bool relaxedPrecision = false, bool precise = false)
-        : type(type_), name(name_), offset(offset_),
+        : type(type_), name(name_), offset(offset_), sizeInBytes(llvm::None),
           matrixStride(matrixStride_), isRowMajor(isRowMajor_),
           isRelaxedPrecision(relaxedPrecision), isPrecise(precise) {
       // A StructType may not contain any hybrid types.
@@ -307,8 +307,10 @@ public:
     const SpirvType *type;
     // The field's name.
     std::string name;
-    // The integer offset for this field.
+    // The integer offset in bytes for this field.
     llvm::Optional<uint32_t> offset;
+    // The integer size in bytes for this field.
+    llvm::Optional<uint32_t> sizeInBytes;
     // The matrix stride for this field (if applicable).
     llvm::Optional<uint32_t> matrixStride;
     // The majorness of this field (if applicable).

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -156,9 +156,9 @@ SpirvDebugTypeTemplate *DebugTypeVisitor::lowerDebugTypeTemplate(
         argList[i].getAsType(), currentDebugInstructionLayoutRule, llvm::None,
         debugTypeComposite->getSourceLocation());
     debugTypeTemplateParam = spvContext.createDebugTypeTemplateParameter(
-        &argList[i], "TemplateParam", lowerToDebugType(spvType), nullptr,
-        debugTypeComposite->getSource(), debugTypeComposite->getLine(),
-        debugTypeComposite->getColumn());
+        &argList[i], "TemplateParam", lowerToDebugType(spvType),
+        getDebugInfoNone(), debugTypeComposite->getSource(),
+        debugTypeComposite->getLine(), debugTypeComposite->getColumn());
     tempTypeParams.push_back(debugTypeTemplateParam);
     setDefaultDebugInfo(debugTypeTemplateParam);
   }
@@ -211,6 +211,7 @@ DebugTypeVisitor::lowerToDebugTypeComposite(const SpirvType *type) {
   if (const auto *declDecl = dyn_cast<Decl>(decl))
     loc = declDecl->getLocation();
   auto *debugTypeComposite = createDebugTypeComposite(structType, loc, tag);
+  setDefaultDebugInfo(debugTypeComposite);
 
   if (const auto *templateDecl =
           dyn_cast<ClassTemplateSpecializationDecl>(decl)) {

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -1,4 +1,4 @@
-//===--- LowerTypeVisitor.cpp - AST type to SPIR-V type impl -----*- C++ -*-==//
+//===--- DebugTypeVisitor.cpp - SPIR-V type to debug type impl ---*- C++ -*-==//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -10,6 +10,7 @@
 #include <sstream>
 
 #include "DebugTypeVisitor.h"
+#include "LowerTypeVisitor.h"
 #include "clang/SPIRV/SpirvBuilder.h"
 #include "clang/SPIRV/SpirvModule.h"
 

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -76,6 +76,12 @@ void DebugTypeVisitor::addDebugTypeForMemberVariables(
     else
       unknownPhysicalLayout = true;
 
+    uint32_t sizeInBits = kUnknownBitSize;
+    if (!unknownPhysicalLayout && field.sizeInBytes.hasValue())
+      sizeInBits = *field.sizeInBytes * 8;
+    else
+      unknownPhysicalLayout = true;
+
     // TODO: We are currently in the discussion about how to handle
     // a variable type with unknown physical layout. Add proper flags
     // or operations for variables with the unknown physical layout.
@@ -90,16 +96,16 @@ void DebugTypeVisitor::addDebugTypeForMemberVariables(
     auto *debugInstr = spvContext.getDebugTypeMember(
         field.name, lowerToDebugType(field.type),
         debugTypeComposite->getSource(), line, column, debugTypeComposite,
-        /* flags */ 3u, offsetInBits, /* value */ nullptr);
+        /* flags */ 3u, offsetInBits, sizeInBits, /* value */ nullptr);
     assert(debugInstr);
 
     setDefaultDebugInfo(debugInstr);
     members.push_back(debugInstr);
 
-    if (offsetInBits == kUnknownBitSize || !field.sizeInBytes.hasValue()) {
+    if (sizeInBits == kUnknownBitSize) {
       compositeSizeInBits = kUnknownBitSize;
     } else {
-      compositeSizeInBits = offsetInBits + *field.sizeInBytes * 8;
+      compositeSizeInBits = offsetInBits + sizeInBits;
     }
   }
   debugTypeComposite->setMembers(members);

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -53,7 +53,6 @@ SpirvDebugTypeComposite *DebugTypeVisitor::createDebugTypeComposite(
   // TODO: Update linkageName using astContext.createMangleContext().
   std::string name = type->getName();
 
-  // TODO: Update size information correctly.
   RichDebugInfo *debugInfo = &spvContext.getDebugInfo().begin()->second;
   const char *file = sm.getPresumedLoc(loc).getFilename();
   if (file)
@@ -222,8 +221,12 @@ DebugTypeVisitor::lowerToDebugTypeComposite(const SpirvType *type) {
     debugTypeComposite->markOpaqueType(getDebugInfoNone());
     return lowerDebugTypeTemplate(templateDecl, debugTypeComposite);
   } else {
+    // If SpirvType is StructType, it is a normal struct/class. Otherwise,
+    // it must be an image or a sampler type that is an opaque type.
     if (const StructType *structType = dyn_cast<StructType>(type))
       lowerDebugTypeMembers(debugTypeComposite, structType, decl);
+    else
+      debugTypeComposite->markOpaqueType(getDebugInfoNone());
     return debugTypeComposite;
   }
 }

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -67,10 +67,18 @@ void DebugTypeVisitor::addDebugTypeMembers(
     SpirvDebugTypeComposite *debugTypeComposite, const StructType *type) {
   llvm::SmallVector<SpirvDebugInstruction *, 4> members;
   uint32_t compositeSizeInBits = kUnknownBitSize;
+  bool unknownPhysicalLayout = false;
   for (auto &field : type->getFields()) {
     uint32_t offsetInBits = kUnknownBitSize;
-    if (field.offset.hasValue())
+    if (!unknownPhysicalLayout && field.offset.hasValue())
       offsetInBits = *field.offset * 8;
+    else
+      unknownPhysicalLayout = true;
+
+    // TODO: We are currently in the discussion about how to handle
+    // a variable type with unknown physical layout. Add proper flags
+    // or operations for variables with the unknown physical layout.
+    // For example, we do not have physical layout for a local variable.
 
     // TODO: Replace 2u and 3u with valid flags when debug info extension is
     // placed in SPIRV-Header.

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.h
@@ -30,7 +30,8 @@ public:
                    const SpirvCodeGenOptions &opts, SpirvBuilder &builder,
                    LowerTypeVisitor &lowerTypeVisitor)
       : Visitor(opts, spvCtx), astContext(astCtx), spvContext(spvCtx),
-        spvBuilder(builder), spvTypeVisitor(lowerTypeVisitor) {}
+        spvBuilder(builder), spvTypeVisitor(lowerTypeVisitor),
+        currentDebugInstructionLayoutRule(SpirvLayoutRule::Void) {}
 
   // Visiting different SPIR-V constructs.
   bool visit(SpirvModule *module, Phase);
@@ -73,9 +74,10 @@ private:
   void addDebugTypeMember(SpirvDebugTypeComposite *debugTypeComposite,
                           const StructType *type, const SourceLocation &loc);
 
-  /// Lowers DebugTypeTemplate for HLSL resource type. Returns false if
-  /// there is an error.
-  bool lowerDebugTypeTemplate(SpirvDebugTypeComposite *instr);
+  /// Lowers DebugTypeTemplate for composite type.
+  SpirvDebugTypeTemplate *
+  lowerDebugTypeTemplate(const TemplateSpecializationType *templateType,
+                         SpirvDebugTypeComposite *debugTypeComposite);
 
   /// Lowers DebugTypeFunction for member function of a composite type.
   /// Returns false if there is an error.
@@ -93,6 +95,8 @@ private:
   SpirvContext &spvContext;         /// SPIR-V context
   SpirvBuilder &spvBuilder;         ///< SPIR-V builder
   LowerTypeVisitor &spvTypeVisitor; /// QualType to SPIR-V type visitor
+
+  SpirvLayoutRule currentDebugInstructionLayoutRule; /// SPIR-V layout rule
 };
 
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.h
@@ -64,9 +64,14 @@ private:
   /// Lowers DebugTypeComposite.
   SpirvDebugInstruction *lowerToDebugTypeComposite(const SpirvType *);
 
-  /// Lowers DebugTypeComposite for cbuffer.
-  SpirvDebugTypeComposite *lowerCbufferDebugType(const StructType *type,
-                                                 const SourceLocation &loc);
+  /// Creates DebugTypeComposite for a struct type.
+  SpirvDebugTypeComposite *createDebugTypeComposite(const StructType *type,
+                                                    const SourceLocation &loc,
+                                                    uint32_t tag);
+
+  /// Adds DebugTypeMembers to DebugTypeComposite.
+  void addDebugTypeMember(SpirvDebugTypeComposite *debugTypeComposite,
+                          const StructType *type, const SourceLocation &loc);
 
   /// Lowers DebugTypeTemplate for HLSL resource type. Returns false if
   /// there is an error.
@@ -75,11 +80,6 @@ private:
   /// Lowers DebugTypeFunction for member function of a composite type.
   /// Returns false if there is an error.
   bool lowerDebugTypeFunctionForMemberFunction(SpirvDebugInstruction *instr);
-
-  /// Lowers debug type for DebugTypeMember of a composite type. Returns
-  /// false if there is an error.
-  bool lowerDebugTypeMember(SpirvDebugTypeMember *debugMember,
-                            uint32_t *sizeInBits, uint32_t *offsetInBits);
 
   /// Set the result type of debug instructions to OpTypeVoid.
   /// According to the OpenCL.DebugInfo.100 spec, all debug instructions are

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.h
@@ -66,7 +66,7 @@ private:
   SpirvDebugType *lowerToDebugTypeComposite(const SpirvType *);
 
   /// Creates DebugTypeComposite for a struct type.
-  SpirvDebugTypeComposite *createDebugTypeComposite(const StructType *type,
+  SpirvDebugTypeComposite *createDebugTypeComposite(const SpirvType *type,
                                                     const SourceLocation &loc,
                                                     uint32_t tag);
 

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.h
@@ -60,10 +60,10 @@ private:
   ///
   /// The lowering is recursive. All the debug types that the target type
   /// depends on will also be created.
-  SpirvDebugInstruction *lowerToDebugType(const SpirvType *);
+  SpirvDebugType *lowerToDebugType(const SpirvType *);
 
   /// Lowers DebugTypeComposite.
-  SpirvDebugInstruction *lowerToDebugTypeComposite(const SpirvType *);
+  SpirvDebugType *lowerToDebugTypeComposite(const SpirvType *);
 
   /// Creates DebugTypeComposite for a struct type.
   SpirvDebugTypeComposite *createDebugTypeComposite(const StructType *type,
@@ -71,12 +71,16 @@ private:
                                                     uint32_t tag);
 
   /// Adds DebugTypeMembers to DebugTypeComposite.
-  void addDebugTypeMember(SpirvDebugTypeComposite *debugTypeComposite,
-                          const StructType *type, const SourceLocation &loc);
+  void addDebugTypeMembers(SpirvDebugTypeComposite *debugTypeComposite,
+                           const StructType *type);
+
+  /// Lowers DebugTypeMembers of DebugTypeComposite.
+  void lowerDebugTypeMembers(SpirvDebugTypeComposite *debugTypeComposite,
+                             const StructType *type, const DeclContext *decl);
 
   /// Lowers DebugTypeTemplate for composite type.
   SpirvDebugTypeTemplate *
-  lowerDebugTypeTemplate(const TemplateSpecializationType *templateType,
+  lowerDebugTypeTemplate(const ClassTemplateSpecializationDecl *templateDecl,
                          SpirvDebugTypeComposite *debugTypeComposite);
 
   /// Lowers DebugTypeFunction for member function of a composite type.

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.h
@@ -71,10 +71,9 @@ private:
                                                     uint32_t tag);
 
   /// Adds DebugTypeMembers for member variables to DebugTypeComposite.
-  void
-  addDebugTypeForMemberVariables(SpirvDebugTypeComposite *debugTypeComposite,
-                                 const StructType *type,
-                                 llvm::function_ref<SourceLocation()> location);
+  void addDebugTypeForMemberVariables(
+      SpirvDebugTypeComposite *debugTypeComposite, const StructType *type,
+      llvm::function_ref<SourceLocation()> location, unsigned numBases);
 
   /// Lowers DebugTypeMembers of DebugTypeComposite.
   void lowerDebugTypeMembers(SpirvDebugTypeComposite *debugTypeComposite,

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.h
@@ -19,6 +19,7 @@ namespace clang {
 namespace spirv {
 
 class SpirvBuilder;
+class LowerTypeVisitor;
 
 /// The class responsible to translate SPIR-V types into DebugType*
 /// types as defined in the OpenCL.DebugInfo.100 spec.
@@ -26,9 +27,10 @@ class SpirvBuilder;
 class DebugTypeVisitor : public Visitor {
 public:
   DebugTypeVisitor(ASTContext &astCtx, SpirvContext &spvCtx,
-                   const SpirvCodeGenOptions &opts, SpirvBuilder &builder)
+                   const SpirvCodeGenOptions &opts, SpirvBuilder &builder,
+                   LowerTypeVisitor &lowerTypeVisitor)
       : Visitor(opts, spvCtx), astContext(astCtx), spvContext(spvCtx),
-        spvBuilder(builder) {}
+        spvBuilder(builder), spvTypeVisitor(lowerTypeVisitor) {}
 
   // Visiting different SPIR-V constructs.
   bool visit(SpirvModule *module, Phase);
@@ -87,9 +89,10 @@ private:
   SpirvDebugInfoNone *getDebugInfoNone();
 
 private:
-  ASTContext &astContext;   /// AST context
-  SpirvContext &spvContext; /// SPIR-V context
-  SpirvBuilder &spvBuilder; ///< SPIR-V builder
+  ASTContext &astContext;           /// AST context
+  SpirvContext &spvContext;         /// SPIR-V context
+  SpirvBuilder &spvBuilder;         ///< SPIR-V builder
+  LowerTypeVisitor &spvTypeVisitor; /// QualType to SPIR-V type visitor
 };
 
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.h
@@ -70,9 +70,11 @@ private:
                                                     const SourceLocation &loc,
                                                     uint32_t tag);
 
-  /// Adds DebugTypeMembers to DebugTypeComposite.
-  void addDebugTypeMembers(SpirvDebugTypeComposite *debugTypeComposite,
-                           const StructType *type);
+  /// Adds DebugTypeMembers for member variables to DebugTypeComposite.
+  void
+  addDebugTypeForMemberVariables(SpirvDebugTypeComposite *debugTypeComposite,
+                                 const StructType *type,
+                                 const DeclContext *decl);
 
   /// Lowers DebugTypeMembers of DebugTypeComposite.
   void lowerDebugTypeMembers(SpirvDebugTypeComposite *debugTypeComposite,
@@ -82,10 +84,6 @@ private:
   SpirvDebugTypeTemplate *
   lowerDebugTypeTemplate(const ClassTemplateSpecializationDecl *templateDecl,
                          SpirvDebugTypeComposite *debugTypeComposite);
-
-  /// Lowers DebugTypeFunction for member function of a composite type.
-  /// Returns false if there is an error.
-  bool lowerDebugTypeFunctionForMemberFunction(SpirvDebugInstruction *instr);
 
   /// Set the result type of debug instructions to OpTypeVoid.
   /// According to the OpenCL.DebugInfo.100 spec, all debug instructions are

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.h
@@ -74,7 +74,7 @@ private:
   void
   addDebugTypeForMemberVariables(SpirvDebugTypeComposite *debugTypeComposite,
                                  const StructType *type,
-                                 const DeclContext *decl);
+                                 llvm::function_ref<SourceLocation()> location);
 
   /// Lowers DebugTypeMembers of DebugTypeComposite.
   void lowerDebugTypeMembers(SpirvDebugTypeComposite *debugTypeComposite,

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -752,9 +752,12 @@ SpirvDebugGlobalVariable *DeclResultIdMapper::createDebugGlobalVariable(
     // TODO: replace this with FlagIsDefinition enum.
     uint32_t flags = 1 << 3;
     // TODO: update linkageName correctly.
-    return spvBuilder.createDebugGlobalVariable(
+    auto *dbgGlobalVar = spvBuilder.createDebugGlobalVariable(
         type, name, info->source, line, column, info->scopeStack.back(),
         /* linkageName */ name, var, flags);
+    dbgGlobalVar->setDebugSpirvType(var->getResultType());
+    dbgGlobalVar->setLayoutRule(var->getLayoutRule());
+    return dbgGlobalVar;
   }
   return nullptr;
 }
@@ -1012,10 +1015,9 @@ SpirvVariable *DeclResultIdMapper::createCTBuffer(const HLSLBufferDecl *decl) {
   auto *dbgGlobalVar = createDebugGlobalVariable(
       bufferVar, QualType(), decl->getLocation(), decl->getName());
   if (dbgGlobalVar != nullptr) {
+    // C/TBuffer needs HLSLBufferDecl for debug type lowering.
     spvContext.addSpirvTypeToDecl(bufferVar->getResultType(), decl);
-    dbgGlobalVar->setDebugSpirvType(bufferVar->getResultType());
   }
-
   return bufferVar;
 }
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1016,7 +1016,7 @@ SpirvVariable *DeclResultIdMapper::createCTBuffer(const HLSLBufferDecl *decl) {
       bufferVar, QualType(), decl->getLocation(), decl->getName());
   if (dbgGlobalVar != nullptr) {
     // C/TBuffer needs HLSLBufferDecl for debug type lowering.
-    spvContext.addSpirvTypeToDecl(bufferVar->getResultType(), decl);
+    spvContext.registerStructDeclForSpirvType(bufferVar->getResultType(), decl);
   }
   return bufferVar;
 }

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -696,10 +696,12 @@ private:
   /// Returns true if the given SPIR-V stage variable has Input storage class.
   inline bool isInputStorageClass(const StageVar &v);
 
-  /// If rich debug info gen is enabled, emit DebugGlobalVariable.
-  void createDebugGlobalVariable(SpirvVariable *var, const QualType &type,
-                                 const SourceLocation &loc,
-                                 const StringRef &name);
+  /// Creates DebugGlobalVariable and returns it if rich debug information
+  /// generation is enabled. Otherwise, returns nullptr.
+  SpirvDebugGlobalVariable *createDebugGlobalVariable(SpirvVariable *var,
+                                                      const QualType &type,
+                                                      const SourceLocation &loc,
+                                                      const StringRef &name);
 
   /// Determines the register type for a resource that does not have an
   /// explicit register() declaration.  Returns true if it is able to

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1438,7 +1438,8 @@ bool EmitVisitor::visit(SpirvDebugTypeMember *inst) {
       getOrAssignResultId<SpirvInstruction>(inst->getInstructionSet()));
   curInst.push_back(inst->getDebugOpcode());
   curInst.push_back(typeNameId);
-  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getType()));
+  curInst.push_back(
+      getOrAssignResultId<SpirvInstruction>(inst->getDebugType()));
   curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getSource()));
   curInst.push_back(inst->getLine());
   curInst.push_back(inst->getColumn());

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -389,7 +389,7 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
     // is then a subclass of RecordDecl.) So we need to check them before
     // checking the general struct type.
     if (const auto *spvType = lowerResourceType(type, rule, srcLoc)) {
-      spvContext.addSpirvTypeToRecordType(spvType, structType);
+      spvContext.addSpirvTypeToDecl(spvType, decl);
       return spvType;
     }
 
@@ -418,7 +418,7 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
 
     const auto *spvStructType =
         spvContext.getStructType(loweredFields, decl->getName());
-    spvContext.addSpirvTypeToRecordType(spvStructType, structType);
+    spvContext.addSpirvTypeToDecl(spvStructType, decl);
     return spvStructType;
   }
 
@@ -836,6 +836,7 @@ LowerTypeVisitor::populateLayoutInformation(
 
     // Each structure-type member must have an Offset Decoration.
     loweredField.offset = offset;
+    loweredField.sizeInBytes = memberSize;
     offset += memberSize;
 
     // Each structure-type member that is a matrix or array-of-matrices must be

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -192,8 +192,8 @@ const SpirvType *LowerTypeVisitor::lowerType(const SpirvType *type,
     const StructType *structType = spvContext.getStructType(
         loweredFields, hybridStruct->getStructName(),
         hybridStruct->isReadOnly(), hybridStruct->getInterfaceType());
-    if (const auto *decl = spvContext.getDeclForSpirvType(type))
-      spvContext.addSpirvTypeToDecl(structType, decl);
+    if (const auto *decl = spvContext.getStructDeclForSpirvType(type))
+      spvContext.registerStructDeclForSpirvType(structType, decl);
     return structType;
   }
   // Void, bool, int, float cannot be further lowered.
@@ -392,7 +392,7 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
     // is then a subclass of RecordDecl.) So we need to check them before
     // checking the general struct type.
     if (const auto *spvType = lowerResourceType(type, rule, srcLoc)) {
-      spvContext.addSpirvTypeToDecl(spvType, decl);
+      spvContext.registerStructDeclForSpirvType(spvType, decl);
       return spvType;
     }
 
@@ -421,7 +421,7 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
 
     const auto *spvStructType =
         spvContext.getStructType(loweredFields, decl->getName());
-    spvContext.addSpirvTypeToDecl(spvStructType, decl);
+    spvContext.registerStructDeclForSpirvType(spvStructType, decl);
     return spvStructType;
   }
 

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -87,6 +87,17 @@ bool LowerTypeVisitor::visitInstruction(SpirvInstruction *instr) {
           lowerType(debugQualType, instr->getLayoutRule(),
                     /*isRowMajor*/ llvm::None, instr->getSourceLocation());
       debugInstruction->setDebugSpirvType(spirvType);
+    } else if (const auto *debugSpirvType =
+                   debugInstruction->getDebugSpirvType()) {
+      // When it does not have a QualType, SpirvEmitter or DeclResultIdMapper
+      // generates a hybrid type. In that case, we keep the hybrid type for the
+      // DebugGlobalVariable, not QualType. We have to lower the hybrid type and
+      // update the SpirvType for the DebugGlobalVariable.
+      assert(isa<SpirvDebugGlobalVariable>(debugInstruction) &&
+             isa<HybridType>(debugSpirvType));
+      const SpirvType *loweredSpirvType = lowerType(
+          debugSpirvType, instr->getLayoutRule(), instr->getSourceLocation());
+      debugInstruction->setDebugSpirvType(loweredSpirvType);
     }
   }
 

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -189,9 +189,12 @@ const SpirvType *LowerTypeVisitor::lowerType(const SpirvType *type,
     // lower all fields of the struct.
     auto loweredFields =
         populateLayoutInformation(hybridStruct->getFields(), rule);
-    return spvContext.getStructType(
+    const StructType *structType = spvContext.getStructType(
         loweredFields, hybridStruct->getStructName(),
         hybridStruct->isReadOnly(), hybridStruct->getInterfaceType());
+    if (const auto *decl = spvContext.getDeclForSpirvType(type))
+      spvContext.addSpirvTypeToDecl(structType, decl);
+    return structType;
   }
   // Void, bool, int, float cannot be further lowered.
   // Matrices cannot contain hybrid types. Only matrices of scalars are valid.

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -74,18 +74,6 @@ bool LowerTypeVisitor::visitInstruction(SpirvInstruction *instr) {
     instr->setResultType(spirvType);
   }
 
-  // Debug instructions have a debug type in addition to the result type.
-  // Their result type is always 'void'. But their debug type can be anything.
-  if (auto *debugInstruction = dyn_cast<SpirvDebugInstruction>(instr)) {
-    const QualType debugQualType = debugInstruction->getDebugQualType();
-    if (!debugQualType.isNull()) {
-      const SpirvType *spirvType =
-          lowerType(debugQualType, instr->getLayoutRule(),
-                    /*isRowMajor*/ llvm::None, instr->getSourceLocation());
-      debugInstruction->setDebugSpirvType(spirvType);
-    }
-  }
-
   // Instruction-specific type updates
 
   const auto *resultType = instr->getResultType();
@@ -373,50 +361,8 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
     // (ClassTemplateSpecializationDecl is a subclass of CXXRecordDecl, which
     // is then a subclass of RecordDecl.) So we need to check them before
     // checking the general struct type.
-    auto spvTypeAndUnderlyingType = lowerResourceType(type, rule, srcLoc);
-    if (spvTypeAndUnderlyingType.first) {
-      if (debugExtInstSet && !visitedRecordDecl.count(decl)) {
-        llvm::SmallVector<StructType::FieldInfo, 4> fields;
-        auto *dbgType = lowerDebugTypeComposite(
-            structType, spvTypeAndUnderlyingType.first, fields, true);
-        visitedRecordDecl.insert(decl);
-
-        // If an underlying type exists, we want to create a template type
-        // information for this composite type e.g., StructuredBuffer<S>.
-        // Note that we pass a pointer to SpirvType for the underlying type
-        // which must be lowered by DebugTypeVisitor.
-        if (spvTypeAndUnderlyingType.second) {
-          const llvm::StringRef name = decl->getName();
-          QualType elemType;
-          if (name == "InputPatch") {
-            elemType = hlsl::GetHLSLInputPatchElementType(type);
-          } else if (name == "OutputPatch") {
-            elemType = hlsl::GetHLSLOutputPatchElementType(type);
-          } else {
-            elemType = hlsl::GetHLSLResourceResultType(type);
-          }
-
-          const SourceLocation &loc = decl->getLocStart();
-          const auto &sm = astContext.getSourceManager();
-          uint32_t line = sm.getPresumedLineNumber(loc);
-          uint32_t column = sm.getPresumedColumnNumber(loc);
-
-          RichDebugInfo *debugInfo = &spvContext.getDebugInfo().begin()->second;
-          const char *file = sm.getPresumedLoc(loc).getFilename();
-          if (file)
-            debugInfo = &spvContext.getDebugInfo()[file];
-
-          spvContext.getDebugTypeTemplate(spvTypeAndUnderlyingType.first,
-                                          dbgType);
-          spvContext.getDebugTypeTemplateParameter(
-              spvTypeAndUnderlyingType.first,
-              std::string(name.data()) + ".TemplateParam",
-              spvTypeAndUnderlyingType.second, nullptr, debugInfo->source, line,
-              column);
-        }
-      }
-      return spvTypeAndUnderlyingType.first;
-    }
+    if (const auto *spvType = lowerResourceType(type, rule, srcLoc))
+      return spvType;
 
     // Collect all fields' information.
     llvm::SmallVector<HybridStructType::FieldInfo, 8> fields;
@@ -441,14 +387,7 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
 
     auto loweredFields = populateLayoutInformation(fields, rule);
 
-    const auto *spvType =
-        spvContext.getStructType(loweredFields, decl->getName(), false,
-                                 StructInterfaceType::InternalStorage);
-    if (debugExtInstSet && !visitedRecordDecl.count(decl)) {
-      lowerDebugTypeComposite(structType, spvType, loweredFields, false);
-      visitedRecordDecl.insert(decl);
-    }
-    return spvType;
+    return spvContext.getStructType(loweredFields, decl->getName());
   }
 
   // Array type
@@ -503,9 +442,9 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
   return 0;
 }
 
-std::pair<const SpirvType *, const SpirvType *>
-LowerTypeVisitor::lowerResourceType(QualType type, SpirvLayoutRule rule,
-                                    SourceLocation srcLoc) {
+const SpirvType *LowerTypeVisitor::lowerResourceType(QualType type,
+                                                     SpirvLayoutRule rule,
+                                                     SourceLocation srcLoc) {
   // Resource types are either represented like C struct or C++ class in the
   // AST. Samplers are represented like C struct, so isStructureType() will
   // return true for it; textures are represented like C++ class, so
@@ -534,14 +473,11 @@ LowerTypeVisitor::lowerResourceType(QualType type, SpirvLayoutRule rule,
         (dim = spv::Dim::Cube, isArray = true, name == "TextureCubeArray")) {
       const bool isMS = (name == "Texture2DMS" || name == "Texture2DMSArray");
       const auto sampledType = hlsl::GetHLSLResourceResultType(type);
-      const SpirvType *underlyingType =
+      return spvContext.getImageType(
           lowerType(getElementType(astContext, sampledType), rule,
-                    /*isRowMajor*/ llvm::None, srcLoc);
-      return std::make_pair(
-          spvContext.getImageType(
-              underlyingType, dim, ImageType::WithDepth::Unknown, isArray, isMS,
-              ImageType::WithSampler::Yes, spv::ImageFormat::Unknown),
-          underlyingType);
+                    /*isRowMajor*/ llvm::None, srcLoc),
+          dim, ImageType::WithDepth::Unknown, isArray, isMS,
+          ImageType::WithSampler::Yes, spv::ImageFormat::Unknown);
     }
 
     // There is no RWTexture3DArray
@@ -553,29 +489,26 @@ LowerTypeVisitor::lowerResourceType(QualType type, SpirvLayoutRule rule,
       const auto sampledType = hlsl::GetHLSLResourceResultType(type);
       const auto format =
           translateSampledTypeToImageFormat(sampledType, srcLoc);
-      const SpirvType *underlyingType =
+      return spvContext.getImageType(
           lowerType(getElementType(astContext, sampledType), rule,
-                    /*isRowMajor*/ llvm::None, srcLoc);
-      return std::make_pair(spvContext.getImageType(
-                                underlyingType, dim,
-                                ImageType::WithDepth::Unknown, isArray,
-                                /*isMultiSampled=*/false,
-                                /*sampled=*/ImageType::WithSampler::No, format),
-                            underlyingType);
+                    /*isRowMajor*/ llvm::None, srcLoc),
+          dim, ImageType::WithDepth::Unknown, isArray,
+          /*isMultiSampled=*/false, /*sampled=*/ImageType::WithSampler::No,
+          format);
     }
   }
 
   // Sampler types
   if (name == "SamplerState" || name == "SamplerComparisonState") {
-    return std::make_pair(spvContext.getSamplerType(), nullptr);
+    return spvContext.getSamplerType();
   }
 
   if (name == "RaytracingAccelerationStructure") {
-    return std::make_pair(spvContext.getAccelerationStructureTypeNV(), nullptr);
+    return spvContext.getAccelerationStructureTypeNV();
   }
 
   if (name == "RayQuery")
-    return std::make_pair(spvContext.getRayQueryProvisionalTypeKHR(), nullptr);
+    return spvContext.getRayQueryProvisionalTypeKHR();
 
   if (name == "StructuredBuffer" || name == "RWStructuredBuffer" ||
       name == "AppendStructuredBuffer" || name == "ConsumeStructuredBuffer") {
@@ -631,12 +564,10 @@ LowerTypeVisitor::lowerResourceType(QualType type, SpirvLayoutRule rule,
 
     if (asAlias) {
       // All structured buffers are in the Uniform storage class.
-      return std::make_pair(
-          spvContext.getPointerType(valType, spv::StorageClass::Uniform),
-          structType);
+      return spvContext.getPointerType(valType, spv::StorageClass::Uniform);
     }
 
-    return std::make_pair(valType, structType);
+    return valType;
   }
 
   // ByteAddressBuffer types.
@@ -645,22 +576,18 @@ LowerTypeVisitor::lowerResourceType(QualType type, SpirvLayoutRule rule,
         spvContext.getByteAddressBufferType(/*isRW*/ false);
     if (rule == SpirvLayoutRule::Void) {
       // All byte address buffers are in the Uniform storage class.
-      return std::make_pair(
-          spvContext.getPointerType(bufferType, spv::StorageClass::Uniform),
-          nullptr);
+      return spvContext.getPointerType(bufferType, spv::StorageClass::Uniform);
     }
-    return std::make_pair(bufferType, nullptr);
+    return bufferType;
   }
   // RWByteAddressBuffer types.
   if (name == "RWByteAddressBuffer") {
     const auto *bufferType = spvContext.getByteAddressBufferType(/*isRW*/ true);
     if (rule == SpirvLayoutRule::Void) {
       // All byte address buffers are in the Uniform storage class.
-      return std::make_pair(
-          spvContext.getPointerType(bufferType, spv::StorageClass::Uniform),
-          nullptr);
+      return spvContext.getPointerType(bufferType, spv::StorageClass::Uniform);
     }
-    return std::make_pair(bufferType, nullptr);
+    return bufferType;
   }
 
   // Buffer and RWBuffer types
@@ -674,67 +601,54 @@ LowerTypeVisitor::lowerResourceType(QualType type, SpirvLayoutRule rule,
       // supported for now.
       emitError("cannot instantiate RWBuffer with struct type %0", srcLoc)
           << sampledType;
-      return std::make_pair(nullptr, nullptr);
+      return 0;
     }
     const auto format = translateSampledTypeToImageFormat(sampledType, srcLoc);
-    const SpirvType *underlyingType =
+    return spvContext.getImageType(
         lowerType(getElementType(astContext, sampledType), rule,
-                  /*isRowMajor*/ llvm::None, srcLoc);
-    return std::make_pair(
-        spvContext.getImageType(
-            underlyingType, spv::Dim::Buffer, ImageType::WithDepth::Unknown,
-            /*isArrayed=*/false, /*isMultiSampled=*/false,
-            /*sampled*/ name == "Buffer" ? ImageType::WithSampler::Yes
-                                         : ImageType::WithSampler::No,
-            format),
-        underlyingType);
+                  /*isRowMajor*/ llvm::None, srcLoc),
+        spv::Dim::Buffer, ImageType::WithDepth::Unknown,
+        /*isArrayed=*/false, /*isMultiSampled=*/false,
+        /*sampled*/ name == "Buffer" ? ImageType::WithSampler::Yes
+                                     : ImageType::WithSampler::No,
+        format);
   }
 
   // InputPatch
   if (name == "InputPatch") {
     const auto elemType = hlsl::GetHLSLInputPatchElementType(type);
     const auto elemCount = hlsl::GetHLSLInputPatchCount(type);
-    const SpirvType *underlyingType =
-        lowerType(elemType, rule, /*isRowMajor*/ llvm::None, srcLoc);
-    return std::make_pair(spvContext.getArrayType(underlyingType, elemCount,
-                                                  /*ArrayStride*/ llvm::None),
-                          underlyingType);
+    return spvContext.getArrayType(
+        lowerType(elemType, rule, /*isRowMajor*/ llvm::None, srcLoc), elemCount,
+        /*ArrayStride*/ llvm::None);
   }
   // OutputPatch
   if (name == "OutputPatch") {
     const auto elemType = hlsl::GetHLSLOutputPatchElementType(type);
     const auto elemCount = hlsl::GetHLSLOutputPatchCount(type);
-    const SpirvType *underlyingType =
-        lowerType(elemType, rule, /*isRowMajor*/ llvm::None, srcLoc);
-    return std::make_pair(spvContext.getArrayType(underlyingType, elemCount,
-                                                  /*ArrayStride*/ llvm::None),
-                          underlyingType);
+    return spvContext.getArrayType(
+        lowerType(elemType, rule, /*isRowMajor*/ llvm::None, srcLoc), elemCount,
+        /*ArrayStride*/ llvm::None);
   }
   // Output stream objects (TriangleStream, LineStream, and PointStream)
   if (name == "TriangleStream" || name == "LineStream" ||
       name == "PointStream") {
-    const SpirvType *underlyingType =
-        lowerType(hlsl::GetHLSLResourceResultType(type), rule,
-                  /*isRowMajor*/ llvm::None, srcLoc);
-    return std::make_pair(underlyingType, underlyingType);
+    return lowerType(hlsl::GetHLSLResourceResultType(type), rule,
+                     /*isRowMajor*/ llvm::None, srcLoc);
   }
 
   if (name == "SubpassInput" || name == "SubpassInputMS") {
     const auto sampledType = hlsl::GetHLSLResourceResultType(type);
-    const SpirvType *underlyingType =
+    return spvContext.getImageType(
         lowerType(getElementType(astContext, sampledType), rule,
-                  /*isRowMajor*/ llvm::None, srcLoc);
-    return std::make_pair(
-        spvContext.getImageType(underlyingType, spv::Dim::SubpassData,
-                                ImageType::WithDepth::Unknown,
-                                /*isArrayed=*/false,
-                                /*isMultipleSampled=*/name == "SubpassInputMS",
-                                ImageType::WithSampler::No,
-                                spv::ImageFormat::Unknown),
-        underlyingType);
+                  /*isRowMajor*/ llvm::None, srcLoc),
+        spv::Dim::SubpassData, ImageType::WithDepth::Unknown,
+        /*isArrayed=*/false,
+        /*isMultipleSampled=*/name == "SubpassInputMS",
+        ImageType::WithSampler::No, spv::ImageFormat::Unknown);
   }
 
-  return std::make_pair(nullptr, nullptr);
+  return nullptr;
 }
 
 spv::ImageFormat
@@ -923,174 +837,6 @@ LowerTypeVisitor::populateLayoutInformation(
     result.push_back(loweredFields[fieldToIndexMap[&field]]);
 
   return result;
-}
-
-SpirvDebugFunction *
-LowerTypeVisitor::generateFunctionInfo(const CXXMethodDecl *decl,
-                                       SpirvDebugInstruction *parent) {
-  // Lower the function return type.
-  const SpirvType *spirvReturnType =
-      lowerType(decl->getReturnType(), SpirvLayoutRule::Void,
-                /*isRowMajor*/ llvm::None,
-                /*SourceLocation*/ {});
-  // Lower the function parameter types.
-  llvm::SmallVector<const SpirvType *, 4> spirvParamTypes;
-  unsigned numParams = decl->getNumParams();
-  for (unsigned i = 0; i < numParams; ++i) {
-    const auto *spirvParamType = lowerType(
-        decl->getParamDecl(i)->getOriginalType(), SpirvLayoutRule::Void,
-        /*isRowMajor*/ llvm::None, SourceLocation());
-    spirvParamTypes.push_back(
-        spvContext.getPointerType(spirvParamType, spv::StorageClass::Function));
-  }
-  auto *fnType = spvContext.getFunctionType(spirvReturnType, spirvParamTypes);
-
-  std::string classOrStructName = "";
-  if (const auto *st = dyn_cast<CXXRecordDecl>(decl->getDeclContext()))
-    classOrStructName = st->getName().str() + ".";
-
-  std::string funcName = classOrStructName + decl->getName().str();
-
-  const auto &sm = astContext.getSourceManager();
-  auto loc = decl->getLocStart();
-  const uint32_t line = sm.getPresumedLineNumber(loc);
-  const uint32_t column = sm.getPresumedColumnNumber(loc);
-
-  RichDebugInfo *debugInfo = &spvContext.getDebugInfo().begin()->second;
-  const char *file = sm.getPresumedLoc(loc).getFilename();
-  if (file)
-    debugInfo = &spvContext.getDebugInfo()[file];
-
-  // using FlagIsPublic for now.
-  uint32_t flags = 3u;
-  auto scopeLine = sm.getPresumedLineNumber(decl->getBody()->getLocStart());
-  SpirvDebugFunction *fn = new (spvContext)
-      SpirvDebugFunction(funcName, debugInfo->source, line, column, parent,
-                         funcName, flags, scopeLine, nullptr);
-  fn->setFunctionType(fnType);
-  return fn;
-}
-
-SpirvDebugTypeComposite *LowerTypeVisitor::lowerDebugTypeComposite(
-    const RecordType *structType, const SpirvType *type,
-    llvm::SmallVector<StructType::FieldInfo, 4> &fields, bool isResourceType) {
-  const auto *decl = structType->getDecl();
-  const SourceLocation &loc = decl->getLocStart();
-  const auto &sm = astContext.getSourceManager();
-  uint32_t line = sm.getPresumedLineNumber(loc);
-  uint32_t column = sm.getPresumedColumnNumber(loc);
-  StringRef linkageName = type->getName();
-
-  // TODO: Update linkageName using astContext.createMangleContext().
-  //
-  // Currently, the following code fails because it is not a
-  // FunctionDecl nor VarDecl. I guess we should mangle a RecordDecl
-  // as well.
-  //
-  // std::string s;
-  // llvm::raw_string_ostream stream(s);
-  // mangleCtx->mangleName(decl, stream);
-
-  uint32_t tag = 1;
-  if (decl->isStruct())
-    tag = 1;
-  else if (decl->isClass())
-    tag = 0;
-  else if (decl->isUnion())
-    tag = 2;
-  else
-    assert(!"DebugTypeComposite must be a struct, class, or union.");
-
-  bool isPrivate = decl->isModulePrivate();
-
-  std::string name = type->getName();
-  if (isResourceType)
-    name = "@" + name;
-
-  // TODO: Update parent, size, and flags information correctly.
-  RichDebugInfo *debugInfo = &spvContext.getDebugInfo().begin()->second;
-  const char *file = sm.getPresumedLoc(loc).getFilename();
-  if (file)
-    debugInfo = &spvContext.getDebugInfo()[file];
-  auto *dbgTyComposite =
-      dyn_cast<SpirvDebugTypeComposite>(spvContext.getDebugTypeComposite(
-          type, name, debugInfo->source, line, column,
-          /* parent */ debugInfo->compilationUnit, linkageName,
-          /* size */ 0,
-          /* flags */ isPrivate ? 2u : 3u, tag));
-
-  // If we already visited this composite type and its members,
-  // we should skip it.
-  auto &members = dbgTyComposite->getMembers();
-  if (!members.empty())
-    return dbgTyComposite;
-
-  dbgTyComposite->setAstResultType(astContext.VoidTy);
-  dbgTyComposite->setResultType(spvContext.getVoidType());
-  dbgTyComposite->setInstructionSet(debugExtInstSet);
-
-  if (isResourceType) {
-    dbgTyComposite->setDebugInfoNone(spvBuilder.getOrCreateDebugInfoNone());
-    return dbgTyComposite;
-  }
-
-  uint32_t fieldIdx = 0;
-  for (auto &memberDecl : decl->decls()) {
-    if (const auto *cxxMethodDecl = dyn_cast<CXXMethodDecl>(memberDecl)) {
-      auto *fn = spvContext.findFunctionInfo(cxxMethodDecl);
-      if (fn) {
-        fn->setParent(dbgTyComposite);
-        members.push_back(fn);
-      } else {
-        members.push_back(generateFunctionInfo(cxxMethodDecl, dbgTyComposite));
-      }
-      continue;
-    }
-
-    // Skip "this" object.
-    if (isa<CXXRecordDecl>(memberDecl)) {
-      continue;
-    }
-
-    assert(isa<FieldDecl>(memberDecl) &&
-           "Decl of member must be CXXMethodDecl, CXXRecordDecl, or FieldDecl");
-
-    const SourceLocation &fieldLoc = memberDecl->getLocStart();
-    const uint32_t fieldLine = sm.getPresumedLineNumber(fieldLoc);
-    const uint32_t fieldColumn = sm.getPresumedColumnNumber(fieldLoc);
-
-    const APValue *value = nullptr;
-    if (const auto *varDecl = dyn_cast<VarDecl>(memberDecl)) {
-      if (const auto *val = varDecl->evaluateValue()) {
-        value = val;
-      }
-    }
-
-    uint32_t offsetInBits = UINT32_MAX;
-    if (fields[fieldIdx].offset.hasValue())
-      offsetInBits = *fields[fieldIdx].offset * 8;
-
-    RichDebugInfo *fieldDebugInfo = debugInfo;
-    file = sm.getPresumedLoc(fieldLoc).getFilename();
-    if (file)
-      fieldDebugInfo = &spvContext.getDebugInfo()[file];
-
-    // TODO: Replace 2u and 3u with valid flags when debug info extension is
-    // placed in SPIRV-Header.
-    auto *debugInstr =
-        dyn_cast<SpirvDebugInstruction>(spvContext.getDebugTypeMember(
-            dyn_cast<FieldDecl>(memberDecl)->getName(), fields[fieldIdx].type,
-            fieldDebugInfo->source, fieldLine, fieldColumn, dbgTyComposite,
-            memberDecl->isModulePrivate() ? 2u : 3u, offsetInBits, value));
-    assert(debugInstr && "We expect SpirvDebugInstruction for DebugTypeMember");
-    debugInstr->setAstResultType(astContext.VoidTy);
-    debugInstr->setResultType(spvContext.getVoidType());
-    debugInstr->setInstructionSet(debugExtInstSet);
-    members.push_back(debugInstr);
-
-    ++fieldIdx;
-  }
-  return dbgTyComposite;
 }
 
 } // namespace spirv

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -41,6 +41,13 @@ public:
   /// regardless of their polymorphism.
   bool visitInstruction(SpirvInstruction *instr) override;
 
+  /// Lowers the given AST QualType into the corresponding SPIR-V type.
+  ///
+  /// The lowering is recursive; all the types that the target type depends
+  /// on will be created in SpirvContext.
+  const SpirvType *lowerType(QualType type, SpirvLayoutRule,
+                             llvm::Optional<bool> isRowMajor, SourceLocation);
+
 private:
   /// Emits error to the diagnostic engine associated with this visitor.
   template <unsigned N>
@@ -51,12 +58,6 @@ private:
     return astContext.getDiagnostics().Report(srcLoc, diagId);
   }
 
-  /// Lowers the given AST QualType into the corresponding SPIR-V type.
-  ///
-  /// The lowering is recursive; all the types that the target type depends
-  /// on will be created in SpirvContext.
-  const SpirvType *lowerType(QualType type, SpirvLayoutRule,
-                             llvm::Optional<bool> isRowMajor, SourceLocation);
   /// Lowers the given Hybrid type into a SPIR-V type.
   ///
   /// Uses the above lowerType method to lower the QualType components of hybrid

--- a/tools/clang/lib/SPIRV/SortDebugInfoVisitor.cpp
+++ b/tools/clang/lib/SPIRV/SortDebugInfoVisitor.cpp
@@ -159,11 +159,13 @@ bool SortDebugInfoVisitor::visit(SpirvModule *mod, Phase phase) {
     return true;
 
   auto &debugInstructions = mod->getDebugInfo();
-  auto numberOfDebugInstrs = debugInstructions.size();
+  llvm::SmallSet<SpirvDebugInstruction *, 32> visited;
+  visited.insert(debugInstructions.begin(), debugInstructions.end());
+  auto numberOfDebugInstrs = visited.size();
   (void)numberOfDebugInstrs;
 
   // Collect nodes without predecessor.
-  llvm::SmallSet<SpirvDebugInstruction *, 32> visited;
+  visited.clear();
   for (auto *di : debugInstructions) {
     whileEachOperandOfDebugInstruction(
         di, [&visited](SpirvDebugInstruction *operand) {

--- a/tools/clang/lib/SPIRV/SortDebugInfoVisitor.cpp
+++ b/tools/clang/lib/SPIRV/SortDebugInfoVisitor.cpp
@@ -113,7 +113,7 @@ void SortDebugInfoVisitor::whileEachOperandOfDebugInstruction(
   case SpirvInstruction::IK_DebugTypeMember: {
     SpirvDebugTypeMember *inst = dyn_cast<SpirvDebugTypeMember>(di);
     assert(inst != nullptr);
-    if (!visitor(inst->getType()))
+    if (!visitor(inst->getDebugType()))
       break;
     if (!visitor(inst->getSource()))
       break;

--- a/tools/clang/lib/SPIRV/SortDebugInfoVisitor.cpp
+++ b/tools/clang/lib/SPIRV/SortDebugInfoVisitor.cpp
@@ -159,13 +159,17 @@ bool SortDebugInfoVisitor::visit(SpirvModule *mod, Phase phase) {
     return true;
 
   auto &debugInstructions = mod->getDebugInfo();
-  llvm::SmallSet<SpirvDebugInstruction *, 32> visited;
-  visited.insert(debugInstructions.begin(), debugInstructions.end());
-  auto numberOfDebugInstrs = visited.size();
+
+  // Keep the number of unique debug instructions to verify that it is not
+  // changed at the end of this visitor.
+  llvm::SmallSet<SpirvDebugInstruction *, 32> uniqueDebugInstructions;
+  uniqueDebugInstructions.insert(debugInstructions.begin(),
+                                 debugInstructions.end());
+  auto numberOfDebugInstrs = uniqueDebugInstructions.size();
   (void)numberOfDebugInstrs;
 
   // Collect nodes without predecessor.
-  visited.clear();
+  llvm::SmallSet<SpirvDebugInstruction *, 32> visited;
   for (auto *di : debugInstructions) {
     whileEachOperandOfDebugInstruction(
         di, [&visited](SpirvDebugInstruction *operand) {

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -281,16 +281,15 @@ SpirvDebugType *SpirvContext::getDebugTypeBasic(const SpirvType *spirvType,
   return debugType;
 }
 
-SpirvDebugType *
-SpirvContext::getDebugTypeMember(llvm::StringRef name, SpirvDebugType *type,
-                                 SpirvDebugSource *source,
-                                 SpirvDebugInstruction *parent, uint32_t flags,
-                                 uint32_t offsetInBits, const APValue *value) {
+SpirvDebugType *SpirvContext::getDebugTypeMember(
+    llvm::StringRef name, SpirvDebugType *type, SpirvDebugSource *source,
+    uint32_t line, uint32_t column, SpirvDebugInstruction *parent,
+    uint32_t flags, uint32_t offsetInBits, const APValue *value) {
   // NOTE: Do not search it in debugTypes because it would have the same
   // spirvType but has different parent i.e., type composite.
 
   SpirvDebugTypeMember *debugType = new (this) SpirvDebugTypeMember(
-      name, type, source, parent, flags, offsetInBits, value);
+      name, type, source, line, column, parent, flags, offsetInBits, value);
   return debugType;
 }
 

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -268,10 +268,10 @@ const StructType *SpirvContext::getACSBufferCounterType() {
   return type;
 }
 
-SpirvDebugInstruction *
-SpirvContext::getDebugTypeBasic(const SpirvType *spirvType,
-                                llvm::StringRef name, SpirvConstant *size,
-                                uint32_t encoding) {
+SpirvDebugType *SpirvContext::getDebugTypeBasic(const SpirvType *spirvType,
+                                                llvm::StringRef name,
+                                                SpirvConstant *size,
+                                                uint32_t encoding) {
   // Reuse existing debug type if possible.
   if (debugTypes.find(spirvType) != debugTypes.end())
     return debugTypes[spirvType];
@@ -281,15 +281,16 @@ SpirvContext::getDebugTypeBasic(const SpirvType *spirvType,
   return debugType;
 }
 
-SpirvDebugInstruction *SpirvContext::getDebugTypeMember(
-    llvm::StringRef name, const SpirvType *type, SpirvDebugSource *source,
-    uint32_t line, uint32_t column, SpirvDebugInstruction *parent,
-    uint32_t flags, uint32_t offsetInBits, const APValue *value) {
+SpirvDebugType *
+SpirvContext::getDebugTypeMember(llvm::StringRef name, SpirvDebugType *type,
+                                 SpirvDebugSource *source,
+                                 SpirvDebugInstruction *parent, uint32_t flags,
+                                 uint32_t offsetInBits, const APValue *value) {
   // NOTE: Do not search it in debugTypes because it would have the same
   // spirvType but has different parent i.e., type composite.
 
   SpirvDebugTypeMember *debugType = new (this) SpirvDebugTypeMember(
-      name, type, source, line, column, parent, flags, offsetInBits, value);
+      name, type, source, parent, flags, offsetInBits, value);
 
   // NOTE: Do not save it in debugTypes because it would have the same
   // spirvType but it has different parent i.e., type composite. Instead,
@@ -314,14 +315,14 @@ SpirvDebugTypeComposite *SpirvContext::getDebugTypeComposite(
   return debugType;
 }
 
-SpirvDebugInstruction *SpirvContext::getDebugType(const SpirvType *spirvType) {
+SpirvDebugType *SpirvContext::getDebugType(const SpirvType *spirvType) {
   auto it = debugTypes.find(spirvType);
   if (it != debugTypes.end())
     return it->second;
   return nullptr;
 }
 
-SpirvDebugInstruction *
+SpirvDebugType *
 SpirvContext::getDebugTypeArray(const SpirvType *spirvType,
                                 SpirvDebugInstruction *elemType,
                                 llvm::ArrayRef<uint32_t> elemCount) {
@@ -336,7 +337,7 @@ SpirvContext::getDebugTypeArray(const SpirvType *spirvType,
   return debugType;
 }
 
-SpirvDebugInstruction *
+SpirvDebugType *
 SpirvContext::getDebugTypeVector(const SpirvType *spirvType,
                                  SpirvDebugInstruction *elemType,
                                  uint32_t elemCount) {
@@ -351,7 +352,7 @@ SpirvContext::getDebugTypeVector(const SpirvType *spirvType,
   return debugType;
 }
 
-SpirvDebugInstruction *
+SpirvDebugType *
 SpirvContext::getDebugTypeFunction(const SpirvType *spirvType, uint32_t flags,
                                    SpirvDebugType *ret,
                                    llvm::ArrayRef<SpirvDebugType *> params) {
@@ -365,7 +366,7 @@ SpirvContext::getDebugTypeFunction(const SpirvType *spirvType, uint32_t flags,
 }
 
 SpirvDebugTypeTemplate *SpirvContext::createDebugTypeTemplate(
-    const TemplateSpecializationType *templateType,
+    const ClassTemplateSpecializationDecl *templateType,
     SpirvDebugInstruction *target,
     const llvm::SmallVector<SpirvDebugTypeTemplateParameter *, 2> &params) {
   auto *tempTy = getDebugTypeTemplate(templateType);
@@ -377,7 +378,7 @@ SpirvDebugTypeTemplate *SpirvContext::createDebugTypeTemplate(
 }
 
 SpirvDebugTypeTemplate *SpirvContext::getDebugTypeTemplate(
-    const TemplateSpecializationType *templateType) {
+    const ClassTemplateSpecializationDecl *templateType) {
   auto it = typeTemplates.find(templateType);
   if (it != typeTemplates.end())
     return it->second;
@@ -386,7 +387,7 @@ SpirvDebugTypeTemplate *SpirvContext::getDebugTypeTemplate(
 
 SpirvDebugTypeTemplateParameter *SpirvContext::createDebugTypeTemplateParameter(
     const TemplateArgument *templateArg, llvm::StringRef name,
-    const SpirvType *type, SpirvInstruction *value, SpirvDebugSource *source,
+    SpirvDebugType *type, SpirvInstruction *value, SpirvDebugSource *source,
     uint32_t line, uint32_t column) {
   auto *param = getDebugTypeTemplateParameter(templateArg);
   if (param != nullptr)

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -298,16 +298,17 @@ SpirvDebugInstruction *SpirvContext::getDebugTypeMember(
   return debugType;
 }
 
-SpirvDebugInstruction *SpirvContext::getDebugTypeComposite(
+SpirvDebugTypeComposite *SpirvContext::getDebugTypeComposite(
     const SpirvType *spirvType, llvm::StringRef name, SpirvDebugSource *source,
     uint32_t line, uint32_t column, SpirvDebugInstruction *parent,
-    llvm::StringRef linkageName, uint32_t size, uint32_t flags, uint32_t tag) {
+    llvm::StringRef linkageName, uint32_t flags, uint32_t tag) {
   // Reuse existing debug type if possible.
-  if (debugTypes.find(spirvType) != debugTypes.end())
-    return debugTypes[spirvType];
+  auto it = debugTypes.find(spirvType);
+  if (it != debugTypes.end())
+    return dyn_cast<SpirvDebugTypeComposite>(it->second);
 
   auto *debugType = new (this) SpirvDebugTypeComposite(
-      name, source, line, column, parent, linkageName, size, flags, tag);
+      name, source, line, column, parent, linkageName, flags, tag);
   debugType->setDebugSpirvType(spirvType);
   debugTypes[spirvType] = debugType;
   return debugType;

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -281,15 +281,18 @@ SpirvDebugType *SpirvContext::getDebugTypeBasic(const SpirvType *spirvType,
   return debugType;
 }
 
-SpirvDebugType *SpirvContext::getDebugTypeMember(
-    llvm::StringRef name, SpirvDebugType *type, SpirvDebugSource *source,
-    uint32_t line, uint32_t column, SpirvDebugInstruction *parent,
-    uint32_t flags, uint32_t offsetInBits, const APValue *value) {
+SpirvDebugType *
+SpirvContext::getDebugTypeMember(llvm::StringRef name, SpirvDebugType *type,
+                                 SpirvDebugSource *source, uint32_t line,
+                                 uint32_t column, SpirvDebugInstruction *parent,
+                                 uint32_t flags, uint32_t offsetInBits,
+                                 uint32_t sizeInBits, const APValue *value) {
   // NOTE: Do not search it in debugTypes because it would have the same
   // spirvType but has different parent i.e., type composite.
 
-  SpirvDebugTypeMember *debugType = new (this) SpirvDebugTypeMember(
-      name, type, source, line, column, parent, flags, offsetInBits, value);
+  SpirvDebugTypeMember *debugType =
+      new (this) SpirvDebugTypeMember(name, type, source, line, column, parent,
+                                      flags, offsetInBits, sizeInBits, value);
   return debugType;
 }
 

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -11,6 +11,7 @@
 #include <tuple>
 
 #include "clang/SPIRV/SpirvContext.h"
+#include "clang/SPIRV/SpirvModule.h"
 
 namespace clang {
 namespace spirv {
@@ -302,8 +303,10 @@ SpirvDebugTypeComposite *SpirvContext::getDebugTypeComposite(
     llvm::StringRef linkageName, uint32_t flags, uint32_t tag) {
   // Reuse existing debug type if possible.
   auto it = debugTypes.find(spirvType);
-  if (it != debugTypes.end())
+  if (it != debugTypes.end()) {
+    assert(it->second != nullptr && isa<SpirvDebugTypeComposite>(it->second));
     return dyn_cast<SpirvDebugTypeComposite>(it->second);
+  }
 
   auto *debugType = new (this) SpirvDebugTypeComposite(
       name, source, line, column, parent, linkageName, flags, tag);
@@ -414,7 +417,7 @@ void SpirvContext::pushDebugLexicalScope(RichDebugInfo *info,
   info->scopeStack.push_back(scope);
 }
 
-void SpirvContext::addDebugTypeToModule(SpirvModule *module) {
+void SpirvContext::addDebugTypesToModule(SpirvModule *module) {
   for (const auto &typePair : debugTypes) {
     module->addDebugInfo(typePair.second);
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1018,9 +1018,8 @@ void SpirvEmitter::doFunctionDecl(const FunctionDecl *decl) {
     // The line number in the source program at which the function scope begins.
     auto scopeLine = sm.getPresumedLineNumber(decl->getBody()->getLocStart());
     SpirvDebugFunction *debugFunction = spvBuilder.createDebugFunction(
-        funcName, source, line, column, parentScope, funcName, flags, scopeLine,
-        func);
-    spvContext.addDeclToDebugFunction(decl, debugFunction);
+        decl, funcName, source, line, column, parentScope, funcName, flags,
+        scopeLine, func);
     func->setDebugScope(new (astContext) SpirvDebugScope(debugFunction));
 
     // We want to keep member function info of a structure, but a StructType

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1020,6 +1020,7 @@ void SpirvEmitter::doFunctionDecl(const FunctionDecl *decl) {
     SpirvDebugFunction *debugFunction = spvBuilder.createDebugFunction(
         funcName, source, line, column, parentScope, funcName, flags, scopeLine,
         func);
+    spvContext.addDeclToDebugFunction(decl, debugFunction);
     func->setDebugScope(new (astContext) SpirvDebugScope(debugFunction));
 
     // We want to keep member function info of a structure, but a StructType

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -940,9 +940,9 @@ SpirvDebugTypeMember::SpirvDebugTypeMember(
     llvm::StringRef name, SpirvDebugType *type, SpirvDebugSource *source_,
     SpirvDebugInstruction *parent_, uint32_t flags_, uint32_t offsetInBits_,
     const APValue *value_)
-    : SpirvDebugType(IK_DebugTypeMember, /*opcode*/ 11u),
-      source(source_), line(0), column(0), parent(parent_),
-      offset(offsetInBits_), size(0), debugFlags(flags_), value(value_) {
+    : SpirvDebugType(IK_DebugTypeMember, /*opcode*/ 11u), source(source_),
+      line(0), column(0), parent(parent_), offset(offsetInBits_), size(0),
+      debugFlags(flags_), value(value_) {
   debugName = name;
   setDebugType(type);
 }

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -953,19 +953,22 @@ SpirvDebugTypeComposite::SpirvDebugTypeComposite(
     llvm::StringRef linkageName_, uint32_t flags_, uint32_t tag_)
     : SpirvDebugType(IK_DebugTypeComposite, /*opcode*/ 10u), source(source_),
       line(line_), column(column_), parent(parent_), linkageName(linkageName_),
-      debugFlags(flags_), tag(tag_), typeTemplate(nullptr), debugNone(nullptr) {
+      debugFlags(flags_), tag(tag_), debugNone(nullptr) {
   debugName = name;
 }
 
-SpirvDebugTypeTemplate::SpirvDebugTypeTemplate(SpirvDebugInstruction *target_)
-    : SpirvDebugType(IK_DebugTypeTemplate, /*opcode*/ 14u), target(target_) {}
+SpirvDebugTypeTemplate::SpirvDebugTypeTemplate(
+    SpirvDebugInstruction *target_,
+    const llvm::SmallVector<SpirvDebugTypeTemplateParameter *, 2> &params_)
+    : SpirvDebugType(IK_DebugTypeTemplate, /*opcode*/ 14u), target(target_),
+      params(params_) {}
 
 SpirvDebugTypeTemplateParameter::SpirvDebugTypeTemplateParameter(
     llvm::StringRef name, const SpirvType *type, SpirvInstruction *value_,
     SpirvDebugSource *source_, uint32_t line_, uint32_t column_)
     : SpirvDebugType(IK_DebugTypeTemplateParameter, /*opcode*/ 15u),
-      actualType(nullptr), value(value_), source(source_), line(line_),
-      column(column_), spvType(type) {
+      actualType(type), value(value_), source(source_), line(line_),
+      column(column_) {
   debugName = name;
 }
 

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -939,10 +939,12 @@ SpirvDebugTypeFunction::SpirvDebugTypeFunction(
 SpirvDebugTypeMember::SpirvDebugTypeMember(
     llvm::StringRef name, SpirvDebugType *type, SpirvDebugSource *source_,
     uint32_t line_, uint32_t column_, SpirvDebugInstruction *parent_,
-    uint32_t flags_, uint32_t offsetInBits_, const APValue *value_)
+    uint32_t flags_, uint32_t offsetInBits_, uint32_t sizeInBits_,
+    const APValue *value_)
     : SpirvDebugType(IK_DebugTypeMember, /*opcode*/ 11u), source(source_),
-      line(line_), column(column_), parent(parent_), offset(offsetInBits_),
-      size(0), debugFlags(flags_), value(value_) {
+      line(line_), column(column_), parent(parent_),
+      offsetInBits(offsetInBits_), sizeInBits(sizeInBits_), debugFlags(flags_),
+      value(value_) {
   debugName = name;
   setDebugType(type);
 }

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -937,13 +937,14 @@ SpirvDebugTypeFunction::SpirvDebugTypeFunction(
       returnType(ret), paramTypes(params.begin(), params.end()) {}
 
 SpirvDebugTypeMember::SpirvDebugTypeMember(
-    llvm::StringRef name, SpirvDebugType *type_, SpirvDebugSource *source_,
+    llvm::StringRef name, SpirvDebugType *type, SpirvDebugSource *source_,
     SpirvDebugInstruction *parent_, uint32_t flags_, uint32_t offsetInBits_,
     const APValue *value_)
-    : SpirvDebugType(IK_DebugTypeMember, /*opcode*/ 11u), type(type_),
+    : SpirvDebugType(IK_DebugTypeMember, /*opcode*/ 11u),
       source(source_), line(0), column(0), parent(parent_),
       offset(offsetInBits_), size(0), debugFlags(flags_), value(value_) {
   debugName = name;
+  setDebugType(type);
 }
 
 SpirvDebugTypeComposite::SpirvDebugTypeComposite(

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -950,12 +950,10 @@ SpirvDebugTypeMember::SpirvDebugTypeMember(
 SpirvDebugTypeComposite::SpirvDebugTypeComposite(
     llvm::StringRef name, SpirvDebugSource *source_, uint32_t line_,
     uint32_t column_, SpirvDebugInstruction *parent_,
-    llvm::StringRef linkageName_, uint32_t size_, uint32_t flags_,
-    uint32_t tag_)
+    llvm::StringRef linkageName_, uint32_t flags_, uint32_t tag_)
     : SpirvDebugType(IK_DebugTypeComposite, /*opcode*/ 10u), source(source_),
       line(line_), column(column_), parent(parent_), linkageName(linkageName_),
-      size(size_), debugFlags(flags_), tag(tag_), typeTemplate(nullptr),
-      fullyLowered(false), debugNone(nullptr) {
+      debugFlags(flags_), tag(tag_), typeTemplate(nullptr), debugNone(nullptr) {
   debugName = name;
 }
 

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -937,13 +937,12 @@ SpirvDebugTypeFunction::SpirvDebugTypeFunction(
       returnType(ret), paramTypes(params.begin(), params.end()) {}
 
 SpirvDebugTypeMember::SpirvDebugTypeMember(
-    llvm::StringRef name, const SpirvType *type_, SpirvDebugSource *source_,
-    uint32_t line_, uint32_t column_, SpirvDebugInstruction *parent_,
-    uint32_t flags_, uint32_t offsetInBits_, const APValue *value_)
-    : SpirvDebugType(IK_DebugTypeMember, /*opcode*/ 11u), type(nullptr),
-      source(source_), line(line_), column(column_), parent(parent_),
-      offset(offsetInBits_), size(0), debugFlags(flags_), value(value_),
-      spvType(type_) {
+    llvm::StringRef name, SpirvDebugType *type_, SpirvDebugSource *source_,
+    SpirvDebugInstruction *parent_, uint32_t flags_, uint32_t offsetInBits_,
+    const APValue *value_)
+    : SpirvDebugType(IK_DebugTypeMember, /*opcode*/ 11u), type(type_),
+      source(source_), line(0), column(0), parent(parent_),
+      offset(offsetInBits_), size(0), debugFlags(flags_), value(value_) {
   debugName = name;
 }
 
@@ -964,7 +963,7 @@ SpirvDebugTypeTemplate::SpirvDebugTypeTemplate(
       params(params_) {}
 
 SpirvDebugTypeTemplateParameter::SpirvDebugTypeTemplateParameter(
-    llvm::StringRef name, const SpirvType *type, SpirvInstruction *value_,
+    llvm::StringRef name, SpirvDebugType *type, SpirvInstruction *value_,
     SpirvDebugSource *source_, uint32_t line_, uint32_t column_)
     : SpirvDebugType(IK_DebugTypeTemplateParameter, /*opcode*/ 15u),
       actualType(type), value(value_), source(source_), line(line_),

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -938,11 +938,11 @@ SpirvDebugTypeFunction::SpirvDebugTypeFunction(
 
 SpirvDebugTypeMember::SpirvDebugTypeMember(
     llvm::StringRef name, SpirvDebugType *type, SpirvDebugSource *source_,
-    SpirvDebugInstruction *parent_, uint32_t flags_, uint32_t offsetInBits_,
-    const APValue *value_)
+    uint32_t line_, uint32_t column_, SpirvDebugInstruction *parent_,
+    uint32_t flags_, uint32_t offsetInBits_, const APValue *value_)
     : SpirvDebugType(IK_DebugTypeMember, /*opcode*/ 11u), source(source_),
-      line(0), column(0), parent(parent_), offset(offsetInBits_), size(0),
-      debugFlags(flags_), value(value_) {
+      line(line_), column(column_), parent(parent_), offset(offsetInBits_),
+      size(0), debugFlags(flags_), value(value_) {
   debugName = name;
   setDebugType(type);
 }

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.cbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.cbuffer.hlsl
@@ -9,9 +9,9 @@ cbuffer MyCbuffer : register(b1) {
     bool     a;    // Size:  32, Offset: [  0 -  32]
     int      b;    // Size:  32, Offset: [ 32 -  64]
     uint2    c;    // Size:  64, Offset: [ 64 - 128]
-    float3x4 d;    // Size: 384, Offset: [128 - 512]
+    float3x4 d;    // Size: 512, Offset: [128 - 640]
     S        s;    // Size: 128, Offset: [640 - 768]
-    float    t[4]; // Size: 128, Offset: [768 - 896]
+    float    t[4]; // Size: 512, Offset: [768 - 1280]
 };
 
 cbuffer AnotherCBuffer : register(b2) {
@@ -19,21 +19,21 @@ cbuffer AnotherCBuffer : register(b2) {
     float4 n;  // Size: 128, Offset: [128 - 256]
 }
 
-// CHECK: [[AnotherCBuffer:%\d+]] = OpExtInst %void [[ext:%\d+]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 0 0 {{%\d+}} {{%\d+}} %uint_256 FlagIsProtected|FlagIsPrivate [[m:%\d+]] [[n:%\d+]]
-// CHECK: [[n]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[AnotherCBuffer]] %uint_128 %uint_128
-// CHECK: [[m]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[AnotherCBuffer]] %uint_0 %uint_96
+// CHECK: [[AnotherCBuffer:%\d+]] = OpExtInst %void [[ext:%\d+]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 17 9 {{%\d+}} {{%\d+}} %uint_256 FlagIsProtected|FlagIsPrivate [[m:%\d+]] [[n:%\d+]]
+// CHECK: [[n]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 19 12 [[AnotherCBuffer]] %uint_128 %uint_128
+// CHECK: [[m]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 18 12 [[AnotherCBuffer]] %uint_0 %uint_96
 
-// CHECK: [[MyCbuffer:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 0 0 {{%\d+}} {{%\d+}} %uint_896 FlagIsProtected|FlagIsPrivate [[a:%\d+]] [[b:%\d+]] [[c:%\d+]] [[d:%\d+]] [[s:%\d+]] [[t:%\d+]]
-// CHECK: [[t]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_768 %uint_128
+// CHECK: [[S:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 3 8 {{%\d+}} {{%\d+}} %uint_128 FlagIsProtected|FlagIsPrivate [[f1:%\d+]] [[f2:%\d+]]
+// CHECK: [[f2]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 5 12 [[S]] %uint_32 %uint_96
+// CHECK: [[f1]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 4 11 [[S]] %uint_0 %uint_32
 
-// CHECK: [[S:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 3 1 {{%\d+}} {{%\d+}} %uint_128 FlagIsProtected|FlagIsPrivate [[f1:%\d+]] [[f2:%\d+]]
-// CHECK: [[s]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} [[S]] {{%\d+}} 0 0 [[MyCbuffer]] %uint_640 %uint_128
-// CHECK: [[d]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_128 %uint_384
-// CHECK: [[c]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_64 %uint_64
-// CHECK: [[b]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_32 %uint_32
-// CHECK: [[a]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 0 0 [[MyCbuffer]] %uint_0 %uint_32
-// CHECK: [[f2]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 5 5 [[S]] %uint_32 %uint_96
-// CHECK: [[f1]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 4 5 [[S]] %uint_0 %uint_32
+// CHECK: [[MyCbuffer:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite {{%\d+}} Structure {{%\d+}} 8 9 {{%\d+}} {{%\d+}} %uint_1280 FlagIsProtected|FlagIsPrivate [[a:%\d+]] [[b:%\d+]] [[c:%\d+]] [[d:%\d+]] [[s:%\d+]] [[t:%\d+]]
+// CHECK: [[t]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 14 11 [[MyCbuffer]] %uint_768 %uint_512
+// CHECK: [[s]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} [[S]] {{%\d+}} 13 7 [[MyCbuffer]] %uint_640 %uint_128
+// CHECK: [[d]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 12 14 [[MyCbuffer]] %uint_128 %uint_512
+// CHECK: [[c]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 11 11 [[MyCbuffer]] %uint_64 %uint_64
+// CHECK: [[b]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 10 9 [[MyCbuffer]] %uint_32 %uint_32
+// CHECK: [[a]] = OpExtInst %void [[ext]] DebugTypeMember {{%\d+}} {{%\d+}} {{%\d+}} 9 10 [[MyCbuffer]] %uint_0 %uint_32
 
 // CHECK: {{%\d+}} = OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} {{%\d+}} {{%\d+}} 17 9 {{%\d+}} {{%\d+}} %AnotherCBuffer
 // CHECK: {{%\d+}} = OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} {{%\d+}} {{%\d+}} 8 9 {{%\d+}} {{%\d+}} %MyCbuffer

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.member.function.param.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.member.function.param.hlsl
@@ -30,8 +30,8 @@ struct foo {
 // CHECK: [[func0:%\d+]] = OpString "foo.func0"
 // CHECK: [[arg:%\d+]] = OpString "arg"
 
-// CHECK: [[foo:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[fooName]] Structure {{%\d+}} 3 1
 // CHECK: [[bool:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Boolean
+// CHECK: [[foo:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[fooName]] Structure {{%\d+}} 3 8
 
 // CHECK: [[float:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Float
 // CHECK: [[int:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Signed

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.rwtexture.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.rwtexture.hlsl
@@ -5,25 +5,24 @@
 //CHECK: [[name_3d:%\d+]] = OpString "@type.3d.image"
 //CHECK: [[name_1d:%\d+]] = OpString "@type.1d.image"
 
-//CHECK: [[2daf:%\d+]] = OpExtInst %void [[ext:%\d+]] DebugTypeComposite [[name_2d_arr]] Class [[src:%\d+]] 0 0 [[cu:%\d+]] {{%\d+}} [[info_none:%\d+]]
+//CHECK: [[2daf_comp:%\d+]] = OpExtInst %void [[ext:%\d+]] DebugTypeComposite [[name_2d_arr]] Class [[src:%\d+]] 0 0 [[cu:%\d+]] {{%\d+}} [[info_none:%\d+]]
 //CHECK: [[tem_p6:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
-//CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[2daf]] [[tem_p6]]
-
-//CHECK: [[1dai:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_1d_arr]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
-//CHECK: [[tem_p3:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
-//CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[1dai]] [[tem_p3]]
-
-//CHECK: [[3df:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_3d]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
-//CHECK: [[tem_p2:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
-//CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[3df]] [[tem_p2]]
-
-//CHECK: [[1di:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_1d]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
-//CHECK: [[tem_p0:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
-//CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[1di]] [[tem_p0]]
-
+//CHECK: [[2daf:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplate [[2daf_comp]] [[tem_p6]]
 //CHECK: OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} [[2daf]] [[src]] {{\d+}} {{\d+}} [[cu]] {{%\d+}} %t8
+
+//CHECK: [[1dai_comp:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_1d_arr]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
+//CHECK: [[tem_p3:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
+//CHECK: [[1dai:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplate [[1dai_comp]] [[tem_p3]]
 //CHECK: OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} [[1dai]] [[src]] {{\d+}} {{\d+}} [[cu]] {{%\d+}} %t5
+
+//CHECK: [[3df_comp:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_3d]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
+//CHECK: [[tem_p2:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
+//CHECK: [[3df:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplate [[3df_comp]] [[tem_p2]]
 //CHECK: OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} [[3df]] [[src]] {{\d+}} {{\d+}} [[cu]] {{%\d+}} %t3
+
+//CHECK: [[1di_comp:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_1d]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
+//CHECK: [[tem_p0:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
+//CHECK: [[1di:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplate [[1di_comp]] [[tem_p0]]
 //CHECK: OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} [[1di]] [[src]] {{\d+}} {{\d+}} [[cu]] {{%\d+}} %t1
 
 RWTexture1D   <int>    t1 ;

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.structured-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.structured-buffer.hlsl
@@ -22,40 +22,41 @@ RWStructuredBuffer<T> mySBuffer4 : register(u4);
 // CHECK: [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 // CHECK: [[T:%\d+]] = OpString "T"
 // CHECK: [[S:%\d+]] = OpString "S"
-// CHECK: [[RW_T:%\d+]] = OpString "@type.RWStructuredBuffer.T"
-// CHECK: [[temp1:%\d+]] = OpString "RWStructuredBuffer.TemplateParam"
 // CHECK: [[RW_S:%\d+]] = OpString "@type.RWStructuredBuffer.S"
-// CHECK: [[SB_T:%\d+]] = OpString "@type.StructuredBuffer.T"
-// CHECK: [[temp0:%\d+]] = OpString "StructuredBuffer.TemplateParam"
-// CHECK: [[SB_S:%\d+]] = OpString "@type.StructuredBuffer.S"
+// CHECK: [[param:%\d+]] = OpString "TemplateParam"
 // CHECK: [[inputBuffer:%\d+]] = OpString "inputBuffer"
+// CHECK: [[RW_T:%\d+]] = OpString "@type.RWStructuredBuffer.T"
+// CHECK: [[SB_T:%\d+]] = OpString "@type.StructuredBuffer.T"
+// CHECK: [[SB_S:%\d+]] = OpString "@type.StructuredBuffer.S"
 
 // CHECK: [[T_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[T]] Structure
 // CHECK: [[S_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[S]] Structure
 
 // CHECK: [[none:%\d+]] = OpExtInst %void [[set]] DebugInfoNone
-// CHECK: [[RW_T_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[RW_T]] Class {{%\d+}} 0 0 {{%\d+}} {{%\d+}} [[none]]
-// CHECK: [[param3:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[temp1]] [[T_ty]]
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugTypeTemplate [[RW_T_ty]] [[param3]]
-
 // CHECK: [[RW_S_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[RW_S]] Class {{%\d+}} 0 0 {{%\d+}} {{%\d+}} [[none]]
-// CHECK: [[param2:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[temp1]] [[S_ty]]
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugTypeTemplate [[RW_S_ty]] [[param2]]
+// CHECK: [[param2:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[param]] [[S_ty]]
+// CHECK: [[RW_S_temp:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplate [[RW_S_ty]] [[param2]]
+
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[inputBuffer]] [[RW_S_temp]]
+
+// CHECK: [[RW_T_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[RW_T]] Class {{%\d+}} 0 0 {{%\d+}} {{%\d+}} [[none]]
+// CHECK: [[param3:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[param]] [[T_ty]]
+// CHECK: [[RW_T_temp:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplate [[RW_T_ty]] [[param3]]
+
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugGlobalVariable {{%\d+}} [[RW_T_temp]] {{%\d+}} {{\d+}} {{\d+}} {{%\d+}} {{%\d+}} %mySBuffer4
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugGlobalVariable {{%\d+}} [[RW_S_temp]] {{%\d+}} {{\d+}} {{\d+}} {{%\d+}} {{%\d+}} %mySBuffer3
 
 // CHECK: [[SB_T_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[SB_T]] Class {{%\d+}} 0 0 {{%\d+}} {{%\d+}} [[none]]
-// CHECK: [[param1:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[temp0]] [[T_ty]]
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugTypeTemplate [[SB_T_ty]] [[param1]]
+// CHECK: [[param1:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[param]] [[T_ty]]
+// CHECK: [[SB_T_temp:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplate [[SB_T_ty]] [[param1]]
+
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugGlobalVariable {{%\d+}} [[SB_T_temp]] {{%\d+}} {{\d+}} {{\d+}} {{%\d+}} {{%\d+}} %mySBuffer2
 
 // CHECK: [[SB_S_ty:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[SB_S]] Class {{%\d+}} 0 0 {{%\d+}} {{%\d+}} [[none]]
-// CHECK: [[param0:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[temp0]] [[S_ty]]
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugTypeTemplate [[SB_S_ty]] [[param0]]
+// CHECK: [[param0:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplateParameter [[param]] [[S_ty]]
+// CHECK: [[SB_S_temp:%\d+]] = OpExtInst %void [[set]] DebugTypeTemplate [[SB_S_ty]] [[param0]]
 
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[inputBuffer]] [[RW_S_ty]]
-
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugGlobalVariable {{%\d+}} [[RW_T_ty]] {{%\d+}} {{\d+}} {{\d+}} {{%\d+}} {{%\d+}} %mySBuffer4
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugGlobalVariable {{%\d+}} [[RW_S_ty]] {{%\d+}} {{\d+}} {{\d+}} {{%\d+}} {{%\d+}} %mySBuffer3
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugGlobalVariable {{%\d+}} [[SB_T_ty]] {{%\d+}} {{\d+}} {{\d+}} {{%\d+}} {{%\d+}} %mySBuffer2
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugGlobalVariable {{%\d+}} [[SB_S_ty]] {{%\d+}} {{\d+}} {{\d+}} {{%\d+}} {{%\d+}} %mySBuffer1
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugGlobalVariable {{%\d+}} [[SB_S_temp]] {{%\d+}} {{\d+}} {{\d+}} {{%\d+}} {{%\d+}} %mySBuffer1
 
 void foo(RWStructuredBuffer<S> inputBuffer) {
   inputBuffer[0].a = 0;

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.texture.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.texture.hlsl
@@ -5,25 +5,24 @@
 //CHECK: [[name_cb_arr:%\d+]] = OpString "@type.cube.image.array"
 
 //CHECK: [[info_none:%\d+]] = OpExtInst %void [[ext:%\d+]] DebugInfoNone
-//CHECK: [[t3_ty:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_2d_arr]] Class [[src:%\d+]] 0 0 [[cu:%\d+]] {{%\d+}} [[info_none]]
+//CHECK: [[t3_comp:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_2d_arr]] Class [[src:%\d+]] 0 0 [[cu:%\d+]] {{%\d+}} [[info_none]]
 //CHECK: [[tem_p3:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
-//CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[t3_ty]] [[tem_p3]]
-
-//CHECK: [[t2_ty:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_2d]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
-//CHECK: [[tem_p2:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
-//CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[t2_ty]] [[tem_p2]]
-
-//CHECK: [[t1_ty:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_cb_arr]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
-//CHECK: [[tem_p1:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
-//CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[t1_ty]] [[tem_p1]]
-
-//CHECK: [[t0_ty:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_2d]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
-//CHECK: [[tem_p0:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
-//CHECK: OpExtInst %void [[ext]] DebugTypeTemplate [[t0_ty]] [[tem_p0]]
-
+//CHECK: [[t3_ty:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplate [[t3_comp]] [[tem_p3]]
 //CHECK: OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} [[t3_ty]] [[src]] {{\d+}} {{\d+}} [[cu]] {{%\d+}} %t3
+
+//CHECK: [[t2_comp:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_2d]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
+//CHECK: [[tem_p2:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
+//CHECK: [[t2_ty:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplate [[t2_comp]] [[tem_p2]]
 //CHECK: OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} [[t2_ty]] [[src]] {{\d+}} {{\d+}} [[cu]] {{%\d+}} %t2
+
+//CHECK: [[t1_comp:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_cb_arr]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
+//CHECK: [[tem_p1:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
+//CHECK: [[t1_ty:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplate [[t1_comp]] [[tem_p1]]
 //CHECK: OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} [[t1_ty]] [[src]] {{\d+}} {{\d+}} [[cu]] {{%\d+}} %t1
+
+//CHECK: [[t0_comp:%\d+]] = OpExtInst %void [[ext]] DebugTypeComposite [[name_2d]] Class [[src]] 0 0 [[cu]] {{%\d+}} [[info_none]]
+//CHECK: [[tem_p0:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplateParameter
+//CHECK: [[t0_ty:%\d+]] = OpExtInst %void [[ext]] DebugTypeTemplate [[t0_comp]] [[tem_p0]]
 //CHECK: OpExtInst %void [[ext]] DebugGlobalVariable {{%\d+}} [[t0_ty]] [[src]] {{\d+}} {{\d+}} [[cu]] {{%\d+}} %t0
 
 Texture2D   <int4>   t0 : register(t0);

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.type.array.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.type.array.hlsl
@@ -1,15 +1,15 @@
 // Run: %dxc -T ps_6_0 -E main -fspv-debug=rich
 
 // CHECK:       [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
-// CHECK:     [[SName:%\d+]] = OpString "S"
 // CHECK:  [[boolName:%\d+]] = OpString "bool"
+// CHECK:     [[SName:%\d+]] = OpString "S"
 // CHECK:   [[intName:%\d+]] = OpString "int"
 // CHECK:  [[uintName:%\d+]] = OpString "uint"
 // CHECK: [[floatName:%\d+]] = OpString "float"
 // CHECK:           %uint_32 = OpConstant %uint 32
 
-// CHECK: [[S:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[SName]]
 // CHECK:   [[bool:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic [[boolName]] %uint_32 Boolean
+// CHECK: [[S:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[SName]]
 // CHECK:   [[int:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic [[intName]] %uint_32 Signed
 // CHECK:  [[uint:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic [[uintName]] %uint_32 Unsigned
 // CHECK: [[float:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic [[floatName]] %uint_32 Float

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.type.composite.empty.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.type.composite.empty.hlsl
@@ -6,7 +6,7 @@ struct foo {
 // CHECK: [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 // CHECK: [[foo:%\d+]] = OpString "foo"
 
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugTypeComposite [[foo]] Structure {{%\d+}} 3 1 {{%\d+}} {{%\d+}} %uint_0 FlagIsProtected|FlagIsPrivate
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugTypeComposite [[foo]] Structure {{%\d+}} 3 8 {{%\d+}} {{%\d+}} %uint_0 FlagIsProtected|FlagIsPrivate
 
 float4 main(float4 color : COLOR) : SV_TARGET {
   foo a;

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.type.composite.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.type.composite.hlsl
@@ -20,8 +20,8 @@ struct foo {
 };
 
 // CHECK: [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
-// CHECK: [[foo:%\d+]] = OpString "foo"
 // CHECK: [[bool_name:%\d+]] = OpString "bool"
+// CHECK: [[foo:%\d+]] = OpString "foo"
 // CHECK: [[c_name:%\d+]] = OpString "c"
 // CHECK: [[float_name:%\d+]] = OpString "float"
 // CHECK: [[b_name:%\d+]] = OpString "b"
@@ -30,15 +30,15 @@ struct foo {
 // CHECK: [[func1:%\d+]] = OpString "foo.func1"
 // CHECK: [[func0:%\d+]] = OpString "foo.func0"
 
-// CHECK: [[parent:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[foo]] Structure {{%\d+}} 3 1 {{%\d+}} {{%\d+}} %uint_192 FlagIsProtected|FlagIsPrivate [[a:%\d+]] [[f0:%\d+]] [[b:%\d+]] [[f1:%\d+]] [[c:%\d+]]
 // CHECK: [[bool:%\d+]] = OpExtInst %void %1 DebugTypeBasic [[bool_name]] %uint_32 Boolean
+// CHECK: [[parent:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[foo]] Structure {{%\d+}} 3 8 {{%\d+}} {{%\d+}} %uint_0 FlagIsProtected|FlagIsPrivate [[a:%\d+]] [[b:%\d+]] [[c:%\d+]] [[f0:%\d+]] [[f1:%\d+]]
 
-// CHECK: [[c]] = OpExtInst %void [[set]] DebugTypeMember [[c_name]] [[bool]] {{%\d+}} 19 3 [[parent]] %uint_160 %uint_32 FlagIsProtected|FlagIsPrivate
+// CHECK: [[c]] = OpExtInst %void [[set]] DebugTypeMember [[c_name]] [[bool]] {{%\d+}} 19 8 [[parent]] %uint_0 %uint_0 FlagIsProtected|FlagIsPrivate
 // CHECK: [[float:%\d+]] = OpExtInst %void %1 DebugTypeBasic [[float_name]] %uint_32 Float
 // CHECK: [[v4f:%\d+]] = OpExtInst %void %1 DebugTypeVector [[float]] 4
-// CHECK: [[b]] = OpExtInst %void [[set]] DebugTypeMember [[b_name]] [[v4f]] {{%\d+}} 10 3 [[parent]] %uint_32 %uint_128 FlagIsProtected|FlagIsPrivate
+// CHECK: [[b]] = OpExtInst %void [[set]] DebugTypeMember [[b_name]] [[v4f]] {{%\d+}} 10 10 [[parent]] %uint_0 %uint_0 FlagIsProtected|FlagIsPrivate
 // CHECK: [[int:%\d+]] = OpExtInst %void %1 DebugTypeBasic [[int_name]] %uint_32 Signed
-// CHECK: [[a]] = OpExtInst %void [[set]] DebugTypeMember [[a_name]] [[int]] {{%\d+}} 4 3 [[parent]] %uint_0 %uint_32 FlagIsProtected|FlagIsPrivate
+// CHECK: [[a]] = OpExtInst %void [[set]] DebugTypeMember [[a_name]] [[int]] {{%\d+}} 4 7 [[parent]] %uint_0 %uint_0 FlagIsProtected|FlagIsPrivate
 // CHECK: [[f1]] = OpExtInst %void [[set]] DebugFunction [[func1]] {{%\d+}} {{%\d+}} 12 3 [[parent]] {{%\d+}} FlagIsProtected|FlagIsPrivate 12 %foo_func1
 // CHECK: [[f0]] = OpExtInst %void [[set]] DebugFunction [[func0]] {{%\d+}} {{%\d+}} 6 3 [[parent]] {{%\d+}} FlagIsProtected|FlagIsPrivate 6 %foo_func0
 

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.type.member.function.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.type.member.function.hlsl
@@ -41,11 +41,10 @@ struct foo : base {
 // CHECK: [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 
 // CHECK: [[fooName:%\d+]] = OpString "foo"
-// CHECK: [[foo:%\d+]] = OpExtInst %void %1 DebugTypeComposite [[fooName]] Structure {{%\d+}} 22 1 {{%\d+}} [[fooName]] %uint_352 FlagIsProtected|FlagIsPrivate
-// CHECK: [[float:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Float
-
-// CHECK: [[int:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Signed
 // CHECK: [[bool:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Boolean
+// CHECK: [[foo:%\d+]] = OpExtInst %void %1 DebugTypeComposite [[fooName]] Structure {{%\d+}} 22 8 {{%\d+}} [[fooName]] %uint_0 FlagIsProtected|FlagIsPrivate
+// CHECK: [[float:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Float
+// CHECK: [[int:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Signed
 
 // CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugTypeFunction FlagIsProtected|FlagIsPrivate [[int]] [[foo]] [[int]] [[float]] [[bool]]
 // CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugTypeFunction FlagIsProtected|FlagIsPrivate %void [[foo]] [[float]]

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2423,24 +2423,30 @@ TEST_F(FileTest, RichDebugInfoTypeFunction) {
   runFileTest("rich.debug.type.function.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
+/*
 TEST_F(FileTest, RichDebugInfoTypeMemberFunction) {
   runFileTest("rich.debug.type.member.function.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+              runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoMemberFunctionWithoutCall) {
   runFileTest("rich.debug.member.function.without-call.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+              runValidationForRichDebugInfo);
 }
+TEST_F(FileTest, RichDebugInfoTypeCompositeBeforeFunction) {
+  runFileTest("rich.debug.type.composite.before.function.hlsl", Expect::Success,
+              runValidationForRichDebugInfo);
+}
+TEST_F(FileTest, RichDebugInfoMemberFunctionParam) {
+  runFileTest("rich.debug.member.function.param.hlsl", Expect::Success,
+              runValidationForRichDebugInfo);
+}
+*/
 TEST_F(FileTest, RichDebugInfoTypeComposite) {
   runFileTest("rich.debug.type.composite.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoTypeCompositeEmpty) {
   runFileTest("rich.debug.type.composite.empty.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoTypeCompositeBeforeFunction) {
-  runFileTest("rich.debug.type.composite.before.function.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoTypeStructuredBuffer) {
@@ -2465,10 +2471,6 @@ TEST_F(FileTest, RichDebugInfoFunctionParent) {
 }
 TEST_F(FileTest, RichDebugInfoFunctionParam) {
   runFileTest("rich.debug.function.param.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoMemberFunctionParam) {
-  runFileTest("rich.debug.member.function.param.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoDebugSourceMultiple) {

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2423,13 +2423,8 @@ TEST_F(FileTest, RichDebugInfoTypeFunction) {
   runFileTest("rich.debug.type.function.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
-/*
 TEST_F(FileTest, RichDebugInfoTypeMemberFunction) {
   runFileTest("rich.debug.type.member.function.hlsl", Expect::Success,
-              runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoMemberFunctionWithoutCall) {
-  runFileTest("rich.debug.member.function.without-call.hlsl", Expect::Success,
               runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoTypeCompositeBeforeFunction) {
@@ -2438,6 +2433,11 @@ TEST_F(FileTest, RichDebugInfoTypeCompositeBeforeFunction) {
 }
 TEST_F(FileTest, RichDebugInfoMemberFunctionParam) {
   runFileTest("rich.debug.member.function.param.hlsl", Expect::Success,
+              runValidationForRichDebugInfo);
+}
+/*
+TEST_F(FileTest, RichDebugInfoMemberFunctionWithoutCall) {
+  runFileTest("rich.debug.member.function.without-call.hlsl", Expect::Success,
               runValidationForRichDebugInfo);
 }
 */

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2425,22 +2425,20 @@ TEST_F(FileTest, RichDebugInfoTypeFunction) {
 }
 TEST_F(FileTest, RichDebugInfoTypeMemberFunction) {
   runFileTest("rich.debug.type.member.function.hlsl", Expect::Success,
-              runValidationForRichDebugInfo);
+              /*runValidation*/ runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoTypeCompositeBeforeFunction) {
   runFileTest("rich.debug.type.composite.before.function.hlsl", Expect::Success,
-              runValidationForRichDebugInfo);
+              /*runValidation*/ runValidationForRichDebugInfo);
 }
 TEST_F(FileTest, RichDebugInfoMemberFunctionParam) {
   runFileTest("rich.debug.member.function.param.hlsl", Expect::Success,
-              runValidationForRichDebugInfo);
+              /*runValidation*/ runValidationForRichDebugInfo);
 }
-/*
-TEST_F(FileTest, RichDebugInfoMemberFunctionWithoutCall) {
+TEST_F(FileTest, DISABLED_RichDebugInfoMemberFunctionWithoutCall) {
   runFileTest("rich.debug.member.function.without-call.hlsl", Expect::Success,
-              runValidationForRichDebugInfo);
+              /*runValidation*/ runValidationForRichDebugInfo);
 }
-*/
 TEST_F(FileTest, RichDebugInfoTypeComposite) {
   runFileTest("rich.debug.type.composite.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);

--- a/tools/clang/unittests/SPIRV/SpirvDebugInstructionTest.cpp
+++ b/tools/clang/unittests/SPIRV/SpirvDebugInstructionTest.cpp
@@ -42,7 +42,7 @@ TEST_F(SpirvDebugInstructionTest, DynamicTypeCheckDebugInfoNone) {
 }
 
 TEST_F(SpirvDebugInstructionTest, DynamicTypeCheckDebugTypeTemplateParameter) {
-  SpirvInstruction *i = getSpirvContext().getDebugTypeTemplateParameter(
+  SpirvInstruction *i = getSpirvContext().createDebugTypeTemplateParameter(
       nullptr, "vtable check", nullptr, nullptr, nullptr, 0, 0);
   EXPECT_TRUE(llvm::isa<SpirvDebugTypeTemplateParameter>(i));
   EXPECT_TRUE(llvm::isa<SpirvDebugInstruction>(i));


### PR DESCRIPTION
The existing code is hard to understand without knowing the context.
For example, SpirvDebugTypeComposite class has a
SpirvDebugTypeTemplate type member variable  for a resource type.
In LowerTypeVisitor, we create a SpirvDebugTypeComposite for a
resource type and DebugTypeVisitor revisits it to generate
SpirvDebugTypeTemplate with a parameter type. This is very
confusing because it does not follow the main rule of type lowering i.e.,

Step1. Lower QualType to SpirvType in LowerTypeVisitor
Step2. Lower SpirvType to debug type in DebugTypeVisitor

We added the large amount of code to handle special cases, which
has lots of implication and is very confusing.

The main purpose of this code refactoring is to follow the main rule
of the type lowering i.e., Step1 and Step2. We have the following
benefits:
- Use upstream LowerTypeVisitor. We added more than 300 LoC to
  LowerTypeVisitor for resource and struct type handling. This
  refactoring lets us add only 10 LoC to LowerTypeVisitor.
- Make DebugTypeVisitor readable. LowerTypeVisitor and DebugTypeVisitor
  implicitly handled many cases like resource types, template types,
  member functions, class inheritance, "this" parameter for member function.
  Now DebugTypeVisitor::lowerToDebugTypeComposite() clearly shows
  how we handle those cases.
- Solve infinite recursive invocations of debug type lowering. Previously,
  when we lower a composite type, we recursively lower its member function
  debug type and for its "this" object whose type is the composite type,
  we infinitely invoke the recursive function. This CL solves the problem.

Note that we need Clang Decl information to lower the
DebugTypeComposite in addition to SpirvType. We keep the information
in `spvTypeToDecl` of SpirvContext. Similarly, we keep Decl to
DebugFunction in `declToDebugFunction` of SpirvContext.