### PR TITLE
[spirv] emit correct DebugFunction name

### DIFF
--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -151,8 +151,6 @@ std::vector<uint32_t> EmitVisitor::Header::takeBinary() {
 }
 
 SpirvString *EmitVisitor::getOrCreateOpString(llvm::StringRef str) {
-  if (str.empty())
-    return nullptr;
   auto it = stringLiteralMap.find(str);
   if (it != stringLiteralMap.end()) {
     return it->second;

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -984,6 +984,7 @@ void SpirvEmitter::doFunctionDecl(const FunctionDecl *decl) {
   // This will allow the entry-point name to be something like
   // myNamespace::myEntrypointFunc.
   std::string funcName = getFnName(decl);
+  std::string debugFuncName = funcName;
 
   SpirvFunction *func = declIdMapper.getOrRegisterFn(decl);
 
@@ -1022,7 +1023,7 @@ void SpirvEmitter::doFunctionDecl(const FunctionDecl *decl) {
     // The line number in the source program at which the function scope begins.
     auto scopeLine = sm.getPresumedLineNumber(decl->getBody()->getLocStart());
     SpirvDebugFunction *debugFunction = spvBuilder.createDebugFunction(
-        decl, funcName, source, line, column, parentScope, funcName, flags,
+        decl, debugFuncName, source, line, column, parentScope, "", flags,
         scopeLine, func);
     func->setDebugScope(new (astContext) SpirvDebugScope(debugFunction));
 

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.function.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.function.hlsl
@@ -4,7 +4,8 @@
 
 // CHECK:             [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 // CHECK:         [[fooName:%\d+]] = OpString "foo"
-// CHECK:        [[mainName:%\d+]] = OpString "src.main"
+// CHECK:        [[emptyStr:%\d+]] = OpString ""
+// CHECK:        [[mainName:%\d+]] = OpString "main"
 
 // CHECK:    [[int:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Signed
 // CHECK:  [[float:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Float
@@ -15,11 +16,11 @@
 
 // Check DebugFunction instructions
 //
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[fooName]] [[fooFnType]] [[source]] 24 1 [[compilationUnit]] [[fooName]] FlagIsProtected|FlagIsPrivate 25 %foo
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[fooName]] [[fooFnType]] [[source]] 25 1 [[compilationUnit]] [[emptyStr]] FlagIsProtected|FlagIsPrivate 26 %foo
 
 // CHECK: [[float4:%\d+]] = OpExtInst %void [[set]] DebugTypeVector [[float]] 4
 // CHECK: [[mainFnType:%\d+]] = OpExtInst %void [[set]] DebugTypeFunction FlagIsProtected|FlagIsPrivate [[float4]] [[float4]]
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[mainName]] [[mainFnType]] [[source]] 29 1 [[compilationUnit]] [[mainName]] FlagIsProtected|FlagIsPrivate 30 %src_main
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[mainName]] [[mainFnType]] [[source]] 30 1 [[compilationUnit]] [[emptyStr]] FlagIsProtected|FlagIsPrivate 31 %src_main
 
 void foo(int x, float y)
 {

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.function.param.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.function.param.hlsl
@@ -4,20 +4,20 @@
 
 // CHECK:             [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 // CHECK:         [[fooName:%\d+]] = OpString "foo"
+// CHECK:        [[emptyStr:%\d+]] = OpString ""
 // CHECK:               [[y:%\d+]] = OpString "y"
 // CHECK:               [[x:%\d+]] = OpString "x"
-// CHECK:        [[mainName:%\d+]] = OpString "src.main"
+// CHECK:        [[mainName:%\d+]] = OpString "main"
 // CHECK:           [[color:%\d+]] = OpString "color"
 
-// CHECK:    [[int:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Signed
-// CHECK:  [[float:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Float
-// CHECK:          [[source:%\d+]] = OpExtInst %void [[set]] DebugSource
-
-// CHECK: [[foo:%\d+]] = OpExtInst %void [[set]] DebugFunction [[fooName]] {{%\d+}} [[source]] 23 1 {{%\d+}} [[fooName]] FlagIsProtected|FlagIsPrivate 24 %foo
+// CHECK: [[int:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Signed
+// CHECK: [[float:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Float
+// CHECK: [[source:%\d+]] = OpExtInst %void [[set]] DebugSource
+// CHECK: [[foo:%\d+]] = OpExtInst %void [[set]] DebugFunction [[fooName]] {{%\d+}} [[source]] 23 1 {{%\d+}} [[emptyStr]] FlagIsProtected|FlagIsPrivate 24 %foo
 // CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[y]] [[float]] [[source]] 23 23 [[foo]] FlagIsLocal 2
 // CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[x]] [[int]] [[source]] 23 14 [[foo]] FlagIsLocal 1
 // CHECK: [[float4:%\d+]] = OpExtInst %void [[set]] DebugTypeVector [[float]] 4
-// CHECK: [[main:%\d+]] = OpExtInst %void [[set]] DebugFunction [[mainName]] {{%\d+}} [[source]] 28 1 {{%\d+}} [[mainName]] FlagIsProtected|FlagIsPrivate 29 %src_main
+// CHECK: [[main:%\d+]] = OpExtInst %void [[set]] DebugFunction [[mainName]] {{%\d+}} [[source]] 28 1 {{%\d+}} [[emptyStr]] FlagIsProtected|FlagIsPrivate 29 %src_main
 // CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugLocalVariable [[color]] [[float4]] [[source]] 28 20 [[main]] FlagIsLocal 1
 
 void foo(int x, float y)

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.type.composite.before.function.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.type.composite.before.function.hlsl
@@ -2,7 +2,7 @@
 
 // CHECK: [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 // CHECK: [[out:%\d+]] = OpString "VS_OUTPUT"
-// CHECK: [[main:%\d+]] = OpString "src.main"
+// CHECK: [[main:%\d+]] = OpString "main"
 
 // CHECK: [[VSOUT:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[out]]
 // CHECK: [[ty:%\d+]] = OpExtInst %void [[set]] DebugTypeFunction FlagIsProtected|FlagIsPrivate [[VSOUT]]


### PR DESCRIPTION
OpenCL.DebugInfo.100 DebugFunction's 'Name' operand must be the name of
the function given by the HLSL code. DXC adds "src." as a prefix of the
enty function, but DebugFunction must not have it.

In addition, the entry function only called by a wrapper is externally
invisible. We have to set an empty string for the linkage name.

Fixes #324