### PR TITLE
[spirv] do not add DebugScope when creating DebugLexicalBlock

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -103,6 +103,10 @@ public:
   /// for the basic block. On failure, returns zero.
   SpirvBasicBlock *createBasicBlock(llvm::StringRef name = "");
 
+  /// \brief Creates a SPIR-V DebugScope (OpenCL.DebugInfo.100 instruction).
+  /// On success, returns the <id> of DebugScope. On failure, returns nullptr.
+  SpirvDebugScope *createDebugScope(SpirvDebugInstruction *scope);
+
   /// \brief Adds the basic block with the given label as a successor to the
   /// current basic block.
   void addSuccessor(SpirvBasicBlock *successorBB);

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -126,6 +126,9 @@ public:
   /// \brief Sets insertion point to the given basic block.
   inline void setInsertPoint(SpirvBasicBlock *bb) { insertPoint = bb; }
 
+  /// \brief Gets insertion point.
+  inline SpirvBasicBlock *getInsertPoint() { return insertPoint; }
+
   // === Instruction at the current Insertion Point ===
 
   /// \brief Creates a composite construct instruction with the given

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -114,6 +114,13 @@ SpirvBasicBlock *SpirvBuilder::createBasicBlock(llvm::StringRef name) {
   return bb;
 }
 
+SpirvDebugScope *SpirvBuilder::createDebugScope(SpirvDebugInstruction *scope) {
+  assert(insertPoint && "null insert point");
+  auto *dbgScope = new (context) SpirvDebugScope(scope);
+  insertPoint->addInstruction(dbgScope);
+  return dbgScope;
+}
+
 void SpirvBuilder::addSuccessor(SpirvBasicBlock *successorBB) {
   assert(insertPoint && "null insert point");
   insertPoint->addSuccessor(successorBB);

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -835,16 +835,6 @@ SpirvBuilder::createDebugLexicalBlock(SpirvDebugSource *source, uint32_t line,
   auto *inst =
       new (context) SpirvDebugLexicalBlock(source, line, column, parent);
   mod->addDebugInfo(inst);
-  if (insertPoint->empty()) {
-    insertPoint->setDebugScope(new (context) SpirvDebugScope(inst));
-  } else {
-    // Note that a SpirvBasicBlock can have multiple lexical blocks. For
-    // example, `void foo() { { { } } { } }` has 4 lexical blocks but
-    // generates only a single `OpLabel`. Since we want to add 4 DebugScope
-    // corresponding to those 4 lexical blocks, we use
-    // insertPoint->addInstruction() instead of setDebugScope() here.
-    insertPoint->addInstruction(new (context) SpirvDebugScope(inst));
-  }
   return inst;
 }
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -705,22 +705,12 @@ void SpirvEmitter::doStmt(const Stmt *stmt,
       // Add this lexical block to the stack of lexical scopes.
       spvContext.pushDebugLexicalScope(info, debugLexicalBlock);
 
-      // Switch DebugScope if the current basic block is empty.
-      //
-      // TODO: Handle the following case
-      //
-      // {    // BB0
-      //   int foo = x;
-      //   {  // BB1
-      //     int bar = y;
-      //     ...
-      //
-      // doStmt() does not emit OpLabel for BB1. `int bar = y;` is under BB0.
-      // We do not create DebugLexicalBlock for BB1 but only for BB0, so the
-      // DebugScope of `int bar = y;` will be wrong.
+      // Update or add DebugScope.
       if (spvBuilder.getInsertPoint()->empty()) {
         spvBuilder.getInsertPoint()->setDebugScope(
             new (astContext) SpirvDebugScope(debugLexicalBlock));
+      } else if (!spvBuilder.isCurrentBasicBlockTerminated()) {
+        spvBuilder.createDebugScope(debugLexicalBlock);
       }
 
       // Iterate over sub-statements

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -708,7 +708,7 @@ void SpirvEmitter::doStmt(const Stmt *stmt,
       // Update or add DebugScope.
       if (spvBuilder.getInsertPoint()->empty()) {
         spvBuilder.getInsertPoint()->setDebugScope(
-            new (astContext) SpirvDebugScope(debugLexicalBlock));
+            new (spvContext) SpirvDebugScope(debugLexicalBlock));
       } else if (!spvBuilder.isCurrentBasicBlockTerminated()) {
         spvBuilder.createDebugScope(debugLexicalBlock);
       }

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debugscope.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debugscope.hlsl
@@ -3,11 +3,11 @@
 // CHECK:  [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 // CHECK: [[compUnit:%\d+]] = OpExtInst %void [[set]] DebugCompilationUnit
 // CHECK: [[main:%\d+]] = OpExtInst %void [[set]] DebugFunction
-// CHECK: [[mainFnLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} {{\d+}} {{\d+}} [[main]]
-// CHECK: [[whileLoopLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} {{\d+}} {{\d+}} [[mainFnLexBlock]]
-// CHECK: [[ifStmtLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} {{\d+}} {{\d+}} [[whileLoopLexBlock]]
-// CHECK: [[tempLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} {{\d+}} {{\d+}} [[ifStmtLexBlock]]
-// CHECK: [[forLoopLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} {{\d+}} {{\d+}} [[mainFnLexBlock]]
+// CHECK: [[mainFnLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 15 1 [[main]]
+// CHECK: [[whileLoopLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 35 3 [[mainFnLexBlock]]
+// CHECK: [[ifStmtLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 42 20 [[whileLoopLexBlock]]
+// CHECK: [[tempLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 47 7 [[ifStmtLexBlock]]
+// CHECK: [[forLoopLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 20 12 [[mainFnLexBlock]]
 
 float4 main(float4 color : COLOR) : SV_TARGET
 // CHECK:     %src_main = OpFunction
@@ -43,8 +43,7 @@ float4 main(float4 color : COLOR) : SV_TARGET
 // CHECK:      %if_true = OpLabel
 // CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[ifStmtLexBlock]]
       c = c + c;
-// TODO: It has to generate
-//       {{%\d+}} = OpExtInst %void [[set]] DebugScope [[tempLexBlock]]
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[tempLexBlock]]
       {
         c = c + c;
       }

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debugscope.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debugscope.hlsl
@@ -3,11 +3,11 @@
 // CHECK:  [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 // CHECK: [[compUnit:%\d+]] = OpExtInst %void [[set]] DebugCompilationUnit
 // CHECK: [[main:%\d+]] = OpExtInst %void [[set]] DebugFunction
-// CHECK: [[mainFnLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 15 1 [[main]]
-// CHECK: [[whileLoopLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 38 3 [[mainFnLexBlock]]
-// CHECK: [[ifStmtLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 45 20 [[whileLoopLexBlock]]
-// CHECK: [[tempLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 50 7 [[ifStmtLexBlock]]
-// CHECK: [[forLoopLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} 23 12 [[mainFnLexBlock]]
+// CHECK: [[mainFnLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} {{\d+}} {{\d+}} [[main]]
+// CHECK: [[whileLoopLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} {{\d+}} {{\d+}} [[mainFnLexBlock]]
+// CHECK: [[ifStmtLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} {{\d+}} {{\d+}} [[whileLoopLexBlock]]
+// CHECK: [[tempLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} {{\d+}} {{\d+}} [[ifStmtLexBlock]]
+// CHECK: [[forLoopLexBlock:%\d+]] = OpExtInst %void [[set]] DebugLexicalBlock {{%\d+}} {{\d+}} {{\d+}} [[mainFnLexBlock]]
 
 float4 main(float4 color : COLOR) : SV_TARGET
 // CHECK:     %src_main = OpFunction
@@ -17,9 +17,6 @@ float4 main(float4 color : COLOR) : SV_TARGET
 // CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[mainFnLexBlock]]
 
   float4 c = 0.xxxx;
-
-// CHECK:    %for_check = OpLabel
-// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[mainFnLexBlock]]
   for (;;) {
 // CHECK:     %for_body = OpLabel
 // CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[forLoopLexBlock]]
@@ -46,7 +43,8 @@ float4 main(float4 color : COLOR) : SV_TARGET
 // CHECK:      %if_true = OpLabel
 // CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[ifStmtLexBlock]]
       c = c + c;
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugScope [[tempLexBlock]]
+// TODO: It has to generate
+//       {{%\d+}} = OpExtInst %void [[set]] DebugScope [[tempLexBlock]]
       {
         c = c + c;
       }

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.switch.debugscope.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.switch.debugscope.hlsl
@@ -1,0 +1,33 @@
+// Run: %dxc -T ps_6_0 -E main -fspv-debug=rich
+
+float4 main(float2 inUV : TEXCOORD0) : SV_TARGET
+{
+  int x = int(floor(inUV.x / 0.25f));
+  float4 samplePos = float4(0, 0, 0, 1);
+  float2 uv = float2(inUV.x * 4.0f, (inUV.y - 1.0/3.0) * 3.0);
+  uv = 2.0 * float2(uv.x - float(x) * 1.0, uv.y) - 1.0;
+
+// CHECK:      OpSelectionMerge %switch_merge None
+// CHECK-NEXT: OpSwitch {{%\d+}} %switch_merge
+
+// OpBranch before a new OpLabel after OpSwitch causes a validation error.
+// CHECK-NOT:  DebugScope
+// CHECK-NOT:  OpBranch
+// CHECK-NEXT: %switch_0 = OpLabel
+
+  switch (x) {
+    case 0: // NEGATIVE_X
+      samplePos = float4(-1.0f, uv.y, uv.x, 1);
+      break;
+    case 1: // POSITIVE_Z
+      samplePos = float4(uv.x, uv.y, 1.0f, 1);
+      break;
+    case 2: // POSITIVE_X
+      samplePos = float4(1.0, uv.y, -uv.x, 1);
+      break;
+    case 3: // NEGATIVE_Z
+      samplePos = float4(-uv.x, uv.y, -1.0f, 1);
+      break;
+  }
+  return samplePos;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2513,8 +2513,12 @@ TEST_F(FileTest, RichDebugInfoCbuffer) {
   runFileTest("rich.debug.cbuffer.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
-TEST_F(FileTest, RichDebugSortTypeTemplate) {
+TEST_F(FileTest, RichDebugInfoSortTypeTemplate) {
   runFileTest("rich.debug.sort.type.template.hlsl", Expect::Success,
+              /*runValidation*/ runValidationForRichDebugInfo);
+}
+TEST_F(FileTest, RichDebugInfoSwitchDebugScope) {
+  runFileTest("rich.debug.switch.debugscope.hlsl", Expect::Success,
               /*runValidation*/ runValidationForRichDebugInfo);
 }
 


### PR DESCRIPTION
We have to add DebugScope when we *switch* the lexical scope, not when
we create DebugLexicalBlock.

Fixes #325