### PR TITLE
[spirv] temporary emission of DebugTypeMember.Offset

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -2658,8 +2658,8 @@ public:
   llvm::StringRef getLinkageName() const { return linkageName; }
   uint32_t getDebugFlags() const { return debugFlags; }
 
-  void setSizeInBits(uint32_t size_) { size = size_; }
-  uint32_t getSizeInBits() const override { return size; }
+  void setSizeInBits(uint32_t size_) { sizeInBits = size_; }
+  uint32_t getSizeInBits() const override { return sizeInBits; }
 
   void markAsOpaqueType(SpirvDebugInfoNone *none) {
     // If it was already marked as a opaque type, just return. For example,
@@ -2682,7 +2682,7 @@ private:
   SpirvDebugInstruction *parent; //< The parent lexical scope
 
   std::string linkageName; //< Linkage name
-  uint32_t size;           //< Size (in bits) of an instance of composite
+  uint32_t sizeInBits;     //< Size (in bits) of an instance of composite
 
   // TODO: Replace uint32_t with enum in the SPIRV-Headers once it is
   // available.

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.type.composite.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.type.composite.hlsl
@@ -31,14 +31,14 @@ struct foo {
 // CHECK: [[func0:%\d+]] = OpString "foo.func0"
 
 // CHECK: [[bool:%\d+]] = OpExtInst %void %1 DebugTypeBasic [[bool_name]] %uint_32 Boolean
-// CHECK: [[parent:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[foo]] Structure {{%\d+}} 3 8 {{%\d+}} {{%\d+}} %uint_0 FlagIsProtected|FlagIsPrivate [[a:%\d+]] [[b:%\d+]] [[c:%\d+]] [[f0:%\d+]] [[f1:%\d+]]
+// CHECK: [[parent:%\d+]] = OpExtInst %void [[set]] DebugTypeComposite [[foo]] Structure {{%\d+}} 3 8 {{%\d+}} {{%\d+}} %uint_192 FlagIsProtected|FlagIsPrivate [[a:%\d+]] [[b:%\d+]] [[c:%\d+]] [[f0:%\d+]] [[f1:%\d+]]
 
-// CHECK: [[c]] = OpExtInst %void [[set]] DebugTypeMember [[c_name]] [[bool]] {{%\d+}} 19 8 [[parent]] %uint_0 %uint_0 FlagIsProtected|FlagIsPrivate
+// CHECK: [[c]] = OpExtInst %void [[set]] DebugTypeMember [[c_name]] [[bool]] {{%\d+}} 19 8 [[parent]] %uint_160 %uint_32 FlagIsProtected|FlagIsPrivate
 // CHECK: [[float:%\d+]] = OpExtInst %void %1 DebugTypeBasic [[float_name]] %uint_32 Float
 // CHECK: [[v4f:%\d+]] = OpExtInst %void %1 DebugTypeVector [[float]] 4
-// CHECK: [[b]] = OpExtInst %void [[set]] DebugTypeMember [[b_name]] [[v4f]] {{%\d+}} 10 10 [[parent]] %uint_0 %uint_0 FlagIsProtected|FlagIsPrivate
+// CHECK: [[b]] = OpExtInst %void [[set]] DebugTypeMember [[b_name]] [[v4f]] {{%\d+}} 10 10 [[parent]] %uint_32 %uint_128 FlagIsProtected|FlagIsPrivate
 // CHECK: [[int:%\d+]] = OpExtInst %void %1 DebugTypeBasic [[int_name]] %uint_32 Signed
-// CHECK: [[a]] = OpExtInst %void [[set]] DebugTypeMember [[a_name]] [[int]] {{%\d+}} 4 7 [[parent]] %uint_0 %uint_0 FlagIsProtected|FlagIsPrivate
+// CHECK: [[a]] = OpExtInst %void [[set]] DebugTypeMember [[a_name]] [[int]] {{%\d+}} 4 7 [[parent]] %uint_0 %uint_32 FlagIsProtected|FlagIsPrivate
 // CHECK: [[f1]] = OpExtInst %void [[set]] DebugFunction [[func1]] {{%\d+}} {{%\d+}} 12 3 [[parent]] {{%\d+}} FlagIsProtected|FlagIsPrivate 12 %foo_func1
 // CHECK: [[f0]] = OpExtInst %void [[set]] DebugFunction [[func0]] {{%\d+}} {{%\d+}} 6 3 [[parent]] {{%\d+}} FlagIsProtected|FlagIsPrivate 6 %foo_func0
 

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.type.member.function.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.type.member.function.hlsl
@@ -42,7 +42,7 @@ struct foo : base {
 
 // CHECK: [[fooName:%\d+]] = OpString "foo"
 // CHECK: [[bool:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Boolean
-// CHECK: [[foo:%\d+]] = OpExtInst %void %1 DebugTypeComposite [[fooName]] Structure {{%\d+}} 22 8 {{%\d+}} [[fooName]] %uint_0 FlagIsProtected|FlagIsPrivate
+// CHECK: [[foo:%\d+]] = OpExtInst %void %1 DebugTypeComposite [[fooName]] Structure {{%\d+}} 22 8 {{%\d+}} [[fooName]] %uint_192 FlagIsProtected|FlagIsPrivate
 // CHECK: [[float:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Float
 // CHECK: [[int:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 Signed
 


### PR DESCRIPTION
When the physical layout of a local variable is unknown, we cannot
properly set Offset and Size of DebugTypeMember based on the current
spec. We need the spec update.

Since we need to test SwiftShader debugger (the first Vulkan shader
debugger that can be used as a reference implementation), we want to
temporarily emit Offset and Size of DebugTypeMember even for local
variables with the unknown physical layout. We assume it uses the
tight data filling.